### PR TITLE
Disable parallel corpus subtests on js/wasm to avoid GC crashes

### DIFF
--- a/ast/corpus_ast_test.go
+++ b/ast/corpus_ast_test.go
@@ -38,7 +38,7 @@ func TestASTGeneration(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testASTGeneration(t, testPair)
 		})
 	}
@@ -122,7 +122,7 @@ func TestWalkTraversal(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testWalkTraversal(t, testPair)
 		})
 	}

--- a/bir/codec/corpus_codec_test.go
+++ b/bir/codec/corpus_codec_test.go
@@ -41,7 +41,7 @@ func TestBIRSerialization(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testBIRSerialization(t, testPair)
 		})
 	}

--- a/bir/corpus_bir_test.go
+++ b/bir/corpus_bir_test.go
@@ -59,7 +59,7 @@ func TestBIRGeneration(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testBIRGeneration(t, testPair)
 		})
 	}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,8 @@
 github_checks:
   annotations: true
 
-ignore:
-  - "test_util"
-
 coverage:
   status:
     patch:
       default:
         target: 80%
-        paths:
-          - "!test_util"

--- a/desugar/corpus_desugar_test.go
+++ b/desugar/corpus_desugar_test.go
@@ -39,7 +39,7 @@ func TestDesugar(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testDesugar(t, testPair)
 		})
 	}

--- a/parser/corpus_parser_test.go
+++ b/parser/corpus_parser_test.go
@@ -221,7 +221,7 @@ func TestParseCorpusFiles(t *testing.T) {
 	// Running in parallel for faster test execution
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel() // Run in parallel for faster execution (native only)
+			test_util.ParallelIfNative(t) // Run in parallel for faster execution (native only)
 			parseFile(t, testPair)
 		})
 	}
@@ -249,7 +249,7 @@ func TestJBalUnitTests(t *testing.T) {
 		testCase := createTestCase(t, balFile, corpusDir)
 
 		t.Run(balFile, func(t *testing.T) {
-			t.Parallel() // Run in parallel for faster execution (native only)
+			test_util.ParallelIfNative(t) // Run in parallel for faster execution (native only)
 			parseFile(t, testCase)
 		})
 	}

--- a/semantics/corpus_cfg_test.go
+++ b/semantics/corpus_cfg_test.go
@@ -39,7 +39,7 @@ func TestCFGGeneration(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testCFGGeneration(t, testPair)
 		})
 	}

--- a/semantics/corpus_semantic_analysis_test.go
+++ b/semantics/corpus_semantic_analysis_test.go
@@ -35,7 +35,7 @@ func TestSemanticAnalysis(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testSemanticAnalysis(t, testPair)
 		})
 	}
@@ -131,7 +131,7 @@ func TestSemanticAnalysisErrors(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testSemanticAnalysisError(t, testPair)
 		})
 	}

--- a/semantics/corpus_symbol_resolver_test.go
+++ b/semantics/corpus_symbol_resolver_test.go
@@ -35,7 +35,7 @@ func TestSymbolResolver(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testSymbolResolution(t, testPair)
 		})
 	}

--- a/semantics/corpus_type_resolver_test.go
+++ b/semantics/corpus_type_resolver_test.go
@@ -35,7 +35,7 @@ func TestTypeResolver(t *testing.T) {
 
 	for _, testPair := range testPairs {
 		t.Run(testPair.Name, func(t *testing.T) {
-			t.Parallel()
+			test_util.ParallelIfNative(t)
 			testTypeResolution(t, testPair)
 		})
 	}

--- a/test_util/test_util.go
+++ b/test_util/test_util.go
@@ -20,6 +20,7 @@ package test_util
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -160,4 +161,13 @@ func computeExpectedPath(inputPath, inputBaseDir, outputBaseDir, outputExt strin
 	relPath, _ := filepath.Rel(inputBaseDir, inputPath)
 	relPath = strings.TrimSuffix(relPath, ".bal") + outputExt
 	return filepath.Join(outputBaseDir, relPath)
+}
+
+// ParallelIfNative runs the test in parallel for non-wasm targets.
+// js/wasm currently hits intermittent runtime GC crashes under heavy parallel corpus loads.
+func ParallelIfNative(t *testing.T) {
+	if runtime.GOOS == "js" && runtime.GOARCH == "wasm" {
+		return
+	}
+	t.Parallel()
 }


### PR DESCRIPTION
## Purpose
$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution strategy for better environment-specific compatibility.

* **Chores**
  * Updated test infrastructure and coverage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->