### PR TITLE
feat(xml): support foreach iteration

### DIFF
--- a/common/assert_debug.go
+++ b/common/assert_debug.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build debug
+
+package common
+
+func Assert(condition func() bool) {
+	if !condition() {
+		panic("Assertion failed")
+	}
+}

--- a/common/assert_release.go
+++ b/common/assert_release.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !debug
+
+package common
+
+func Assert(_ func() bool) {}

--- a/common/values.go
+++ b/common/values.go
@@ -54,12 +54,6 @@ func OptionalEmpty[T any]() Optional[T] {
 	}
 }
 
-func Assert(condition bool) {
-	if !condition {
-		panic("Assertion failed")
-	}
-}
-
 func PointerEqualToValue[T comparable](ptr any, value T) bool {
 	if val, ok := ptr.(T); ok {
 		return val == value

--- a/corpus/ast/subset9/09-xml/iterator-v.txt
+++ b/corpus/ast/subset9/09-xml/iterator-v.txt
@@ -1,0 +1,212 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (constrained-type
+            (builtin-ref-type xml)
+            (union-type
+              (union-type
+                (user-defined-type xml Element)
+                (user-defined-type xml Text))
+              (user-defined-type xml Comment)))) (expr
+          (xml-sequence-literal
+            (xml-element-literal a)
+            (xml-text-literal hello)
+            (xml-comment-literal c)))))
+      (var-def
+        (variable methodNext (type
+          (union-type
+            (record-type
+              (field value
+                (union-type
+                  (union-type
+                    (user-defined-type xml Element)
+                    (user-defined-type xml Text))
+                  (user-defined-type xml Comment))))
+            (value-type null))) (expr
+          (invocation next expr:
+            (invocation iterator expr:
+              (simple-var-ref x) ()) ()))))
+      (if
+        (binary-expr !=
+          (simple-var-ref methodNext)
+          (literal <nil>))
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (field-based-access value
+                (simple-var-ref methodNext)))))) ())
+      (block-stmt
+        (var-def
+          (variable functionNext (type
+            (union-type
+              (record-type
+                (field value
+                  (union-type
+                    (union-type
+                      (user-defined-type xml Element)
+                      (user-defined-type xml Text))
+                    (user-defined-type xml Comment))))
+              (value-type null))) (expr
+            (invocation next expr:
+              (invocation xml iterator (
+                (simple-var-ref x))) ()))))
+        (if
+          (binary-expr !=
+            (simple-var-ref functionNext)
+            (literal <nil>))
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (field-based-access value
+                  (simple-var-ref functionNext)))))) ())
+        (block-stmt
+          (foreach
+            (var-def
+              (variable item (type
+                (union-type
+                  (union-type
+                    (user-defined-type xml Element)
+                    (user-defined-type xml Text))
+                  (user-defined-type xml Comment)))))
+            (simple-var-ref x)
+            (block-stmt
+              (expression-stmt
+                (invocation io println (
+                  (simple-var-ref item))))))
+          (var-def
+            (variable element (type
+              (user-defined-type xml Element)) (expr
+              (xml-element-literal e))))
+          (var-def
+            (variable elementNext (type
+              (union-type
+                (record-type
+                  (field value
+                    (user-defined-type xml Element)))
+                (value-type null))) (expr
+              (invocation next expr:
+                (invocation iterator expr:
+                  (simple-var-ref element) ()) ()))))
+          (if
+            (binary-expr !=
+              (simple-var-ref elementNext)
+              (literal <nil>))
+            (block-stmt
+              (expression-stmt
+                (invocation io println (
+                  (field-based-access value
+                    (simple-var-ref elementNext)))))) ())
+          (block-stmt
+            (foreach
+              (var-def
+                (variable item (type
+                  (user-defined-type xml Element))))
+              (simple-var-ref element)
+              (block-stmt
+                (expression-stmt
+                  (invocation io println (
+                    (simple-var-ref item))))))
+            (var-def
+              (variable comment (type
+                (user-defined-type xml Comment)) (expr
+                (xml-comment-literal comment))))
+            (var-def
+              (variable commentNext (type
+                (union-type
+                  (record-type
+                    (field value
+                      (user-defined-type xml Comment)))
+                  (value-type null))) (expr
+                (invocation next expr:
+                  (invocation iterator expr:
+                    (simple-var-ref comment) ()) ()))))
+            (if
+              (binary-expr !=
+                (simple-var-ref commentNext)
+                (literal <nil>))
+              (block-stmt
+                (expression-stmt
+                  (invocation io println (
+                    (field-based-access value
+                      (simple-var-ref commentNext)))))) ())
+            (block-stmt
+              (foreach
+                (var-def
+                  (variable item (type
+                    (user-defined-type xml Comment))))
+                (simple-var-ref comment)
+                (block-stmt
+                  (expression-stmt
+                    (invocation io println (
+                      (simple-var-ref item))))))
+              (var-def
+                (variable pi (type
+                  (user-defined-type xml ProcessingInstruction)) (expr
+                  (xml-pi-literal p data))))
+              (var-def
+                (variable piNext (type
+                  (union-type
+                    (record-type
+                      (field value
+                        (user-defined-type xml ProcessingInstruction)))
+                    (value-type null))) (expr
+                  (invocation next expr:
+                    (invocation iterator expr:
+                      (simple-var-ref pi) ()) ()))))
+              (if
+                (binary-expr !=
+                  (simple-var-ref piNext)
+                  (literal <nil>))
+                (block-stmt
+                  (expression-stmt
+                    (invocation io println (
+                      (field-based-access value
+                        (simple-var-ref piNext)))))) ())
+              (block-stmt
+                (foreach
+                  (var-def
+                    (variable item (type
+                      (user-defined-type xml ProcessingInstruction))))
+                  (simple-var-ref pi)
+                  (block-stmt
+                    (expression-stmt
+                      (invocation io println (
+                        (simple-var-ref item))))))
+                (var-def
+                  (variable text (type
+                    (user-defined-type xml Text)) (expr
+                    (xml-text-literal text))))
+                (var-def
+                  (variable textNext (type
+                    (union-type
+                      (record-type
+                        (field value
+                          (user-defined-type xml Text)))
+                      (value-type null))) (expr
+                    (invocation next expr:
+                      (invocation iterator expr:
+                        (simple-var-ref text) ()) ()))))
+                (if
+                  (binary-expr !=
+                    (simple-var-ref textNext)
+                    (literal <nil>))
+                  (block-stmt
+                    (expression-stmt
+                      (invocation io println (
+                        (field-based-access value
+                          (simple-var-ref textNext)))))) ())
+                (block-stmt
+                  (foreach
+                    (var-def
+                      (variable item (type
+                        (user-defined-type xml Text))))
+                    (simple-var-ref text)
+                    (block-stmt
+                      (expression-stmt
+                        (invocation io println (
+                          (simple-var-ref item)))))))))))))))

--- a/corpus/ast/subset9/09-xml/iterator-var-v.txt
+++ b/corpus/ast/subset9/09-xml/iterator-var-v.txt
@@ -1,0 +1,46 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable element (type
+          (user-defined-type xml Element)) (expr
+          (xml-element-literal e))))
+      (foreach
+        (var-def
+          (variable item))
+        (simple-var-ref element)
+        (block-stmt
+          (var-def
+            (variable typed (type
+              (user-defined-type xml Element)) (expr
+              (simple-var-ref item))))
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref typed))))))
+      (var-def
+        (variable elementOrText (type
+          (constrained-type
+            (builtin-ref-type xml)
+            (union-type
+              (user-defined-type xml Element)
+              (user-defined-type xml Text)))) (expr
+          (xml-sequence-literal
+            (xml-element-literal e)
+            (xml-text-literal text)))))
+      (foreach
+        (var-def
+          (variable item))
+        (simple-var-ref elementOrText)
+        (block-stmt
+          (var-def
+            (variable typed (type
+              (union-type
+                (user-defined-type xml Element)
+                (user-defined-type xml Text))) (expr
+              (simple-var-ref item))))
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref typed)))))))))

--- a/corpus/bal/subset9/09-xml/iterator-e.bal
+++ b/corpus/bal/subset9/09-xml/iterator-e.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    xml:Element element = xml `<e/>`;
+    xml:Text text = xml `text`;
+    xml<xml:Element|xml:Text> elementOrText = xml `<e/>text`;
+
+    record {| xml:Comment value; |}? _ = element.iterator().next(); // @error iterator value type is xml:Element
+    record {| xml:Element value; |}? _ = xml:iterator(text).next(); // @error iterator value type is xml:Text
+    record {| xml:Comment value; |}? _ = elementOrText.iterator().next(); // @error iterator value type is xml:Element|xml:Text
+
+    foreach xml:Comment item in element { // @error foreach item type is xml:Element
+        _ = item;
+    }
+
+    foreach xml:Comment item in elementOrText { // @error foreach item type is xml:Element|xml:Text
+        _ = item;
+    }
+
+    foreach int item in text { // @error foreach item type is xml:Text
+        _ = item;
+    }
+}

--- a/corpus/bal/subset9/09-xml/iterator-nonxml-e.bal
+++ b/corpus/bal/subset9/09-xml/iterator-nonxml-e.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    _ = xml:iterator(1); // @error non-xml value is not valid for xml iterator
+    _ = 1.iterator(); // @error non-xml receiver has no iterator method
+}

