### PR TITLE
test(corpus): skip update for CLI goldens

### DIFF
--- a/corpus/cli_integration_test.go
+++ b/corpus/cli_integration_test.go
@@ -335,13 +335,6 @@ func assertBalCommandMatchesTxtarFragmentsLoose(t *testing.T, balBin, repoRoot, 
 	stdout = test_util.NormalizeNewlines(stdout)
 	stderr = test_util.NormalizeNewlines(stderr)
 
-	if *update {
-		if test_util.UpdateTxtarArchiveIfNeeded(t, txtarPath, test_util.TxtarFilesStdoutStderrExitcode(stdout, stderr, strconv.Itoa(exitCode))) {
-			t.Fatalf("Updated expected file: %s", txtarPath)
-		}
-		return
-	}
-
 	expectedStdoutFragments, expectedStderrFragments, expectedExitCode, err := test_util.LoadTxtarStdoutStderrExitcode(txtarPath)
 	if err != nil {
 		t.Fatalf("failed to parse txtar file %s: %v", txtarPath, err)
@@ -480,13 +473,6 @@ func assertBalCommandMatchesTxtarFragmentsForBinary(t *testing.T, balBin, repoRo
 	stderr = test_util.NormalizeNewlines(stderr)
 	expectedPath := filepath.Join(append([]string{repoRoot, "corpus", "cli", "output"}, txtarPathParts...)...)
 
-	if *update {
-		if test_util.UpdateTxtarArchiveIfNeeded(t, expectedPath, test_util.TxtarFilesStdoutStderrExitcode(stdout, stderr, strconv.Itoa(exitCode))) {
-			t.Fatalf("Updated expected file: %s", expectedPath)
-		}
-		return
-	}
-
 	expectedStdoutFragments, expectedStderr, expectedExitCode, err := test_util.LoadTxtarStdoutStderrExitcode(expectedPath)
 	if err != nil {
 		t.Fatalf("failed to parse txtar file %s: %v", expectedPath, err)
@@ -572,13 +558,6 @@ func runBalRunCorpusCase(t *testing.T, balBin, repoRoot, coverDir, outputsRoot, 
 		actualOutput := test_util.NormalizeNewlines(stdout)
 		actualError := test_util.NormalizeNewlines(stderr)
 		actualExitCode := strconv.Itoa(exitCode)
-
-		if *update {
-			if test_util.UpdateTxtarArchiveIfNeeded(t, expectedPath, test_util.TxtarFilesStdoutStderrExitcode(actualOutput, actualError, actualExitCode)) {
-				t.Fatalf("Updated expected file: %s", expectedPath)
-			}
-			return
-		}
 
 		expectedOutput, expectedError, expectedExitCode, err := test_util.LoadTxtarStdoutStderrExitcode(expectedPath)
 		if err != nil {


### PR DESCRIPTION
## Summary
- prevent CLI corpus tests from rewriting golden files when --update is passed
- keep fragment-based CLI golden checks unchanged in normal test runs

## Tests
- go test ./corpus --update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tightened command output checks so expected results are no longer rewritten automatically during test runs.
  * Fixture mismatches will now fail clearly, helping catch regressions in command output earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->