### PR TITLE
Remove CODECOV_TOKEN from native CI uploads

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.coverage.outputs.files }}
           flags: native
           fail_ci_if_error: true


### PR DESCRIPTION
## Purpose
The repository is public and Codecov no longer requires a token for uploads from GitHub Actions