--- a/corpus/bal/subset9/09-xml/iterator-v.bal
+++ b/corpus/bal/subset9/09-xml/iterator-v.bal
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    xml<xml:Element|xml:Text|xml:Comment> x = xml `<a/>hello<!--c-->`;
+
+    record {| xml:Element|xml:Text|xml:Comment value; |}? methodNext = x.iterator().next();
+    if methodNext != () {
+        io:println(methodNext.value); // @output <a/>
+    }
+
+    record {| xml:Element|xml:Text|xml:Comment value; |}? functionNext = xml:iterator(x).next();
+    if functionNext != () {
+        io:println(functionNext.value); // @output <a/>
+    }
+
+    foreach xml:Element|xml:Text|xml:Comment item in x {
+        io:println(item); // @output <a/>
+                          // @output hello
+                          // @output <!--c-->
+    }
+
+    xml:Element element = xml `<e/>`;
+    record {| xml:Element value; |}? elementNext = element.iterator().next();
+    if elementNext != () {
+        io:println(elementNext.value); // @output <e/>
+    }
+    foreach xml:Element item in element {
+        io:println(item); // @output <e/>
+    }
+
+    xml:Comment comment = xml `<!--comment-->`;
+    record {| xml:Comment value; |}? commentNext = comment.iterator().next();
+    if commentNext != () {
+        io:println(commentNext.value); // @output <!--comment-->
+    }
+    foreach xml:Comment item in comment {
+        io:println(item); // @output <!--comment-->
+    }
+
+    xml:ProcessingInstruction pi = xml `<?p data?>`;
+    record {| xml:ProcessingInstruction value; |}? piNext = pi.iterator().next();
+    if piNext != () {
+        io:println(piNext.value); // @output <?p data?>
+    }
+    foreach xml:ProcessingInstruction item in pi {
+        io:println(item); // @output <?p data?>
+    }
+
+    xml:Text text = xml `text`;
+    record {| xml:Text value; |}? textNext = text.iterator().next();
+    if textNext != () {
+        io:println(textNext.value); // @output text
+    }
+    foreach xml:Text item in text {
+        io:println(item); // @output text
+    }
+}

--- a/corpus/bal/subset9/09-xml/iterator-var-v.bal
+++ b/corpus/bal/subset9/09-xml/iterator-var-v.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    xml:Element element = xml `<e/>`;
+    foreach var item in element {
+        xml:Element typed = item;
+        io:println(typed); // @output <e/>
+    }
+
+    xml<xml:Element|xml:Text> elementOrText = xml `<e/>text`;
+    foreach var item in elementOrText {
+        xml:Element|xml:Text typed = item;
+        io:println(typed); // @output <e/>
+                           // @output text
+    }
+}

--- a/corpus/bir/subset9/09-xml/iterator-v.txt
+++ b/corpus/bir/subset9/09-xml/iterator-v.txt
@@ -1,0 +1,362 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad a
+    %2 = newXMLElement(%1, ())
+    %3 = ConstantLoad hello
+    %4 = newXMLText(%3)
+    %5 = ConstantLoad c
+    %6 = newXMLComment(%5)
+    %7 = newXMLSequence{%2, %4, %6}
+    x = %7;
+    %9 = iterator(x) -> bb1;
+  }
+  bb1 {
+    %10 = next(%9) -> bb2;
+  }
+  bb2 {
+    methodNext = %10;
+    %13 = ConstantLoad <nil>
+    %14 = %13;
+    %12 = != methodNext %14;
+    %12 ? bb3 : bb5;
+  }
+  bb3 {
+    PushScopeFrame 3
+    %1 = ConstantLoad value
+    %0 = (1, methodNext)[%1];
+    %2 = println(%0) -> bb4;
+  }
+  bb4 {
+    PopScopeFrame
+    GOTO bb5;
+  }
+  bb5 {
+    PushScopeFrame 6
+    %0 = iterator((1, x)) -> bb6;
+  }
+  bb6 {
+    %1 = next(%0) -> bb7;
+  }
+  bb7 {
+    functionNext = %1;
+    %4 = ConstantLoad <nil>
+    %5 = %4;
+    %3 = != functionNext %5;
+    %3 ? bb8 : bb10;
+  }
+  bb8 {
+    PushScopeFrame 3
+    %1 = ConstantLoad value
+    %0 = (1, functionNext)[%1];
+    %2 = println(%0) -> bb9;
+  }
+  bb9 {
+    PopScopeFrame
+    GOTO bb10;
+  }
+  bb10 {
+    PushScopeFrame 13
+    $desugar$0 = (2, x);
+    %1 = iterator($desugar$0) -> bb11;
+  }
+  bb11 {
+    $desugar$1 = %1;
+    GOTO bb12;
+  }
+  bb12 {
+    %3 = ConstantLoad true
+    %3 ? bb13 : bb14;
+  }
+  bb13 {
+    PushScopeFrame 7
+    %0 = next((1, $desugar$1)) -> bb15;
+  }
+  bb14 {
+    %4 = ConstantLoad e
+    %5 = newXMLElement(%4, ())
+    element = %5;
+    %7 = iterator(element) -> bb19;
+  }
+  bb15 {
+    $desugar$3 = %0;
+    %2 = $desugar$3 is nil
+    %2 ? bb16 : bb17;
+  }
+  bb16 {
+    PushScopeFrame 0
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb14;
+  }
+  bb17 {
+    %4 = ConstantLoad value
+    %3 = $desugar$3[%4];
+    item = %3;
+    %6 = println(item) -> bb18;
+  }
+  bb18 {
+    PopScopeFrame
+    GOTO bb12;
+  }
+  bb19 {
+    %8 = next(%7) -> bb20;
+  }
+  bb20 {
+    elementNext = %8;
+    %11 = ConstantLoad <nil>
+    %12 = %11;
+    %10 = != elementNext %12;
+    %10 ? bb21 : bb23;
+  }
+  bb21 {
+    PushScopeFrame 3
+    %1 = ConstantLoad value
+    %0 = (1, elementNext)[%1];
+    %2 = println(%0) -> bb22;
+  }
+  bb22 {
+    PopScopeFrame
+    GOTO bb23;
+  }
+  bb23 {
+    PushScopeFrame 13
+    $desugar$4 = (1, element);
+    %1 = iterator($desugar$4) -> bb24;
+  }
+  bb24 {
+    $desugar$5 = %1;
+    GOTO bb25;
+  }
+  bb25 {
+    %3 = ConstantLoad true
+    %3 ? bb26 : bb27;
+  }
+  bb26 {
+    PushScopeFrame 7
+    %0 = next((1, $desugar$5)) -> bb28;
+  }
+  bb27 {
+    %4 = ConstantLoad comment
+    %5 = newXMLComment(%4)
+    comment = %5;
+    %7 = iterator(comment) -> bb32;
+  }
+  bb28 {
+    $desugar$7 = %0;
+    %2 = $desugar$7 is nil
+    %2 ? bb29 : bb30;
+  }
+  bb29 {
+    PushScopeFrame 0
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb27;
+  }
+  bb30 {
+    %4 = ConstantLoad value
+    %3 = $desugar$7[%4];
+    item = %3;
+    %6 = println(item) -> bb31;
+  }
+  bb31 {
+    PopScopeFrame
+    GOTO bb25;
+  }
+  bb32 {
+    %8 = next(%7) -> bb33;
+  }
+  bb33 {
+    commentNext = %8;
+    %11 = ConstantLoad <nil>
+    %12 = %11;
+    %10 = != commentNext %12;
+    %10 ? bb34 : bb36;
+  }
+  bb34 {
+    PushScopeFrame 3
+    %1 = ConstantLoad value
+    %0 = (1, commentNext)[%1];
+    %2 = println(%0) -> bb35;
+  }
+  bb35 {
+    PopScopeFrame
+    GOTO bb36;
+  }
+  bb36 {
+    PushScopeFrame 14
+    $desugar$8 = (1, comment);
+    %1 = iterator($desugar$8) -> bb37;
+  }
+  bb37 {
+    $desugar$9 = %1;
+    GOTO bb38;
+  }
+  bb38 {
+    %3 = ConstantLoad true
+    %3 ? bb39 : bb40;
+  }
+  bb39 {
+    PushScopeFrame 7
+    %0 = next((1, $desugar$9)) -> bb41;
+  }
+  bb40 {
+    %4 = ConstantLoad p
+    %5 = ConstantLoad data
+    %6 = newXMLPI(%4, %5)
+    pi = %6;
+    %8 = iterator(pi) -> bb45;
+  }
+  bb41 {
+    $desugar$11 = %0;
+    %2 = $desugar$11 is nil
+    %2 ? bb42 : bb43;
+  }
+  bb42 {
+    PushScopeFrame 0
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb40;
+  }
+  bb43 {
+    %4 = ConstantLoad value
+    %3 = $desugar$11[%4];
+    item = %3;
+    %6 = println(item) -> bb44;
+  }
+  bb44 {
+    PopScopeFrame
+    GOTO bb38;
+  }
+  bb45 {
+    %9 = next(%8) -> bb46;
+  }
+  bb46 {
+    piNext = %9;
+    %12 = ConstantLoad <nil>
+    %13 = %12;
+    %11 = != piNext %13;
+    %11 ? bb47 : bb49;
+  }
+  bb47 {
+    PushScopeFrame 3
+    %1 = ConstantLoad value
+    %0 = (1, piNext)[%1];
+    %2 = println(%0) -> bb48;
+  }
+  bb48 {
+    PopScopeFrame
+    GOTO bb49;
+  }
+  bb49 {
+    PushScopeFrame 13
+    $desugar$12 = (1, pi);
+    %1 = iterator($desugar$12) -> bb50;
+  }
+  bb50 {
+    $desugar$13 = %1;
+    GOTO bb51;
+  }
+  bb51 {
+    %3 = ConstantLoad true
+    %3 ? bb52 : bb53;
+  }
+  bb52 {
+    PushScopeFrame 7
+    %0 = next((1, $desugar$13)) -> bb54;
+  }
+  bb53 {
+    %4 = ConstantLoad text
+    %5 = newXMLText(%4)
+    text = %5;
+    %7 = iterator(text) -> bb58;
+  }
+  bb54 {
+    $desugar$15 = %0;
+    %2 = $desugar$15 is nil
+    %2 ? bb55 : bb56;
+  }
+  bb55 {
+    PushScopeFrame 0
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb53;
+  }
+  bb56 {
+    %4 = ConstantLoad value
+    %3 = $desugar$15[%4];
+    item = %3;
+    %6 = println(item) -> bb57;
+  }
+  bb57 {
+    PopScopeFrame
+    GOTO bb51;
+  }
+  bb58 {
+    %8 = next(%7) -> bb59;
+  }
+  bb59 {
+    textNext = %8;
+    %11 = ConstantLoad <nil>
+    %12 = %11;
+    %10 = != textNext %12;
+    %10 ? bb60 : bb62;
+  }
+  bb60 {
+    PushScopeFrame 3
+    %1 = ConstantLoad value
+    %0 = (1, textNext)[%1];
+    %2 = println(%0) -> bb61;
+  }
+  bb61 {
+    PopScopeFrame
+    GOTO bb62;
+  }
+  bb62 {
+    PushScopeFrame 4
+    $desugar$16 = (1, text);
+    %1 = iterator($desugar$16) -> bb63;
+  }
+  bb63 {
+    $desugar$17 = %1;
+    GOTO bb64;
+  }
+  bb64 {
+    %3 = ConstantLoad true
+    %3 ? bb65 : bb66;
+  }
+  bb65 {
+    PushScopeFrame 7
+    %0 = next((1, $desugar$17)) -> bb67;
+  }
+  bb66 {
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb67 {
+    $desugar$19 = %0;
+    %2 = $desugar$19 is nil
+    %2 ? bb68 : bb69;
+  }
+  bb68 {
+    PushScopeFrame 0
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb66;
+  }
+  bb69 {
+    %4 = ConstantLoad value
+    %3 = $desugar$19[%4];
+    item = %3;
+    %6 = println(item) -> bb70;
+  }
+  bb70 {
+    PopScopeFrame
+    GOTO bb64;
+  }
+}

