### PR TITLE
fix(runtime): synchronize lifecycle state access

### DIFF
--- a/desugar/desugar.go
+++ b/desugar/desugar.go
@@ -620,6 +620,8 @@ func createLifeCycleHooks(pkgCtx *packageContext, pkg *ast.BLangPackage, moduleL
 		loopVarRef.SetPosition(initPos)
 
 		collectionRef := *moduleListenersRef
+		variableName := *moduleListenersRef.VariableName
+		collectionRef.VariableName = &variableName
 		bodyStmt := buildMethodCallStmt(foreachScope, loopVarRef, methodName)
 
 		foreach := &ast.BLangForeach{
@@ -661,7 +663,7 @@ func createLifeCycleHooks(pkgCtx *packageContext, pkg *ast.BLangPackage, moduleL
 	}
 
 	for _, fnName := range []string{StartFunctionName, GracefulStopFunctionName, ImmediateStopFunctionName} {
-		pkg.Functions = append(pkg.Functions, *desugarFunction(pkgCtx, buildLifecycleFn(fnName)))
+		pkg.Functions = append(pkg.Functions, *buildLifecycleFn(fnName))
 	}
 }
 
@@ -1247,11 +1249,6 @@ func DesugarPackage(compilerCtx *context.CompilerContext, pkg *ast.BLangPackage,
 	desugarTopLevelFunctionDefaults(pkgCtx, pkg)
 	desugarClassMethodDefaults(pkgCtx, pkg)
 
-	// Desugar all functions
-	for i := range pkg.Functions {
-		desugarFn(&pkg.Functions[i])
-	}
-
 	desugarObjectDefinitionConcurrently := func(class *ast.BLangClassDefinition) {
 		wg.Go(func() {
 			defer func() {
@@ -1268,10 +1265,6 @@ func DesugarPackage(compilerCtx *context.CompilerContext, pkg *ast.BLangPackage,
 			}
 			*class.InitFunction = *desugarFunction(pkgCtx, class.InitFunction)
 		})
-	}
-	// Desugar class definitions (each class concurrently, members sequentially)
-	for i := range pkg.ClassDefinitions {
-		desugarObjectDefinitionConcurrently(&pkg.ClassDefinitions[i])
 	}
 	desugarServiceConcurrently := func(svc *ast.BLangService) {
 		wg.Go(func() {
@@ -1297,6 +1290,15 @@ func DesugarPackage(compilerCtx *context.CompilerContext, pkg *ast.BLangPackage,
 	hoistInlineServiceListeners(pkgCtx, pkg)
 	desugarInitFn(pkgCtx, compilerCtx, pkg)
 
+	// Desugar all functions after desugarInitFn has created any lifecycle hooks.
+	for i := range pkg.Functions {
+		desugarFn(&pkg.Functions[i])
+	}
+
+	// Desugar class definitions (each class concurrently, members sequentially)
+	for i := range pkg.ClassDefinitions {
+		desugarObjectDefinitionConcurrently(&pkg.ClassDefinitions[i])
+	}
 	for i := range pkg.Services {
 		desugarServiceConcurrently(&pkg.Services[i])
 	}

--- a/runtime/lifecycle.go
+++ b/runtime/lifecycle.go
@@ -144,7 +144,9 @@ func abortAction(_ *Runtime) {
 }
 
 func (rt *Runtime) stopAfterInitFailure() {
+	rt.mu.Lock()
 	rt.exitCode = 1
+	rt.mu.Unlock()
 	rt.transition(StateGracefulStopping)
 }
 
@@ -241,15 +243,15 @@ func (rt *Runtime) gracefulStopFnSeq() iter.Seq[*exec.InvokableHandle] {
 // immediateStopAction call immediateStop on all module listeners in the reverse order
 // they got registered. should any of those functions return an error runtime will panic
 func immediateStopAction(rt *Runtime) {
-	if rt.exitCode == 0 {
-		rt.exitCode = 131 // 128  + SIGQUIT
-	}
 	onError := func(reason string) {
 		rt.mu.Unlock()
 		writeStderr(rt.env, fmt.Sprintf("panic: immediate stop failed due to %s\n", reason))
 		rt.transition(StateStopped)
 	}
 	rt.mu.Lock()
+	if rt.exitCode == 0 {
+		rt.exitCode = 131 // 128  + SIGQUIT
+	}
 	rt.state = StateImmediateStopping
 	for i := len(rt.immediateStopFns) - 1; i >= 0; i-- {
 		fn := rt.immediateStopFns[i]
@@ -269,13 +271,15 @@ func immediateStopAction(rt *Runtime) {
 }
 
 func stoppedAction(rt *Runtime) {
+	rt.mu.Lock()
 	if rt.state == StateStopped {
+		rt.mu.Unlock()
 		return
 	}
-	rt.mu.Lock()
 	rt.state = StateStopped
+	exitCode := rt.exitCode
 	rt.mu.Unlock()
-	rt.exitCodeChan <- rt.exitCode
+	rt.exitCodeChan <- exitCode
 	close(rt.exitCodeChan)
 }
 
@@ -290,7 +294,13 @@ func (rt *Runtime) setupSignalListeners() {
 		panic("no signal channel in PAL")
 	}
 	go func(ch <-chan pal.Signal) {
-		for rt.state != StateStopped {
+		for {
+			rt.mu.Lock()
+			stopped := rt.state == StateStopped
+			rt.mu.Unlock()
+			if stopped {
+				return
+			}
 			sig, ok := <-ch
 			if !ok {
 				return


### PR DESCRIPTION
## Summary
- guard lifecycle state and exit-code accesses in runtime signal handling
- create lifecycle hooks before concurrent desugar and avoid shared identifier nodes

Closes #550

## Tests
- go test -race -count=1 -run "^TestLifecycle(GracefulStopSignal|ImmediateStopSignal|InitFailureStopsRuntime|OnGracefulStopHandlers|OnGracefulStopWithoutListenersExitStatus|OnGracefulStopWithoutListenersHandlerError|OnGracefulStopWithoutListenersAfterInitFailure|OnGracefulStopExternHandler|OnGracefulStopAfterListenReportsCurrentState|OnGracefulStopAfterInitializationFailsFast)$" ./runtime
- go test -race -count=10 -run "^TestLifecycleOnGracefulStopWithoutListenersHandlerError$" ./runtime
- go test -race -count=1 ./runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exit code handling during initialization failures with proper synchronization.
  * Enhanced idempotency of runtime stop operations to prevent duplicate state transitions.
  * Strengthened signal listener reliability by ensuring proper state checks during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->