### PR TITLE
Document type cast expression support in subset2

### DIFF
--- a/doc/subset2.md
+++ b/doc/subset2.md
@@ -35,6 +35,7 @@
   - Currently only support [variable-reference-lvexpr](https://ballerina.io/spec/lang/master/#variable-reference-lvexpr)
 - [`Call`](https://ballerina.io/spec/lang/master/#call-expr)
   - Currently only support `function-call-expr`
+- [Type cast expression](https://ballerina.io/spec/lang/master/#section_6.20)
 - [List constructor](https://ballerina.io/spec/lang/master/#list-constructor-expr)
   - Currently [spread-list-member](https://ballerina.io/spec/lang/master/#spread-list-member) not supported
 - [Variable reference](https://ballerina.io/spec/lang/master/#variable-reference-expr)


### PR DESCRIPTION
## Purpose
$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature documentation to include type cast expression support in the documented expression types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->