--- a/corpus/bir/subset9/09-xml/iterator-var-v.txt
+++ b/corpus/bir/subset9/09-xml/iterator-var-v.txt
@@ -1,0 +1,91 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad e
+    %2 = newXMLElement(%1, ())
+    element = %2;
+    $desugar$0 = element;
+    %5 = iterator($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$1 = %5;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = ConstantLoad true
+    %7 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 8
+    %0 = next((1, $desugar$1)) -> bb5;
+  }
+  bb4 {
+    %8 = ConstantLoad e
+    %9 = newXMLElement(%8, ())
+    %10 = ConstantLoad text
+    %11 = newXMLText(%10)
+    %12 = newXMLSequence{%9, %11}
+    elementOrText = %12;
+    $desugar$4 = elementOrText;
+    %15 = iterator($desugar$4) -> bb9;
+  }
+  bb5 {
+    $desugar$3 = %0;
+    %2 = $desugar$3 is nil
+    %2 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb4;
+  }
+  bb7 {
+    %4 = ConstantLoad value
+    %3 = $desugar$3[%4];
+    item = %3;
+    typed = item;
+    %7 = println(typed) -> bb8;
+  }
+  bb8 {
+    PopScopeFrame
+    GOTO bb2;
+  }
+  bb9 {
+    $desugar$5 = %15;
+    GOTO bb10;
+  }
+  bb10 {
+    %17 = ConstantLoad true
+    %17 ? bb11 : bb12;
+  }
+  bb11 {
+    PushScopeFrame 8
+    %0 = next((1, $desugar$5)) -> bb13;
+  }
+  bb12 {
+    return;
+  }
+  bb13 {
+    $desugar$7 = %0;
+    %2 = $desugar$7 is nil
+    %2 ? bb14 : bb15;
+  }
+  bb14 {
+    PushScopeFrame 0
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb12;
+  }
+  bb15 {
+    %4 = ConstantLoad value
+    %3 = $desugar$7[%4];
+    item = %3;
+    typed = item;
+    %7 = println(typed) -> bb16;
+  }
+  bb16 {
+    PopScopeFrame
+    GOTO bb10;
+  }
+}

--- a/corpus/cfg/subset9/09-xml/iterator-v.txt
+++ b/corpus/cfg/subset9/09-xml/iterator-v.txt
@@ -1,0 +1,230 @@
+(main
+  (bb0 () (bb1 bb2)
+    (var-def
+      (variable x (type
+        (constrained-type
+          (builtin-ref-type xml)
+          (union-type
+            (union-type
+              (user-defined-type xml Element)
+              (user-defined-type xml Text))
+            (user-defined-type xml Comment)))) (expr
+        (xml-sequence-literal
+          (xml-element-literal a)
+          (xml-text-literal hello)
+          (xml-comment-literal c)))))
+    (var-def
+      (variable methodNext (type
+        (union-type
+          (record-type
+            (field value
+              (union-type
+                (union-type
+                  (user-defined-type xml Element)
+                  (user-defined-type xml Text))
+                (user-defined-type xml Comment))))
+          (value-type null))) (expr
+        (invocation next expr:
+          (invocation lang.xml iterator (
+            (simple-var-ref x))) ()))))
+    (binary-expr !=
+      (simple-var-ref methodNext)
+      (literal <nil>))
+  )
+  (bb1 (bb0) (bb2)
+    (expression-stmt
+      (invocation io println (
+        (field-based-access value
+          (simple-var-ref methodNext)))))
+  )
+  (bb2 (bb1 bb0) (bb3 bb4)
+    (var-def
+      (variable functionNext (type
+        (union-type
+          (record-type
+            (field value
+              (union-type
+                (union-type
+                  (user-defined-type xml Element)
+                  (user-defined-type xml Text))
+                (user-defined-type xml Comment))))
+          (value-type null))) (expr
+        (invocation next expr:
+          (invocation xml iterator (
+            (simple-var-ref x))) ()))))
+    (binary-expr !=
+      (simple-var-ref functionNext)
+      (literal <nil>))
+  )
+  (bb3 (bb2) (bb4)
+    (expression-stmt
+      (invocation io println (
+        (field-based-access value
+          (simple-var-ref functionNext)))))
+  )
+  (bb4 (bb3 bb2) (bb5))
+  (bb5 (bb4 bb6) (bb6 bb7)
+    (simple-var-ref x)
+    (var-def
+      (variable item (type
+        (union-type
+          (union-type
+            (user-defined-type xml Element)
+            (user-defined-type xml Text))
+          (user-defined-type xml Comment)))))
+  )
+  (bb6 (bb5) (bb5)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref item))))
+  )
+  (bb7 (bb5) (bb8 bb9)
+    (var-def
+      (variable element (type
+        (user-defined-type xml Element)) (expr
+        (xml-element-literal e))))
+    (var-def
+      (variable elementNext (type
+        (union-type
+          (record-type
+            (field value
+              (user-defined-type xml Element)))
+          (value-type null))) (expr
+        (invocation next expr:
+          (invocation lang.xml iterator (
+            (simple-var-ref element))) ()))))
+    (binary-expr !=
+      (simple-var-ref elementNext)
+      (literal <nil>))
+  )
+  (bb8 (bb7) (bb9)
+    (expression-stmt
+      (invocation io println (
+        (field-based-access value
+          (simple-var-ref elementNext)))))
+  )
+  (bb9 (bb8 bb7) (bb10))
+  (bb10 (bb9 bb11) (bb11 bb12)
+    (simple-var-ref element)
+    (var-def
+      (variable item (type
+        (user-defined-type xml Element))))
+  )
+  (bb11 (bb10) (bb10)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref item))))
+  )
+  (bb12 (bb10) (bb13 bb14)
+    (var-def
+      (variable comment (type
+        (user-defined-type xml Comment)) (expr
+        (xml-comment-literal comment))))
+    (var-def
+      (variable commentNext (type
+        (union-type
+          (record-type
+            (field value
+              (user-defined-type xml Comment)))
+          (value-type null))) (expr
+        (invocation next expr:
+          (invocation lang.xml iterator (
+            (simple-var-ref comment))) ()))))
+    (binary-expr !=
+      (simple-var-ref commentNext)
+      (literal <nil>))
+  )
+  (bb13 (bb12) (bb14)
+    (expression-stmt
+      (invocation io println (
+        (field-based-access value
+          (simple-var-ref commentNext)))))
+  )
+  (bb14 (bb13 bb12) (bb15))
+  (bb15 (bb14 bb16) (bb16 bb17)
+    (simple-var-ref comment)
+    (var-def
+      (variable item (type
+        (user-defined-type xml Comment))))
+  )
+  (bb16 (bb15) (bb15)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref item))))
+  )
+  (bb17 (bb15) (bb18 bb19)
+    (var-def
+      (variable pi (type
+        (user-defined-type xml ProcessingInstruction)) (expr
+        (xml-pi-literal p data))))
+    (var-def
+      (variable piNext (type
+        (union-type
+          (record-type
+            (field value
+              (user-defined-type xml ProcessingInstruction)))
+          (value-type null))) (expr
+        (invocation next expr:
+          (invocation lang.xml iterator (
+            (simple-var-ref pi))) ()))))
+    (binary-expr !=
+      (simple-var-ref piNext)
+      (literal <nil>))
+  )
+  (bb18 (bb17) (bb19)
+    (expression-stmt
+      (invocation io println (
+        (field-based-access value
+          (simple-var-ref piNext)))))
+  )
+  (bb19 (bb18 bb17) (bb20))
+  (bb20 (bb19 bb21) (bb21 bb22)
+    (simple-var-ref pi)
+    (var-def
+      (variable item (type
+        (user-defined-type xml ProcessingInstruction))))
+  )
+  (bb21 (bb20) (bb20)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref item))))
+  )
+  (bb22 (bb20) (bb23 bb24)
+    (var-def
+      (variable text (type
+        (user-defined-type xml Text)) (expr
+        (xml-text-literal text))))
+    (var-def
+      (variable textNext (type
+        (union-type
+          (record-type
+            (field value
+              (user-defined-type xml Text)))
+          (value-type null))) (expr
+        (invocation next expr:
+          (invocation lang.xml iterator (
+            (simple-var-ref text))) ()))))
+    (binary-expr !=
+      (simple-var-ref textNext)
+      (literal <nil>))
+  )
+  (bb23 (bb22) (bb24)
+    (expression-stmt
+      (invocation io println (
+        (field-based-access value
+          (simple-var-ref textNext)))))
+  )
+  (bb24 (bb23 bb22) (bb25))
+  (bb25 (bb24 bb26) (bb26 bb27)
+    (simple-var-ref text)
+    (var-def
+      (variable item (type
+        (user-defined-type xml Text))))
+  )
+  (bb26 (bb25) (bb25)
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref item))))
+  )
+  (bb27 (bb25) ())
+)

