### PR TITLE
Fix module init check expressions

### DIFF
--- a/corpus/ast/subset8/08-error/check13-v.txt
+++ b/corpus/ast/subset8/08-error/check13-v.txt
@@ -1,0 +1,22 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function mayFail () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (return
+        (literal 1))))
+  (variable moduleValue (type
+    (value-type int)) (expr
+    (checked-expr
+      (invocation mayFail ()))))
+  (function main () (
+    (union-type
+      (error-type)
+      (value-type null)))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref moduleValue)))))))

--- a/corpus/ast/subset8/08-error/check14-p.txt
+++ b/corpus/ast/subset8/08-error/check14-p.txt
@@ -1,0 +1,20 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (function mayFail () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (return
+        (error-constructor-expr (
+          (literal module init failed))))))
+  (variable moduleValue (type
+    (value-type int)) (expr
+    (checked-expr
+      (invocation mayFail ()))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (assignment
+        (wildcard-binding-pattern)
+        (simple-var-ref moduleValue)))))

--- a/corpus/bal/subset8/08-error/check13-v.bal
+++ b/corpus/bal/subset8/08-error/check13-v.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ballerina/io;
+
+function mayFail() returns int|error {
+    return 1;
+}
+
+final int moduleValue = check mayFail();
+
+public function main() returns error? {
+    io:println(moduleValue); // @output 1
+}

--- a/corpus/bal/subset8/08-error/check14-p.bal
+++ b/corpus/bal/subset8/08-error/check14-p.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function mayFail() returns int|error {
+    return error("module init failed");
+}
+
+final int moduleValue = check mayFail(); // @panic module init failed
+
+public function main() {
+    _ = moduleValue;
+}

--- a/corpus/bir/subset8/08-error/check13-v.txt
+++ b/corpus/bir/subset8/08-error/check13-v.txt
@@ -1,0 +1,17 @@
+module $anon.. v 0.0.0;
+moduleValue  int;
+mayFail() -> int|error{
+  bb0 {
+    %1 = ConstantLoad 1
+    %0 = %1;
+    return;
+  }
+}
+main() -> nil|error{
+  bb0 {
+    %1 = println(moduleValue) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-error/check14-p.txt
+++ b/corpus/bir/subset8/08-error/check14-p.txt
@@ -1,0 +1,16 @@
+module $anon.. v 0.0.0;
+moduleValue  int;
+mayFail() -> int|error{
+  bb0 {
+    %1 = ConstantLoad module init failed
+    %2 = newError error(%1)
+    %0 = %2;
+    return;
+  }
+}
+main() -> nil{
+  bb0 {
+    %1 = moduleValue;
+    return;
+  }
+}

--- a/corpus/cfg/subset8/08-error/check13-v.txt
+++ b/corpus/cfg/subset8/08-error/check13-v.txt
@@ -1,0 +1,13 @@
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref moduleValue))))
+  )
+)
+(mayFail
+  (bb0 () ()
+    (return
+      (literal 1))
+  )
+)

--- a/corpus/cfg/subset8/08-error/check14-p.txt
+++ b/corpus/cfg/subset8/08-error/check14-p.txt
@@ -1,0 +1,14 @@
+(main
+  (bb0 () ()
+    (assignment
+      (wildcard-binding-pattern)
+      (simple-var-ref moduleValue))
+  )
+)
+(mayFail
+  (bb0 () ()
+    (return
+      (error-constructor-expr (
+        (literal module init failed))))
+  )
+)

--- a/corpus/desugared/subset8/08-error/check13-v.txt
+++ b/corpus/desugared/subset8/08-error/check13-v.txt
@@ -1,0 +1,33 @@
+(package
+  (import-package ballerina io (as io))
+  (variable moduleValue (type
+    (value-type int)))
+  (function init () ()
+    (block-function-body
+      (var-def
+        (variable $desugar$0 (expr
+          (invocation mayFail ()))))
+      (if
+        (type-test-expr is
+          (simple-var-ref $desugar$0))
+        (block-stmt
+          (return
+            (simple-var-ref $desugar$0))) ())
+      (assignment
+        (simple-var-ref moduleValue)
+        (simple-var-ref $desugar$0))))
+  (function mayFail () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (return
+        (literal 1))))
+  (function main () (
+    (union-type
+      (error-type)
+      (value-type null)))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref moduleValue)))))))

