### PR TITLE
fix(ci): shard wasm corpus tests

### DIFF
--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -10,6 +10,11 @@ jobs:
   ubuntu-build:
     name: Ubuntu WASM Build
     runs-on: ubuntu-latest
+    env:
+      GOOS: js
+      GOARCH: wasm
+      GOEXPERIMENT: greenteagc
+      GOGC: "1000"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -19,10 +24,26 @@ jobs:
         with:
           go-version: '1.26'
 
-      - name: Run WASM tests
+      - name: Run WASM tests (non-corpus)
         run: |
-          export GOOS=js
-          export GOARCH=wasm
-          export GOEXPERIMENT=greenteagc
-          export GOGC=1000
-          go test -p=1 -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -timeout 30m ./... -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+          wasm_exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+          packages=$(go list ./... | sed '/^ballerina-lang-go\/corpus$/d')
+          go test -p=1 -skip 'TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests' -timeout 30m $packages -exec="$wasm_exec"
+
+      - name: Run WASM corpus light tests
+        run: |
+          wasm_exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+          go test -p=1 -skip '^(TestParseCorpusFiles|TestJBalUnitTests|TestJBalUnitBIRTests|TestIntegration|TestBIRSerializationRoundtrip)$' -timeout 30m ./corpus -exec="$wasm_exec"
+
+      - name: Run WASM corpus integration tests (sharded)
+        run: |
+          wasm_exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+          shards=$(find corpus/bal -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+          if [ -z "$shards" ]; then
+            echo "No corpus shards found under corpus/bal" >&2
+            exit 1
+          fi
+
+          for shard in $shards; do
+            go test -p=1 -run "^(TestIntegration|TestBIRSerializationRoundtrip)$/^${shard}$" -timeout 30m ./corpus -exec="$wasm_exec"
+          done


### PR DESCRIPTION
## Summary
- run non-corpus wasm tests separately from the corpus package
- split the heavy corpus wasm integration and BIR roundtrip tests by top-level corpus/bal shard
- discover corpus shards dynamically from corpus/bal

## Validation
- ran non-corpus wasm package tests locally with Go 1.26.4
- ran corpus remainder and all discovered corpus shards locally with Go 1.26.4 wasm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Split WASM CI coverage into separate test runs for standard packages, lightweight corpus checks, and sharded corpus integration tests.
  * Improved CI reliability by setting WASM-related environment values at the job level and adding a clearer failure when no corpus shards are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->