--- a/corpus/cfg/subset9/09-xml/iterator-var-v.txt
+++ b/corpus/cfg/subset9/09-xml/iterator-var-v.txt
@@ -1,0 +1,51 @@
+(main
+  (bb0 () (bb1)
+    (var-def
+      (variable element (type
+        (user-defined-type xml Element)) (expr
+        (xml-element-literal e))))
+  )
+  (bb1 (bb0 bb2) (bb2 bb3)
+    (simple-var-ref element)
+    (var-def
+      (variable item))
+  )
+  (bb2 (bb1) (bb1)
+    (var-def
+      (variable typed (type
+        (user-defined-type xml Element)) (expr
+        (simple-var-ref item))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref typed))))
+  )
+  (bb3 (bb1) (bb4)
+    (var-def
+      (variable elementOrText (type
+        (constrained-type
+          (builtin-ref-type xml)
+          (union-type
+            (user-defined-type xml Element)
+            (user-defined-type xml Text)))) (expr
+        (xml-sequence-literal
+          (xml-element-literal e)
+          (xml-text-literal text)))))
+  )
+  (bb4 (bb3 bb5) (bb5 bb6)
+    (simple-var-ref elementOrText)
+    (var-def
+      (variable item))
+  )
+  (bb5 (bb4) (bb4)
+    (var-def
+      (variable typed (type
+        (union-type
+          (user-defined-type xml Element)
+          (user-defined-type xml Text))) (expr
+        (simple-var-ref item))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref typed))))
+  )
+  (bb6 (bb4) ())
+)

--- a/corpus/desugared/subset9/09-xml/iterator-v.txt
+++ b/corpus/desugared/subset9/09-xml/iterator-v.txt
@@ -1,0 +1,314 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang xml (as lang.xml))
+  (import-package ballerina lang xml (as lang.xml))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable x (type
+          (constrained-type
+            (builtin-ref-type xml)
+            (union-type
+              (union-type
+                (user-defined-type xml Element)
+                (user-defined-type xml Text))
+              (user-defined-type xml Comment)))) (expr
+          (xml-sequence-literal
+            (xml-element-literal a)
+            (xml-text-literal hello)
+            (xml-comment-literal c)))))
+      (var-def
+        (variable methodNext (type
+          (union-type
+            (record-type
+              (field value
+                (union-type
+                  (union-type
+                    (user-defined-type xml Element)
+                    (user-defined-type xml Text))
+                  (user-defined-type xml Comment))))
+            (value-type null))) (expr
+          (invocation next expr:
+            (invocation lang.xml iterator (
+              (simple-var-ref x))) ()))))
+      (if
+        (binary-expr !=
+          (simple-var-ref methodNext)
+          (literal <nil>))
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (index-based-access
+                (simple-var-ref methodNext)
+                (literal value)))))) ())
+      (block-stmt
+        (var-def
+          (variable functionNext (type
+            (union-type
+              (record-type
+                (field value
+                  (union-type
+                    (union-type
+                      (user-defined-type xml Element)
+                      (user-defined-type xml Text))
+                    (user-defined-type xml Comment))))
+              (value-type null))) (expr
+            (invocation next expr:
+              (invocation xml iterator (
+                (simple-var-ref x))) ()))))
+        (if
+          (binary-expr !=
+            (simple-var-ref functionNext)
+            (literal <nil>))
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (index-based-access
+                  (simple-var-ref functionNext)
+                  (literal value)))))) ())
+        (block-stmt
+          (var-def
+            (variable $desugar$0 (expr
+              (simple-var-ref x))))
+          (var-def
+            (variable $desugar$1 (expr
+              (invocation lang.xml iterator (
+                (simple-var-ref $desugar$0))))))
+          (while
+            (literal true)
+            (block-stmt
+              (var-def
+                (variable $desugar$3 (expr
+                  (invocation next expr:
+                    (simple-var-ref $desugar$1) ()))))
+              (if
+                (type-test-expr is
+                  (simple-var-ref $desugar$3))
+                (block-stmt
+                  (break)) ())
+              (var-def
+                (variable item (type
+                  (union-type
+                    (union-type
+                      (user-defined-type xml Element)
+                      (user-defined-type xml Text))
+                    (user-defined-type xml Comment))) (expr
+                  (index-based-access
+                    (simple-var-ref $desugar$3)
+                    (literal value)))))
+              (expression-stmt
+                (invocation io println (
+                  (simple-var-ref item))))))
+          (var-def
+            (variable element (type
+              (user-defined-type xml Element)) (expr
+              (xml-element-literal e))))
+          (var-def
+            (variable elementNext (type
+              (union-type
+                (record-type
+                  (field value
+                    (user-defined-type xml Element)))
+                (value-type null))) (expr
+              (invocation next expr:
+                (invocation lang.xml iterator (
+                  (simple-var-ref element))) ()))))
+          (if
+            (binary-expr !=
+              (simple-var-ref elementNext)
+              (literal <nil>))
+            (block-stmt
+              (expression-stmt
+                (invocation io println (
+                  (index-based-access
+                    (simple-var-ref elementNext)
+                    (literal value)))))) ())
+          (block-stmt
+            (var-def
+              (variable $desugar$4 (expr
+                (simple-var-ref element))))
+            (var-def
+              (variable $desugar$5 (expr
+                (invocation lang.xml iterator (
+                  (simple-var-ref $desugar$4))))))
+            (while
+              (literal true)
+              (block-stmt
+                (var-def
+                  (variable $desugar$7 (expr
+                    (invocation next expr:
+                      (simple-var-ref $desugar$5) ()))))
+                (if
+                  (type-test-expr is
+                    (simple-var-ref $desugar$7))
+                  (block-stmt
+                    (break)) ())
+                (var-def
+                  (variable item (type
+                    (user-defined-type xml Element)) (expr
+                    (index-based-access
+                      (simple-var-ref $desugar$7)
+                      (literal value)))))
+                (expression-stmt
+                  (invocation io println (
+                    (simple-var-ref item))))))
+            (var-def
+              (variable comment (type
+                (user-defined-type xml Comment)) (expr
+                (xml-comment-literal comment))))
+            (var-def
+              (variable commentNext (type
+                (union-type
+                  (record-type
+                    (field value
+                      (user-defined-type xml Comment)))
+                  (value-type null))) (expr
+                (invocation next expr:
+                  (invocation lang.xml iterator (
+                    (simple-var-ref comment))) ()))))
+            (if
+              (binary-expr !=
+                (simple-var-ref commentNext)
+                (literal <nil>))
+              (block-stmt
+                (expression-stmt
+                  (invocation io println (
+                    (index-based-access
+                      (simple-var-ref commentNext)
+                      (literal value)))))) ())
+            (block-stmt
+              (var-def
+                (variable $desugar$8 (expr
+                  (simple-var-ref comment))))
+              (var-def
+                (variable $desugar$9 (expr
+                  (invocation lang.xml iterator (
+                    (simple-var-ref $desugar$8))))))
+              (while
+                (literal true)
+                (block-stmt
+                  (var-def
+                    (variable $desugar$11 (expr
+                      (invocation next expr:
+                        (simple-var-ref $desugar$9) ()))))
+                  (if
+                    (type-test-expr is
+                      (simple-var-ref $desugar$11))
+                    (block-stmt
+                      (break)) ())
+                  (var-def
+                    (variable item (type
+                      (user-defined-type xml Comment)) (expr
+                      (index-based-access
+                        (simple-var-ref $desugar$11)
+                        (literal value)))))
+                  (expression-stmt
+                    (invocation io println (
+                      (simple-var-ref item))))))
+              (var-def
+                (variable pi (type
+                  (user-defined-type xml ProcessingInstruction)) (expr
+                  (xml-pi-literal p data))))
+              (var-def
+                (variable piNext (type
+                  (union-type
+                    (record-type
+                      (field value
+                        (user-defined-type xml ProcessingInstruction)))
+                    (value-type null))) (expr
+                  (invocation next expr:
+                    (invocation lang.xml iterator (
+                      (simple-var-ref pi))) ()))))
+              (if
+                (binary-expr !=
+                  (simple-var-ref piNext)
+                  (literal <nil>))
+                (block-stmt
+                  (expression-stmt
+                    (invocation io println (
+                      (index-based-access
+                        (simple-var-ref piNext)
+                        (literal value)))))) ())
+              (block-stmt
+                (var-def
+                  (variable $desugar$12 (expr
+                    (simple-var-ref pi))))
+                (var-def
+                  (variable $desugar$13 (expr
+                    (invocation lang.xml iterator (
+                      (simple-var-ref $desugar$12))))))
+                (while
+                  (literal true)
+                  (block-stmt
+                    (var-def
+                      (variable $desugar$15 (expr
+                        (invocation next expr:
+                          (simple-var-ref $desugar$13) ()))))
+                    (if
+                      (type-test-expr is
+                        (simple-var-ref $desugar$15))
+                      (block-stmt
+                        (break)) ())
+                    (var-def
+                      (variable item (type
+                        (user-defined-type xml ProcessingInstruction)) (expr
+                        (index-based-access
+                          (simple-var-ref $desugar$15)
+                          (literal value)))))
+                    (expression-stmt
+                      (invocation io println (
+                        (simple-var-ref item))))))
+                (var-def
+                  (variable text (type
+                    (user-defined-type xml Text)) (expr
+                    (xml-text-literal text))))
+                (var-def
+                  (variable textNext (type
+                    (union-type
+                      (record-type
+                        (field value
+                          (user-defined-type xml Text)))
+                      (value-type null))) (expr
+                    (invocation next expr:
+                      (invocation lang.xml iterator (
+                        (simple-var-ref text))) ()))))
+                (if
+                  (binary-expr !=
+                    (simple-var-ref textNext)
+                    (literal <nil>))
+                  (block-stmt
+                    (expression-stmt
+                      (invocation io println (
+                        (index-based-access
+                          (simple-var-ref textNext)
+                          (literal value)))))) ())
+                (block-stmt
+                  (var-def
+                    (variable $desugar$16 (expr
+                      (simple-var-ref text))))
+                  (var-def
+                    (variable $desugar$17 (expr
+                      (invocation lang.xml iterator (
+                        (simple-var-ref $desugar$16))))))
+                  (while
+                    (literal true)
+                    (block-stmt
+                      (var-def
+                        (variable $desugar$19 (expr
+                          (invocation next expr:
+                            (simple-var-ref $desugar$17) ()))))
+                      (if
+                        (type-test-expr is
+                          (simple-var-ref $desugar$19))
+                        (block-stmt
+                          (break)) ())
+                      (var-def
+                        (variable item (type
+                          (user-defined-type xml Text)) (expr
+                          (index-based-access
+                            (simple-var-ref $desugar$19)
+                            (literal value)))))
+                      (expression-stmt
+                        (invocation io println (
+                          (simple-var-ref item)))))))))))))))