--- a/corpus/desugared/subset8/08-error/check14-p.txt
+++ b/corpus/desugared/subset8/08-error/check14-p.txt
@@ -1,0 +1,31 @@
+(package
+  (variable moduleValue (type
+    (value-type int)))
+  (function init () ()
+    (block-function-body
+      (var-def
+        (variable $desugar$0 (expr
+          (invocation mayFail ()))))
+      (if
+        (type-test-expr is
+          (simple-var-ref $desugar$0))
+        (block-stmt
+          (return
+            (simple-var-ref $desugar$0))) ())
+      (assignment
+        (simple-var-ref moduleValue)
+        (simple-var-ref $desugar$0))))
+  (function mayFail () (
+    (union-type
+      (value-type int)
+      (error-type)))
+    (block-function-body
+      (return
+        (error-constructor-expr (
+          (literal module init failed))))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (assignment
+        (wildcard-binding-pattern)
+        (simple-var-ref moduleValue)))))

--- a/corpus/integration/subset8/08-error/check13-v.txtar
+++ b/corpus/integration/subset8/08-error/check13-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+1
+-- stderr --

--- a/corpus/integration/subset8/08-error/check14-p.txtar
+++ b/corpus/integration/subset8/08-error/check14-p.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+-- stderr --
+error: module init failed

--- a/desugar/desugar.go
+++ b/desugar/desugar.go
@@ -517,9 +517,7 @@ func desugarInitFn(pkgCtx *packageContext, compilerCtx *context.CompilerContext,
 	// service init or listener registration can actually fail.
 	hasListeners := len(pkg.Services) > 0 || hasModuleListenerVar(compilerCtx, nodes)
 
-	if hasListeners {
-		widenInitReturnTypeToErrorOptional(compilerCtx, pkg.InitFunction)
-	}
+	widenInitReturnTypeToErrorOptional(compilerCtx, pkg.InitFunction)
 
 	var initStmts []ast.StatementNode
 	var moduleListenersRef *ast.BLangSimpleVarRef

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -1013,15 +1013,13 @@ func analyzeCheckedExpr[A analyzer](a A, expr *ast.BLangCheckedExpr, expectedTyp
 		return false
 	}
 	retTy := expectedReturnType(a)
-	if semtypes.IsZero(retTy) {
-		a.ctx().SemanticError("check expression not allowed outside a function", expr.GetPosition())
-		return false
-	}
-	exprTy := expr.Expr.GetDeterminedType()
-	errorPart := semtypes.Intersect(exprTy, semtypes.ERROR)
-	if !semtypes.IsEmpty(a.tyCtx(), errorPart) {
-		if !semtypes.IsSubtype(a.tyCtx(), errorPart, retTy) {
-			a.ctx().SemanticError("error type of check expression is not a subtype of the enclosing function's return type", expr.GetPosition())
+	if !semtypes.IsZero(retTy) {
+		exprTy := expr.Expr.GetDeterminedType()
+		errorPart := semtypes.Intersect(exprTy, semtypes.ERROR)
+		if !semtypes.IsEmpty(a.tyCtx(), errorPart) {
+			if !semtypes.IsSubtype(a.tyCtx(), errorPart, retTy) {
+				a.ctx().SemanticError("error type of check expression is not a subtype of the enclosing function's return type", expr.GetPosition())
+			}
 		}
 	}
 	return validateResolvedType(a, expr, expectedType)


### PR DESCRIPTION
## Summary
- allow `check` expressions in module-level initializers
- always model desugared module `init` as fallible when generated/used
- add valid and runtime-error corpus coverage for module init `check`

Closes #600



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Module initialization now supports checked expressions that can propagate failures as runtime errors or panics.
  * Programs can print values computed during initialization when no error occurs.

* **Bug Fixes**
  * Improved handling of `check` expressions outside function return contexts, avoiding incorrect errors in module-level initialization.
  * Module initialization return behavior now applies consistently, even without services or listeners.

* **Tests**
  * Added coverage for successful module initialization output.
  * Added coverage for module initialization failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->