### PR TITLE
Fix typos and improve function and variable names

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -601,7 +601,7 @@ func (this *BLangAnnotationAttachment) GetKind() model.NodeKind {
 	return model.NodeKind_ANNOTATION_ATTACHMENT
 }
 
-func (this *BLangAnnotationAttachment) GetPackgeAlias() model.IdentifierNode {
+func (this *BLangAnnotationAttachment) GetPackageAlias() model.IdentifierNode {
 	return this.PkgAlias
 }
 

--- a/ast/node_builder.go
+++ b/ast/node_builder.go
@@ -1525,7 +1525,7 @@ func (n *NodeBuilder) TransformCompoundAssignmentStatement(compoundAssignmentStm
 	bLCompAssignment.SetExpression(n.createExpression(compoundAssignmentStmtNode.RhsExpression()))
 	bLCompAssignment.SetVariable(n.createExpression(compoundAssignmentStmtNode.LhsExpression()))
 	BLangNode(bLCompAssignment).SetPosition(getPosition(compoundAssignmentStmtNode))
-	bLCompAssignment.OpKind = model.OperatorKind_valueFrom(compoundAssignmentStmtNode.BinaryOperator().Text())
+	bLCompAssignment.OpKind = model.OperatorKindValueFrom(compoundAssignmentStmtNode.BinaryOperator().Text())
 	return bLCompAssignment
 }
 
@@ -1819,7 +1819,7 @@ func (n *NodeBuilder) TransformBinaryExpression(binaryExpressionNode *tree.Binar
 	if binaryExpressionNode.Operator() == nil {
 		operator = model.OperatorKind_UNDEFINED
 	} else {
-		operator = model.OperatorKind_valueFrom(binaryExpressionNode.Operator().Text())
+		operator = model.OperatorKindValueFrom(binaryExpressionNode.Operator().Text())
 	}
 	bLBinaryExpr.OpKind = operator
 	return &bLBinaryExpr
@@ -1959,7 +1959,7 @@ func (n *NodeBuilder) TransformTypeofExpression(typeofExpressionNode *tree.Typeo
 
 func (n *NodeBuilder) TransformUnaryExpression(unaryExpressionNode *tree.UnaryExpressionNode) BLangNode {
 	pos := getPosition(unaryExpressionNode)
-	operator := model.OperatorKind_valueFrom(unaryExpressionNode.UnaryOperator().Text())
+	operator := model.OperatorKindValueFrom(unaryExpressionNode.UnaryOperator().Text())
 	expr := n.createExpression(unaryExpressionNode.Expression())
 	return createBLangUnaryExpr(pos, operator, expr)
 }

--- a/context/context.go
+++ b/context/context.go
@@ -28,8 +28,8 @@ type CompilerContext struct {
 	tyContext   semtypes.Context
 }
 
-func (this *CompilerContext) NewSymbolSpace(packageId model.PackageID) *model.SymbolSpace {
-	return this.env.NewSymbolSpace(packageId)
+func (this *CompilerContext) NewSymbolSpace(packageID model.PackageID) *model.SymbolSpace {
+	return this.env.NewSymbolSpace(packageID)
 }
 
 func (this *CompilerContext) NewFunctionScope(parent model.Scope, pkg model.PackageID) *model.FunctionScope {

--- a/context/env.go
+++ b/context/env.go
@@ -32,8 +32,8 @@ type CompilerEnvironment struct {
 	typeDefns        map[model.SymbolRef]model.TypeDefinition
 }
 
-func (this *CompilerEnvironment) NewSymbolSpace(packageId model.PackageID) *model.SymbolSpace {
-	space := model.NewSymbolSpaceInner(packageId, len(this.symbolSpaces))
+func (this *CompilerEnvironment) NewSymbolSpace(packageID model.PackageID) *model.SymbolSpace {
+	space := model.NewSymbolSpaceInner(packageID, len(this.symbolSpaces))
 	this.symbolSpaces = append(this.symbolSpaces, space)
 	return space
 }

--- a/model/symbol.go
+++ b/model/symbol.go
@@ -205,11 +205,11 @@ func (space *SymbolSpace) SymbolAt(index int) Symbol {
 	return space.Symbols[index]
 }
 
-func NewSymbolSpaceInner(packageId PackageID, index int) *SymbolSpace {
+func NewSymbolSpaceInner(packageID PackageID, index int) *SymbolSpace {
 	pkg := PackageIdentifier{
-		Organization: packageId.OrgName.Value(),
-		Package:      packageId.PkgName.Value(),
-		Version:      packageId.Version.Value(),
+		Organization: packageID.OrgName.Value(),
+		Package:      packageID.PkgName.Value(),
+		Version:      packageID.Version.Value(),
 	}
 	return &SymbolSpace{index: index, pkg: pkg, lookupTable: make(map[string]int), Symbols: make([]Symbol, 0)}
 }

--- a/model/tree.go
+++ b/model/tree.go
@@ -433,7 +433,7 @@ const (
 	OperatorKind_UNDEFINED                    OperatorKind = "UNDEF"
 )
 
-func OperatorKind_valueFrom(opValue string) OperatorKind {
+func OperatorKindValueFrom(opValue string) OperatorKind {
 	switch opValue {
 	case "+":
 		return OperatorKind_ADD
@@ -1218,7 +1218,7 @@ type IdentifierNode interface {
 }
 
 type AnnotationAttachmentNode interface {
-	GetPackgeAlias() IdentifierNode
+	GetPackageAlias() IdentifierNode
 	SetPackageAlias(pkgAlias IdentifierNode)
 	GetAnnotationName() IdentifierNode
 	SetAnnotationName(name IdentifierNode)

--- a/projects/build_options.go
+++ b/projects/build_options.go
@@ -231,12 +231,12 @@ func (b BuildOptions) TraceRecovery() bool {
 // AcceptTheirs merges the given build options by favoring theirs if there are conflicts.
 func (b BuildOptions) AcceptTheirs(theirs BuildOptions) BuildOptions {
 	merged := BuildOptions{
-		skipTests:                 acceptoptionalBool(b.skipTests, theirs.skipTests),
-		codeCoverage:              acceptoptionalBool(b.codeCoverage, theirs.codeCoverage),
-		testReport:                acceptoptionalBool(b.testReport, theirs.testReport),
-		dumpBuildTime:             acceptoptionalBool(b.dumpBuildTime, theirs.dumpBuildTime),
-		exportComponentModel:      acceptoptionalBool(b.exportComponentModel, theirs.exportComponentModel),
-		showDependencyDiagnostics: acceptoptionalBool(b.showDependencyDiagnostics, theirs.showDependencyDiagnostics),
+		skipTests:                 acceptOptionalBool(b.skipTests, theirs.skipTests),
+		codeCoverage:              acceptOptionalBool(b.codeCoverage, theirs.codeCoverage),
+		testReport:                acceptOptionalBool(b.testReport, theirs.testReport),
+		dumpBuildTime:             acceptOptionalBool(b.dumpBuildTime, theirs.dumpBuildTime),
+		exportComponentModel:      acceptOptionalBool(b.exportComponentModel, theirs.exportComponentModel),
+		showDependencyDiagnostics: acceptOptionalBool(b.showDependencyDiagnostics, theirs.showDependencyDiagnostics),
 	}
 
 	if theirs.targetDir != "" {

--- a/projects/compilation_options.go
+++ b/projects/compilation_options.go
@@ -286,8 +286,8 @@ func (c CompilationOptions) LockingMode() PackageLockingMode {
 	return c.lockingMode
 }
 
-// acceptoptionalBool returns theirs if set, else ours.
-func acceptoptionalBool(ours, theirs optionalBool) optionalBool {
+// acceptOptionalBool returns theirs if set, else ours.
+func acceptOptionalBool(ours, theirs optionalBool) optionalBool {
 	if theirs.isSet() {
 		return theirs
 	}
@@ -297,28 +297,28 @@ func acceptoptionalBool(ours, theirs optionalBool) optionalBool {
 // AcceptTheirs merges the given compilation options by favoring theirs if there are conflicts.
 func (c CompilationOptions) AcceptTheirs(theirs CompilationOptions) CompilationOptions {
 	merged := CompilationOptions{
-		offlineBuild:                  acceptoptionalBool(c.offlineBuild, theirs.offlineBuild),
-		experimental:                  acceptoptionalBool(c.experimental, theirs.experimental),
-		observabilityIncluded:         acceptoptionalBool(c.observabilityIncluded, theirs.observabilityIncluded),
-		dumpAST:                       acceptoptionalBool(c.dumpAST, theirs.dumpAST),
-		dumpBIR:                       acceptoptionalBool(c.dumpBIR, theirs.dumpBIR),
-		dumpBIRFile:                   acceptoptionalBool(c.dumpBIRFile, theirs.dumpBIRFile),
-		dumpCFG:                       acceptoptionalBool(c.dumpCFG, theirs.dumpCFG),
-		dumpGraph:                     acceptoptionalBool(c.dumpGraph, theirs.dumpGraph),
-		dumpRawGraphs:                 acceptoptionalBool(c.dumpRawGraphs, theirs.dumpRawGraphs),
-		dumpTokens:                    acceptoptionalBool(c.dumpTokens, theirs.dumpTokens),
-		dumpST:                        acceptoptionalBool(c.dumpST, theirs.dumpST),
-		listConflictedClasses:         acceptoptionalBool(c.listConflictedClasses, theirs.listConflictedClasses),
-		sticky:                        acceptoptionalBool(c.sticky, theirs.sticky),
-		withCodeGenerators:            acceptoptionalBool(c.withCodeGenerators, theirs.withCodeGenerators),
-		withCodeModifiers:             acceptoptionalBool(c.withCodeModifiers, theirs.withCodeModifiers),
-		configSchemaGen:               acceptoptionalBool(c.configSchemaGen, theirs.configSchemaGen),
-		exportOpenAPI:                 acceptoptionalBool(c.exportOpenAPI, theirs.exportOpenAPI),
-		exportComponentModel:          acceptoptionalBool(c.exportComponentModel, theirs.exportComponentModel),
-		disableSyntaxTree:             acceptoptionalBool(c.disableSyntaxTree, theirs.disableSyntaxTree),
-		remoteManagement:              acceptoptionalBool(c.remoteManagement, theirs.remoteManagement),
-		optimizeDependencyCompilation: acceptoptionalBool(c.optimizeDependencyCompilation, theirs.optimizeDependencyCompilation),
-		traceRecovery:                 acceptoptionalBool(c.traceRecovery, theirs.traceRecovery),
+		offlineBuild:                  acceptOptionalBool(c.offlineBuild, theirs.offlineBuild),
+		experimental:                  acceptOptionalBool(c.experimental, theirs.experimental),
+		observabilityIncluded:         acceptOptionalBool(c.observabilityIncluded, theirs.observabilityIncluded),
+		dumpAST:                       acceptOptionalBool(c.dumpAST, theirs.dumpAST),
+		dumpBIR:                       acceptOptionalBool(c.dumpBIR, theirs.dumpBIR),
+		dumpBIRFile:                   acceptOptionalBool(c.dumpBIRFile, theirs.dumpBIRFile),
+		dumpCFG:                       acceptOptionalBool(c.dumpCFG, theirs.dumpCFG),
+		dumpGraph:                     acceptOptionalBool(c.dumpGraph, theirs.dumpGraph),
+		dumpRawGraphs:                 acceptOptionalBool(c.dumpRawGraphs, theirs.dumpRawGraphs),
+		dumpTokens:                    acceptOptionalBool(c.dumpTokens, theirs.dumpTokens),
+		dumpST:                        acceptOptionalBool(c.dumpST, theirs.dumpST),
+		listConflictedClasses:         acceptOptionalBool(c.listConflictedClasses, theirs.listConflictedClasses),
+		sticky:                        acceptOptionalBool(c.sticky, theirs.sticky),
+		withCodeGenerators:            acceptOptionalBool(c.withCodeGenerators, theirs.withCodeGenerators),
+		withCodeModifiers:             acceptOptionalBool(c.withCodeModifiers, theirs.withCodeModifiers),
+		configSchemaGen:               acceptOptionalBool(c.configSchemaGen, theirs.configSchemaGen),
+		exportOpenAPI:                 acceptOptionalBool(c.exportOpenAPI, theirs.exportOpenAPI),
+		exportComponentModel:          acceptOptionalBool(c.exportComponentModel, theirs.exportComponentModel),
+		disableSyntaxTree:             acceptOptionalBool(c.disableSyntaxTree, theirs.disableSyntaxTree),
+		remoteManagement:              acceptOptionalBool(c.remoteManagement, theirs.remoteManagement),
+		optimizeDependencyCompilation: acceptOptionalBool(c.optimizeDependencyCompilation, theirs.optimizeDependencyCompilation),
+		traceRecovery:                 acceptOptionalBool(c.traceRecovery, theirs.traceRecovery),
 	}
 
 	// Cloud (*string)

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -825,7 +825,7 @@ func isEqualityExpr(opExpr opExpr) bool {
 	}
 }
 
-func isMultipcativeExpr(opExpr opExpr) bool {
+func isMultiplicativeExpr(opExpr opExpr) bool {
 	switch opExpr.GetOperatorKind() {
 	case model.OperatorKind_MUL, model.OperatorKind_DIV, model.OperatorKind_MOD:
 		return true
@@ -1105,7 +1105,7 @@ func (t *TypeResolver) resolveBinaryExpr(chain *binding, expr *ast.BLangBinaryEx
 	return resultTy, effect, true
 }
 
-func isSingletonbool(ty semtypes.SemType, value bool) bool {
+func isSingletonBool(ty semtypes.SemType, value bool) bool {
 	singleShape := semtypes.SingleShape(ty)
 	if singleShape.IsPresent() {
 		return singleShape.Get().Value == value
@@ -1138,9 +1138,9 @@ func (t *TypeResolver) resolveLogicalExpr(chain *binding, expr *ast.BLangBinaryE
 			return nil, expressionEffect{}, false
 		}
 		var resultTy semtypes.SemType = &semtypes.BOOLEAN
-		if isSingletonbool(lhsTy, true) {
+		if isSingletonBool(lhsTy, true) {
 			resultTy = rhsTy
-		} else if isSingletonbool(lhsTy, false) {
+		} else if isSingletonBool(lhsTy, false) {
 			resultTy = semtypes.BooleanConst(false)
 		}
 		setExpectedType(expr, resultTy)
@@ -1158,9 +1158,9 @@ func (t *TypeResolver) resolveLogicalExpr(chain *binding, expr *ast.BLangBinaryE
 			return nil, expressionEffect{}, false
 		}
 		var resultTy semtypes.SemType = &semtypes.BOOLEAN
-		if isSingletonbool(lhsTy, true) {
+		if isSingletonBool(lhsTy, true) {
 			resultTy = semtypes.BooleanConst(true)
-		} else if isSingletonbool(lhsTy, false) {
+		} else if isSingletonBool(lhsTy, false) {
 			resultTy = rhsTy
 		}
 		setExpectedType(expr, resultTy)
@@ -1245,7 +1245,7 @@ func (t *TypeResolver) NilLiftingExprResultTy(lhsTy, rhsTy semtypes.SemType, exp
 		return nil, false
 	}
 
-	if isMultipcativeExpr(expr) {
+	if isMultiplicativeExpr(expr) {
 		if !isNumericType(&lhsBasicTy) || !isNumericType(&rhsBasicTy) {
 			t.ctx.SemanticError(fmt.Sprintf("expect numeric types for %s", string(expr.GetOperatorKind())), expr.GetPosition())
 			return nil, false


### PR DESCRIPTION
## Purpose
$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Corrected naming conventions across the codebase for consistency.
  * Fixed public API method name typo for proper spelling.
  * Standardized function and parameter naming to follow Go conventions.
  * Internal helper functions renamed for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->