--- a/corpus/desugared/subset9/09-xml/iterator-var-v.txt
+++ b/corpus/desugared/subset9/09-xml/iterator-var-v.txt
@@ -1,0 +1,84 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang xml (as lang.xml))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable element (type
+          (user-defined-type xml Element)) (expr
+          (xml-element-literal e))))
+      (var-def
+        (variable $desugar$0 (expr
+          (simple-var-ref element))))
+      (var-def
+        (variable $desugar$1 (expr
+          (invocation lang.xml iterator (
+            (simple-var-ref $desugar$0))))))
+      (while
+        (literal true)
+        (block-stmt
+          (var-def
+            (variable $desugar$3 (expr
+              (invocation next expr:
+                (simple-var-ref $desugar$1) ()))))
+          (if
+            (type-test-expr is
+              (simple-var-ref $desugar$3))
+            (block-stmt
+              (break)) ())
+          (var-def
+            (variable item (expr
+              (index-based-access
+                (simple-var-ref $desugar$3)
+                (literal value)))))
+          (var-def
+            (variable typed (type
+              (user-defined-type xml Element)) (expr
+              (simple-var-ref item))))
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref typed))))))
+      (var-def
+        (variable elementOrText (type
+          (constrained-type
+            (builtin-ref-type xml)
+            (union-type
+              (user-defined-type xml Element)
+              (user-defined-type xml Text)))) (expr
+          (xml-sequence-literal
+            (xml-element-literal e)
+            (xml-text-literal text)))))
+      (var-def
+        (variable $desugar$4 (expr
+          (simple-var-ref elementOrText))))
+      (var-def
+        (variable $desugar$5 (expr
+          (invocation lang.xml iterator (
+            (simple-var-ref $desugar$4))))))
+      (while
+        (literal true)
+        (block-stmt
+          (var-def
+            (variable $desugar$7 (expr
+              (invocation next expr:
+                (simple-var-ref $desugar$5) ()))))
+          (if
+            (type-test-expr is
+              (simple-var-ref $desugar$7))
+            (block-stmt
+              (break)) ())
+          (var-def
+            (variable item (expr
+              (index-based-access
+                (simple-var-ref $desugar$7)
+                (literal value)))))
+          (var-def
+            (variable typed (type
+              (union-type
+                (user-defined-type xml Element)
+                (user-defined-type xml Text))) (expr
+              (simple-var-ref item))))
+          (expression-stmt
+            (invocation io println (
+              (simple-var-ref typed)))))))))

--- a/corpus/integration/subset3/03-loop/list-2-e.txtar
+++ b/corpus/integration/subset3/03-loop/list-2-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: invalid type for variable
+error[SEMANTIC_ERROR]: invalid variable type boolean
   --> list-2-e.bal:21:13
    |
 21 |     foreach boolean val in arr { // @error

--- a/corpus/integration/subset3/03-loop/list-4-e.txtar
+++ b/corpus/integration/subset3/03-loop/list-4-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: invalid type for variable
+error[SEMANTIC_ERROR]: invalid variable type int
   --> list-4-e.bal:21:13
    |
 21 |     foreach int val in arr { // @error

--- a/corpus/integration/subset5/05-list/iter-e.txtar
+++ b/corpus/integration/subset5/05-list/iter-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: invalid type for variable
+error[SEMANTIC_ERROR]: invalid variable type int
   --> iter-e.bal:22:13
    |
 22 |     foreach int i in f { // @error

--- a/corpus/integration/subset6/06-map/foreach2-e.txtar
+++ b/corpus/integration/subset6/06-map/foreach2-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: invalid type for variable
+error[SEMANTIC_ERROR]: invalid variable type boolean
   --> foreach2-e.bal:21:13
    |
 21 |     foreach boolean val in m { // @error

--- a/corpus/integration/subset6/06-map/foreach4-e.txtar
+++ b/corpus/integration/subset6/06-map/foreach4-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: invalid type for variable
+error[SEMANTIC_ERROR]: invalid variable type int
   --> foreach4-e.bal:21:13
    |
 21 |     foreach int val in m { // @error

--- a/corpus/integration/subset6/06-map/foreach8-e.txtar
+++ b/corpus/integration/subset6/06-map/foreach8-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: invalid type for variable
+error[SEMANTIC_ERROR]: invalid variable type string
   --> foreach8-e.bal:26:13
    |
 26 |     foreach string val in p { // @error

--- a/corpus/integration/subset9/09-xml/iterator-e.txtar
+++ b/corpus/integration/subset9/09-xml/iterator-e.txtar
@@ -1,0 +1,37 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: incompatible type: expected nil|{| value: xml:Comment, never... |}, got nil|{| value: xml:Element, never... |}
+  --> iterator-e.bal:22:42
+   |
+22 |     record {| xml:Comment value; |}? _ = element.iterator().next(); // @error iterator value type is xml:Element
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: incompatible type: expected nil|{| value: xml:Comment, never... |}, got nil|{| value: xml<xml:Text|xml:Element>, never... |}
+  --> iterator-e.bal:24:42
+   |
+24 |     record {| xml:Comment value; |}? _ = elementOrText.iterator().next(); // @error iterator value type is xml:Element|xml:Text
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: incompatible type: expected nil|{| value: xml:Element, never... |}, got nil|{| value: xml:Text, never... |}
+  --> iterator-e.bal:23:42
+   |
+23 |     record {| xml:Element value; |}? _ = xml:iterator(text).next(); // @error iterator value type is xml:Text
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: invalid type for variable
+  --> iterator-e.bal:26:13
+   |
+26 |     foreach xml:Comment item in element { // @error foreach item type is xml:Element
+   |             ^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: invalid type for variable
+  --> iterator-e.bal:30:13
+   |
+30 |     foreach xml:Comment item in elementOrText { // @error foreach item type is xml:Element|xml:Text
+   |             ^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: invalid type for variable
+  --> iterator-e.bal:34:13
+   |
+34 |     foreach int item in text { // @error foreach item type is xml:Text
+   |             ^^^^^^^^

--- a/corpus/integration/subset9/09-xml/iterator-e.txtar
+++ b/corpus/integration/subset9/09-xml/iterator-e.txtar
@@ -18,20 +18,20 @@ error[SEMANTIC_ERROR]: incompatible type: expected nil|{| value: xml:Element, ne
 23 |     record {| xml:Element value; |}? _ = xml:iterator(text).next(); // @error iterator value type is xml:Text
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[SEMANTIC_ERROR]: invalid type for variable
+error[SEMANTIC_ERROR]: invalid variable type int
+  --> iterator-e.bal:34:13
+   |
+34 |     foreach int item in text { // @error foreach item type is xml:Text
+   |             ^^^^^^^^
+
+error[SEMANTIC_ERROR]: invalid variable type xml:Comment
   --> iterator-e.bal:26:13
    |
 26 |     foreach xml:Comment item in element { // @error foreach item type is xml:Element
    |             ^^^^^^^^^^^^^^^^
 
-error[SEMANTIC_ERROR]: invalid type for variable
+error[SEMANTIC_ERROR]: invalid variable type xml:Comment
   --> iterator-e.bal:30:13
    |
 30 |     foreach xml:Comment item in elementOrText { // @error foreach item type is xml:Element|xml:Text
    |             ^^^^^^^^^^^^^^^^
-
-error[SEMANTIC_ERROR]: invalid type for variable
-  --> iterator-e.bal:34:13
-   |
-34 |     foreach int item in text { // @error foreach item type is xml:Text
-   |             ^^^^^^^^

--- a/corpus/integration/subset9/09-xml/iterator-nonxml-e.txtar
+++ b/corpus/integration/subset9/09-xml/iterator-nonxml-e.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: expect first argument to be a subtype of xml
+  --> iterator-nonxml-e.bal:18:9
+   |
+18 |     _ = xml:iterator(1); // @error non-xml value is not valid for xml iterator
+   |         ^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: method not found: iterator
+  --> iterator-nonxml-e.bal:19:9
+   |
+19 |     _ = 1.iterator(); // @error non-xml receiver has no iterator method
+   |         ^^^^^^^^^^^^

--- a/corpus/integration/subset9/09-xml/iterator-v.txtar
+++ b/corpus/integration/subset9/09-xml/iterator-v.txtar
@@ -1,0 +1,15 @@
+-- stdout --
+<a/>
+<a/>
+<a/>
+hello
+<!--c-->
+<e/>
+<e/>
+<!--comment-->
+<!--comment-->
+<?p data?>
+<?p data?>
+text
+text
+-- stderr --

--- a/corpus/integration/subset9/09-xml/iterator-var-v.txtar
+++ b/corpus/integration/subset9/09-xml/iterator-var-v.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+<e/>
+<e/>
+text
+-- stderr --

--- a/desugar/desugar.go
+++ b/desugar/desugar.go
@@ -47,6 +47,7 @@ type packageContext struct {
 	addedImplicitImports map[string]bool
 	desugarSymbolCounter int
 	typeContext          semtypes.Context
+	xmlIteratorTypes     *semtypes.SemTypeCache
 }
 
 var _ desugarContext = &packageContext{}
@@ -58,6 +59,7 @@ func newPackageContext(compilerCtx *context.CompilerContext, pkg *ast.BLangPacka
 		importedSymbols:      importedSymbols,
 		addedImplicitImports: make(map[string]bool),
 		typeContext:          semtypes.ContextFrom(compilerCtx.GetTypeEnv()),
+		xmlIteratorTypes:     semtypes.NewSemTypeCache(),
 	}
 }
 

--- a/desugar/statement.go
+++ b/desugar/statement.go
@@ -821,6 +821,65 @@ func isRangeExpr(expr ast.BLangActionOrExpression) bool {
 	return false
 }
 
+func createIteratorInvocation(cx *functionContext, receiver ast.BLangExpression, receiverType semtypes.SemType) *ast.BLangInvocation {
+	if semtypes.IsSubtype(cx.typeCtx(), receiverType, semtypes.XML) {
+		return createXMLIteratorInvocation(cx, receiver, receiverType)
+	}
+	return createMethodInvocation(cx, receiver, "iterator", receiverType, []ast.BLangExpression{})
+}
+
+func createXMLIteratorInvocation(cx *functionContext, receiver ast.BLangExpression, receiverType semtypes.SemType) *ast.BLangInvocation {
+	pkgName := "lang.xml"
+	space, ok := cx.pkgCtx.getImportedSymbolSpace(pkgName)
+	if !ok {
+		cx.pkgCtx.internalError(pkgName + " symbol space not found")
+		return nil
+	}
+	iteratorRef, ok := space.GetSymbol("iterator")
+	if !ok {
+		cx.pkgCtx.internalError(pkgName + ":iterator symbol not found")
+		return nil
+	}
+	cx.pkgCtx.addImplicitImport(pkgName, ast.BLangImportPackage{
+		OrgName:      &ast.BLangIdentifier{Value: "ballerina"},
+		PkgNameComps: []ast.BLangIdentifier{{Value: "lang"}, {Value: "xml"}},
+		Alias:        &ast.BLangIdentifier{Value: pkgName},
+	})
+	inv := &ast.BLangInvocation{PkgAlias: &ast.BLangIdentifier{Value: pkgName}}
+	inv.Name = &ast.BLangIdentifier{Value: "iterator"}
+	inv.ArgExprs = []ast.BLangExpression{receiver}
+	inv.SetSymbol(iteratorRef)
+	inv.SetDeterminedType(cx.pkgCtx.xmlIteratorType(semtypes.XMLItemType(receiverType)))
+	inv.SetPosition(receiver.GetPosition())
+	return inv
+}
+
+func (ctx *packageContext) xmlIteratorType(itemTy semtypes.SemType) semtypes.SemType {
+	return ctx.xmlIteratorTypes.GetOrBuild(itemTy, func() semtypes.SemType {
+		return buildXMLIteratorType(ctx.typeEnv(), itemTy)
+	})
+}
+
+func buildXMLIteratorType(env semtypes.Env, itemTy semtypes.SemType) semtypes.SemType {
+	recordDef := semtypes.NewMappingDefinition()
+	recordTy := recordDef.DefineMappingTypeWrapped(env,
+		[]semtypes.Field{semtypes.FieldFrom("value", itemTy, false, false)},
+		semtypes.NEVER)
+	nextReturnTy := semtypes.Union(recordTy, semtypes.NIL)
+	ld := semtypes.NewListDefinition()
+	emptyParams := ld.DefineListTypeWrapped(env, nil, 0, semtypes.NEVER, semtypes.CellMutability_CELL_MUT_NONE)
+	fd := semtypes.NewFunctionDefinition()
+	nextFnTy := fd.Define(env, emptyParams, nextReturnTy, semtypes.FunctionQualifiersFrom(env, true, false))
+	iterOd := semtypes.NewObjectDefinition()
+	return iterOd.Define(env, semtypes.ObjectQualifiersDEFAULT, []semtypes.Member{{
+		Name:       "next",
+		ValueTy:    nextFnTy,
+		Kind:       semtypes.MemberKindMethod,
+		Visibility: semtypes.VisibilityPublic,
+		Immutable:  true,
+	}})
+}
+
 func createMethodInvocation(cx *functionContext, receiver ast.BLangExpression, methodName string, receiverType semtypes.SemType, args []ast.BLangExpression) *ast.BLangInvocation {
 	tyCtx := cx.typeCtx()
 	fnTy := semtypes.ObjectMemberType(tyCtx, semtypes.StringConst(methodName), receiverType)
@@ -870,7 +929,7 @@ func desugarForEachOnIterable(cx *functionContext, collection ast.BLangActionOrE
 	collVarRef.SetDeterminedType(collType)
 
 	// Step 2: Create iterator = collection.iterator()
-	iteratorInv := createMethodInvocation(cx, collVarRef, "iterator", collType, []ast.BLangExpression{})
+	iteratorInv := createIteratorInvocation(cx, collVarRef, collType)
 	iteratorType := iteratorInv.GetDeterminedType()
 
 	iterName, iterSymbol := cx.addDesugardSymbol(iteratorType, model.SymbolKindVariable, false)
@@ -958,7 +1017,7 @@ func desugarForEachOnIterable(cx *functionContext, collection ast.BLangActionOrE
 	// 4d: loopVar = $next.value (field access desugared to index access by walkBlockStmt)
 	nextRefForValue := &ast.BLangSimpleVarRef{VariableName: nextVarName}
 	nextRefForValue.SetSymbol(nextSymbol)
-	nextRefForValue.SetDeterminedType(nextReturnType)
+	nextRefForValue.SetDeterminedType(semtypes.MAPPING)
 
 	valueAccess := &ast.BLangFieldBaseAccess{
 		Field: ast.BLangIdentifier{Value: "value"},

--- a/lib/langlibs/go/lang.xml/xml.go
+++ b/lib/langlibs/go/lang.xml/xml.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package xml
+
+import (
+	"ballerina-lang-go/runtime"
+	"ballerina-lang-go/runtime/extern"
+	"ballerina-lang-go/semtypes"
+	"ballerina-lang-go/values"
+)
+
+const (
+	orgName        = "ballerina"
+	moduleName     = "lang.xml"
+	nextMethodName = "$xmlIterator.next"
+)
+
+func initXMLModule(rt *runtime.Runtime) {
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "iterator", xmlIterator)
+	runtime.RegisterExternFunction(rt, orgName, moduleName, nextMethodName, xmlIteratorNext)
+}
+
+func xmlIterator(_ *extern.Context, args []values.BalValue) (values.BalValue, error) {
+	x, _ := args[0].(values.XMLValue)
+	return values.NewObject(semtypes.OBJECT, map[string]values.BalValue{
+		"items": x.IterItems(),
+		"idx":   int64(0),
+	}, map[string]string{
+		"next": orgName + "/" + moduleName + ":" + nextMethodName,
+	}, nil), nil
+}
+
+func xmlIteratorNext(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+	it := args[0].(*values.Object)
+	itemsValue, _ := it.Get("items")
+	idxValue, _ := it.Get("idx")
+	items := itemsValue.([]values.XMLValue)
+	idx := idxValue.(int64)
+	if idx >= int64(len(items)) {
+		return nil, nil
+	}
+	it.Put("idx", idx+1)
+	recordTy := xmlIteratorNextRecordType(ctx.Env.TypeEnv)
+	return values.NewMap(recordTy, semtypes.ToMappingAtomicType(ctx.TypeCtx, recordTy), false, []values.MapEntry{{
+		Key:   "value",
+		Value: items[idx],
+	}}), nil
+}
+
+func xmlIteratorNextRecordType(env semtypes.Env) semtypes.SemType {
+	def := semtypes.NewMappingDefinition()
+	return def.DefineMappingTypeWrapped(env,
+		[]semtypes.Field{semtypes.FieldFrom("value", semtypes.XML, false, false)},
+		semtypes.NEVER)
+}
+
+func init() {
+	runtime.RegisterModuleInitializer(initXMLModule)
+}

--- a/lib/rt/libs.go
+++ b/lib/rt/libs.go
@@ -26,6 +26,7 @@ import (
 	_ "ballerina-lang-go/lib/langlibs/go/lang.int"
 	_ "ballerina-lang-go/lib/langlibs/go/lang.map"
 	_ "ballerina-lang-go/lib/langlibs/go/lang.string"
+	_ "ballerina-lang-go/lib/langlibs/go/lang.xml"
 
 	// standard libraries
 	_ "ballerina-lang-go/lib/stdlibs/ballerina/http/0.0.1/go1.2/native"

--- a/model/opaque.go
+++ b/model/opaque.go
@@ -48,6 +48,8 @@ const (
 	OpaqueFnArrayPush = 0
 	// lang.map
 	OpaqueFnMapRemove = 0
+	// lang.xml
+	OpaqueFnXMLIterator = 4
 )
 
 func newOpaqueFunctionSymbol(name string, id int) *OpaqueFunctionSymbol {
@@ -154,9 +156,10 @@ func langXMLOpaqueSymbols() []Symbol {
 		{"Text", semtypes.XML_TEXT},
 		{"ProcessingInstruction", semtypes.XML_PI},
 	}
-	syms := make([]Symbol, len(defs))
+	syms := make([]Symbol, len(defs)+1)
 	for i, def := range defs {
 		syms[i] = newOpaqueTypeSymbol(def.name, def.ty, i)
 	}
+	syms[OpaqueFnXMLIterator] = newOpaqueFunctionSymbol("iterator", OpaqueFnXMLIterator)
 	return syms
 }

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -2067,7 +2067,7 @@ func validateForeach[A analyzer](a A, foreachStmt *ast.BLangForeach) bool {
 			expectedValueType = semtypes.MappingMemberTypeInnerVal(tyCtx, recordPart, semtypes.StringConst("value"))
 		}
 		if !semtypes.IsSubtype(a.tyCtx(), expectedValueType, variableType) {
-			a.ctx().SemanticError("invalid type for variable", variable.GetPosition())
+			a.ctx().SemanticError(fmt.Sprintf("invalid variable type %s", semtypes.ToString(a.tyCtx(), variableType)), variable.GetPosition())
 			return false
 		}
 	}

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -2046,6 +2046,8 @@ func validateForeach[A analyzer](a A, foreachStmt *ast.BLangForeach) bool {
 			expectedValueType = result
 		case semtypes.IsSubtype(a.tyCtx(), collectionType, semtypes.MAPPING):
 			expectedValueType = semtypes.MappingMemberTypeInnerVal(a.tyCtx(), collectionType, semtypes.STRING)
+		case semtypes.IsSubtype(a.tyCtx(), collectionType, semtypes.XML):
+			expectedValueType = semtypes.XMLItemType(collectionType)
 		default:
 			tyCtx := a.tyCtx()
 			iterableTy := semtypes.CreateIterable(tyCtx)

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -82,6 +82,7 @@ type typeResolver interface {
 	lookupClassMethodSymbol(receiverTy semtypes.SemType, methodName string) (model.SymbolRef, bool)
 
 	ensureNotEmpty(ty semtypes.SemType, onEmpty func()) bool
+	xmlIteratorTypeCache() *semtypes.SemTypeCache
 }
 
 // deferredEmptinessCheck is an emptiness check that was registered while the
@@ -132,6 +133,7 @@ type packageTypeResolver struct {
 	classAtomSymbols     map[*semtypes.MappingAtomicType]model.SymbolRef
 	classSymbolByType    map[semtypes.InternHandle]model.SymbolRef
 	semtypeInterner      *semtypes.SemtypeInterner
+	xmlIteratorTypes     *semtypes.SemTypeCache
 
 	deferredEmptinessChecks []deferredEmptinessCheck
 }
@@ -169,6 +171,9 @@ func (t *packageTypeResolver) typeContext() semtypes.Context        { return t.t
 func (t *packageTypeResolver) expectedReturnType() semtypes.SemType { return semtypes.SemType{} }
 func (t *packageTypeResolver) parent() typeResolver                 { return nil }
 func (t *packageTypeResolver) typeEnv() semtypes.Env                { return t.ctx.GetTypeEnv() }
+func (t *packageTypeResolver) xmlIteratorTypeCache() *semtypes.SemTypeCache {
+	return t.xmlIteratorTypes
+}
 
 func (t *packageTypeResolver) semanticError(msg string, loc diagnostics.Location) {
 	t.ctx.SemanticError(msg, loc)
@@ -321,6 +326,9 @@ func (f *functionTypeResolver) typeContext() semtypes.Context        { return f.
 func (f *functionTypeResolver) expectedReturnType() semtypes.SemType { return f.retTy }
 func (f *functionTypeResolver) parent() typeResolver                 { return f.parentResolver }
 func (f *functionTypeResolver) typeEnv() semtypes.Env                { return f.parentResolver.typeEnv() }
+func (f *functionTypeResolver) xmlIteratorTypeCache() *semtypes.SemTypeCache {
+	return f.parentResolver.xmlIteratorTypeCache()
+}
 
 func (f *functionTypeResolver) semanticError(msg string, loc diagnostics.Location) {
 	f.parentResolver.semanticError(msg, loc)
@@ -472,6 +480,7 @@ func newPackageTypeResolver(ctx *context.CompilerContext, pkg *ast.BLangPackage,
 		classAtomSymbols:       make(map[*semtypes.MappingAtomicType]model.SymbolRef),
 		classSymbolByType:      make(map[semtypes.InternHandle]model.SymbolRef),
 		semtypeInterner:        semtypes.NewSemtypeInterner(),
+		xmlIteratorTypes:       semtypes.NewSemTypeCache(),
 		monoCounters:           make(map[string]int),
 		scope:                  moduleScope,
 	}
@@ -3528,6 +3537,8 @@ func resolveForeachVariableType(t typeResolver, collection ast.BLangActionOrExpr
 		return semtypes.ListMemberTypeInnerVal(ctx, collectionTy, semtypes.INT), true
 	case semtypes.IsSubtype(ctx, collectionTy, semtypes.MAPPING):
 		return semtypes.MappingMemberTypeInnerVal(ctx, collectionTy, semtypes.STRING), true
+	case semtypes.IsSubtype(ctx, collectionTy, semtypes.XML):
+		return semtypes.XMLItemType(collectionTy), true
 	default:
 		ld := semtypes.NewListDefinition()
 		emptyListTy := ld.DefineListTypeWrapped(t.typeEnv(), nil, 0, semtypes.NEVER, semtypes.CellMutability_CELL_MUT_NONE)
@@ -6762,6 +6773,7 @@ type opaqueFnMonomorphizer func(t typeResolver, sym *model.OpaqueFunctionSymbol,
 var (
 	arrayOpaqueMonomorphizers []opaqueFnMonomorphizer
 	mapOpaqueMonomorphizers   []opaqueFnMonomorphizer
+	xmlOpaqueMonomorphizers   []opaqueFnMonomorphizer
 )
 
 func init() {
@@ -6770,6 +6782,9 @@ func init() {
 	}
 	mapOpaqueMonomorphizers = []opaqueFnMonomorphizer{
 		model.OpaqueFnMapRemove: monomorphizeMapRemove,
+	}
+	xmlOpaqueMonomorphizers = []opaqueFnMonomorphizer{
+		model.OpaqueFnXMLIterator: monomorphizeXMLIterator,
 	}
 }
 
@@ -6785,6 +6800,8 @@ func opaqueFunctionMonomorphizerFor(org, pkg string, id int) (opaqueFnMonomorphi
 		monomorphizers = arrayOpaqueMonomorphizers
 	case "lang.map":
 		monomorphizers = mapOpaqueMonomorphizers
+	case "lang.xml":
+		monomorphizers = xmlOpaqueMonomorphizers
 	default:
 		return nil, false
 	}
@@ -6871,6 +6888,59 @@ func monomorphizeArrayPush(t typeResolver, sym *model.OpaqueFunctionSymbol, poly
 		Flags:         model.FuncSymbolFlagIsolated,
 	}
 	return storeMonomorphizedOpaqueFn(t, sym, polymorphicRef, sig, containerTy), true
+}
+
+func monomorphizeXMLIterator(t typeResolver, sym *model.OpaqueFunctionSymbol, polymorphicRef model.SymbolRef, chain *binding, args []ast.BLangExpression, pos diagnostics.Location) (model.SymbolRef, bool) {
+	containerExpr, ok := containerArgExpr(args, "x")
+	if !ok {
+		t.semanticError("missing container argument", pos)
+		return model.SymbolRef{}, false
+	}
+	containerTy, _, ok := resolveActionOrExpression(t, chain, containerExpr, semtypes.SemType{})
+	if !ok {
+		return model.SymbolRef{}, false
+	}
+	if sym.Lookup != nil {
+		if ref, ok := sym.Lookup(containerTy); ok {
+			return ref, true
+		}
+	}
+	cx := t.typeContext()
+	if !semtypes.IsSubtype(cx, containerTy, semtypes.XML) {
+		t.semanticError("expect first argument to be a subtype of xml", pos)
+		return model.SymbolRef{}, false
+	}
+	itemTy := semtypes.XMLItemType(containerTy)
+	sig := model.FunctionSignature{
+		ParamTypes:    []semtypes.SemType{containerTy},
+		RestParamType: semtypes.NEVER,
+		ReturnType:    createXMLIteratorType(t, itemTy),
+		Flags:         model.FuncSymbolFlagIsolated,
+	}
+	return storeMonomorphizedOpaqueFn(t, sym, polymorphicRef, sig, containerTy), true
+}
+
+func createXMLIteratorType(t typeResolver, itemTy semtypes.SemType) semtypes.SemType {
+	env := t.typeEnv()
+	return t.xmlIteratorTypeCache().GetOrBuild(itemTy, func() semtypes.SemType {
+		recordDef := semtypes.NewMappingDefinition()
+		recordTy := recordDef.DefineMappingTypeWrapped(env,
+			[]semtypes.Field{semtypes.FieldFrom("value", itemTy, false, false)},
+			semtypes.NEVER)
+		nextReturnTy := semtypes.Union(recordTy, semtypes.NIL)
+		ld := semtypes.NewListDefinition()
+		emptyParams := ld.DefineListTypeWrapped(env, nil, 0, semtypes.NEVER, semtypes.CellMutability_CELL_MUT_NONE)
+		fd := semtypes.NewFunctionDefinition()
+		nextFnTy := fd.Define(env, emptyParams, nextReturnTy, semtypes.FunctionQualifiersFrom(env, true, false))
+		iterOd := semtypes.NewObjectDefinition()
+		return iterOd.Define(env, semtypes.ObjectQualifiersDEFAULT, []semtypes.Member{{
+			Name:       "next",
+			ValueTy:    nextFnTy,
+			Kind:       semtypes.MemberKindMethod,
+			Visibility: semtypes.VisibilityPublic,
+			Immutable:  true,
+		}})
+	})
 }
 
 func monomorphizeMapRemove(t typeResolver, sym *model.OpaqueFunctionSymbol, polymorphicRef model.SymbolRef, chain *binding, args []ast.BLangExpression, pos diagnostics.Location) (model.SymbolRef, bool) {

--- a/semantics/type_resolver_loop.go
+++ b/semantics/type_resolver_loop.go
@@ -51,6 +51,9 @@ func (l *loopTypeResolver) nextMonoFnName(origName string) string {
 	return l.parentResolver.nextMonoFnName(origName)
 }
 func (l *loopTypeResolver) typeEnv() semtypes.Env { return l.parentResolver.typeEnv() }
+func (l *loopTypeResolver) xmlIteratorTypeCache() *semtypes.SemTypeCache {
+	return l.parentResolver.xmlIteratorTypeCache()
+}
 
 func (l *loopTypeResolver) semanticError(msg string, loc diagnostics.Location) {
 	l.parentResolver.semanticError(msg, loc)

--- a/semtypes/core.go
+++ b/semtypes/core.go
@@ -210,7 +210,7 @@ func Intersect(t1, t2 SemType) SemType {
 func intersectMemberSemTypes(env Env, t1, t2 SemType) SemType {
 	c1 := getCellAtomicType(t1)
 	c2 := getCellAtomicType(t2)
-	common.Assert(c1 != nil && c2 != nil)
+	common.Assert(func() bool { return c1 != nil && c2 != nil })
 	atomicType := intersectCellAtomicType(c1, c2)
 	var mut CellMutability
 	if sameSemType(atomicType.Ty, UNDEF) {
@@ -576,13 +576,13 @@ func cellInnerVal(t SemType) SemType {
 
 func cellInner(t SemType) SemType {
 	cat := getCellAtomicType(t)
-	common.Assert(cat != nil)
+	common.Assert(func() bool { return cat != nil })
 	return cat.Ty
 }
 
 func cellContainingInnerVal(env Env, t SemType) SemType {
 	cat := getCellAtomicType(t)
-	common.Assert(cat != nil)
+	common.Assert(func() bool { return cat != nil })
 	return cellContainingWithEnvSemTypeCellMutability(env, Diff(cat.Ty, UNDEF), cat.Mut)
 }
 

--- a/semtypes/error.go
+++ b/semtypes/error.go
@@ -88,7 +88,7 @@ func ErrorWithDetail(detail SemType) SemType {
 }
 
 func errorDistinct(distinctId int) SemType {
-	common.Assert(distinctId >= 0)
+	common.Assert(func() bool { return distinctId >= 0 })
 	bdd := bddAtom(new(createDistinctRecAtom(((-distinctId) - 1))))
 	return getBasicSubtype(BTError, bdd)
 }

--- a/semtypes/fixed_length_array.go
+++ b/semtypes/fixed_length_array.go
@@ -27,7 +27,7 @@ func newFixedLengthArrayFromInitialFixedLength(initial []SemType, fixedLength in
 	this := fixedLengthArray{}
 	copiedInitial := make([]SemType, len(initial))
 	copy(copiedInitial, initial)
-	common.Assert(fixedLength >= 0)
+	common.Assert(func() bool { return fixedLength >= 0 })
 	this.initial = copiedInitial
 	this.FixedLength = fixedLength
 	return this

--- a/semtypes/object_definition.go
+++ b/semtypes/object_definition.go
@@ -32,7 +32,7 @@ func NewObjectDefinition() ObjectDefinition {
 }
 
 func ObjectDefinitionDistinct(distinctId int) SemType {
-	common.Assert(distinctId >= 0)
+	common.Assert(func() bool { return distinctId >= 0 })
 	bdd := bddAtom(new(createDistinctRecAtom(-distinctId - 1)))
 	return getBasicSubtype(BTObject, bdd)
 }
@@ -94,7 +94,7 @@ func stripDistinctAtomsFromSemType(ty SemType, typeCode BasicTypeCode, stripBdd 
 //	   }
 //	}
 func (o *ObjectDefinition) Define(env Env, qualifiers ObjectQualifiers, members []Member) SemType {
-	common.Assert(objectDefinitionValidateMembers(members))
+	common.Assert(func() bool { return objectDefinitionValidateMembers(members) })
 	var mut CellMutability
 	if qualifiers.readonly {
 		mut = CellMutability_CELL_MUT_NONE

--- a/semtypes/type_atom.go
+++ b/semtypes/type_atom.go
@@ -27,7 +27,7 @@ type typeAtom struct {
 var _ atom = &typeAtom{}
 
 func createTypeAtom(index int, atomicType atomicType) typeAtom {
-	common.Assert(index >= 0)
+	common.Assert(func() bool { return index >= 0 })
 
 	return typeAtom{
 		idx:        index,
@@ -36,8 +36,8 @@ func createTypeAtom(index int, atomicType atomicType) typeAtom {
 }
 
 func createEphemeralTypeAtom(index int, gen uint64, atomicType atomicType) *typeAtom {
-	common.Assert(index >= 0)
-	common.Assert(gen > 0)
+	common.Assert(func() bool { return index >= 0 })
+	common.Assert(func() bool { return gen > 0 })
 
 	return &typeAtom{
 		idx:        index,

--- a/semtypes/type_cache.go
+++ b/semtypes/type_cache.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package semtypes
+
+import "sync"
+
+// SemTypeCache caches semtypes keyed by interned semtype values. SemTypeCache is safe for concurrent use.
+type SemTypeCache struct {
+	mu       sync.Mutex
+	interner *SemtypeInterner
+	values   map[InternHandle]SemType
+}
+
+func NewSemTypeCache() *SemTypeCache {
+	return &SemTypeCache{
+		interner: NewSemtypeInterner(),
+		values:   make(map[InternHandle]SemType),
+	}
+}
+
+func (c *SemTypeCache) GetOrBuild(key SemType, build func() SemType) SemType {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	handle := c.interner.Intern(key)
+	if value, ok := c.values[handle]; ok {
+		return value
+	}
+	value := build()
+	c.values[handle] = value
+	return value
+}

--- a/semtypes/xml_subtype.go
+++ b/semtypes/xml_subtype.go
@@ -59,7 +59,7 @@ func XMLSingleton(primitives int) SemType {
 }
 
 func XMLSequence(constituentType SemType) SemType {
-	common.Assert(IsSubtypeSimple(constituentType, XML))
+	common.Assert(func() bool { return IsSubtypeSimple(constituentType, XML) })
 	if IsNever(constituentType) {
 		return XMLSequence(XMLSingleton(XML_PRIMITIVE_NEVER))
 	}

--- a/semtypes/xml_subtype.go
+++ b/semtypes/xml_subtype.go
@@ -75,6 +75,37 @@ func XMLSequence(constituentType SemType) SemType {
 	return createXmlSemtype(xmlSt)
 }
 
+func XMLItemType(t SemType) SemType {
+	if !IsSubtypeSimple(t, XML) {
+		return NEVER
+	}
+	if t.some() == 0 {
+		return t
+	}
+	xmlSt := getComplexSubtypeData(t, BTXML)
+	if allOrNothing, ok := xmlSt.(allOrNothingSubtype); ok {
+		if allOrNothing.IsAllSubtype() {
+			return XML
+		}
+		return NEVER
+	}
+	bits := xmlSt.(*xmlSubtype).Primitives &^ XML_PRIMITIVE_NEVER
+	var itemTy = NEVER
+	if bits&(XML_PRIMITIVE_ELEMENT_RO|XML_PRIMITIVE_ELEMENT_RW) != 0 {
+		itemTy = Union(itemTy, XML_ELEMENT)
+	}
+	if bits&(XML_PRIMITIVE_COMMENT_RO|XML_PRIMITIVE_COMMENT_RW) != 0 {
+		itemTy = Union(itemTy, XML_COMMENT)
+	}
+	if bits&(XML_PRIMITIVE_PI_RO|XML_PRIMITIVE_PI_RW) != 0 {
+		itemTy = Union(itemTy, XML_PI)
+	}
+	if bits&XML_PRIMITIVE_TEXT != 0 {
+		itemTy = Union(itemTy, XML_TEXT)
+	}
+	return itemTy
+}
+
 func makeXmlSequence(d *xmlSubtype) SubtypeData {
 	primitives := (XML_PRIMITIVE_NEVER | d.Primitives)
 	atom := (d.Primitives & XML_PRIMITIVE_SINGLETON)

--- a/values/xml.go
+++ b/values/xml.go
@@ -28,6 +28,7 @@ type (
 		Type() semtypes.SemType
 		Readonly() bool
 		XMLString() string
+		IterItems() []XMLValue
 	}
 
 	XMLElement struct {
@@ -78,6 +79,8 @@ var (
 func (e *XMLElement) Type() semtypes.SemType { return e.semType }
 
 func (e *XMLElement) Readonly() bool { return e.isReadonly }
+
+func (e *XMLElement) IterItems() []XMLValue { return []XMLValue{e} }
 
 func (e *XMLElement) XMLString() string {
 	var b strings.Builder
@@ -145,6 +148,8 @@ func (s *XMLSequence) Type() semtypes.SemType { return s.semType }
 
 func (s *XMLSequence) Readonly() bool { return s.isReadonly }
 
+func (s *XMLSequence) IterItems() []XMLValue { return s.Children }
+
 func (s *XMLSequence) XMLString() string {
 	var b strings.Builder
 	for _, child := range s.Children {
@@ -157,6 +162,8 @@ func (p *XMLProcessingInstruction) Type() semtypes.SemType { return p.semType }
 
 func (p *XMLProcessingInstruction) Readonly() bool { return p.isReadonly }
 
+func (p *XMLProcessingInstruction) IterItems() []XMLValue { return []XMLValue{p} }
+
 func (p *XMLProcessingInstruction) XMLString() string {
 	if strings.Contains(p.Data, "?>") {
 		panic(NewErrorWithMessage(fmt.Sprintf("xml processing instruction %q data must not contain '?>'", p.Target)))
@@ -168,6 +175,8 @@ func (t *XMLText) Type() semtypes.SemType { return t.semType }
 
 func (t *XMLText) Readonly() bool { return true }
 
+func (t *XMLText) IterItems() []XMLValue { return []XMLValue{t} }
+
 func (t *XMLText) XMLString() string {
 	return EscapeXMLContent(t.Body)
 }
@@ -175,6 +184,8 @@ func (t *XMLText) XMLString() string {
 func (c *XMLComment) Type() semtypes.SemType { return c.semType }
 
 func (c *XMLComment) Readonly() bool { return c.isReadonly }
+
+func (c *XMLComment) IterItems() []XMLValue { return []XMLValue{c} }
 
 func (c *XMLComment) XMLString() string {
 	if strings.Contains(c.Body, "--") || strings.HasSuffix(c.Body, "-") {


### PR DESCRIPTION
Closes #292.

## Summary
- Add foreach iteration support for XML values
- Include diagnostics for invalid foreach variable types
- Make common assertions debug-only to avoid release overhead

## Testing
- go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XML iterator support, enabling iterator-based traversal and `foreach` loops over XML values (via `lang.xml`).
  * Extended the `XMLValue` interface with `IterItems()` to expose XML items for iteration.
* **Bug Fixes**
  * Improved type-checking diagnostics with more specific `foreach` loop variable type error messages.
* **Tests**
  * Updated and added XML iterator integration fixtures, including new expected outputs and compile-time failure checks.
* **Chores**
  * Assertions now evaluate/panic in debug builds and become no-ops in release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->