### PR TITLE
fix(service): handle distinct service types

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -153,10 +153,14 @@ type (
 
 	BLangService struct {
 		classDefnBase
-		AttachedExprs []BLangExpression
-		// attach point either AbsoluteResourcePath or AttachPointLiteral
+		AttachedExprs         []BLangExpression
+		AttachedExprsPosition diagnostics.Location
+		// A nil AbsoluteResourcePath means there is no attach point; an empty,
+		// non-nil path represents the root attach point `/`.
 		AbsoluteResourcePath []BLangIdentifier
 		AttachPointLiteral   *BLangLiteral
+		AttachPointType      semtypes.SemType
+		ObjectBodyType       semtypes.SemType
 	}
 
 	BLangCompilationUnit struct {

--- a/ast/node_builder.go
+++ b/ast/node_builder.go
@@ -1835,6 +1835,9 @@ func (n *NodeBuilder) populateServiceAttachPoint(service *BLangService, node *tr
 	if node.HasDiagnostics() {
 		return
 	}
+	if paths.Size() > 0 {
+		service.AbsoluteResourcePath = []BLangIdentifier{}
+	}
 	for i := 0; i < paths.Size(); i++ {
 		seg := paths.Get(i)
 		if seg.Kind() == common.STRING_LITERAL {
@@ -1860,6 +1863,9 @@ func (n *NodeBuilder) populateServiceAttachPoint(service *BLangService, node *tr
 
 func (n *NodeBuilder) populateServiceAttachedExprs(service *BLangService, node *tree.ServiceDeclarationNode) {
 	exprs := node.Expressions()
+	if exprs.Size() > 0 {
+		service.AttachedExprsPosition = n.getPositionRange(exprs.Get(0), exprs.Get(exprs.Size()-1))
+	}
 	for i := 0; i < exprs.Size(); i += 2 {
 		service.AttachedExprs = append(service.AttachedExprs, n.createExpression(exprs.Get(i)))
 	}

--- a/ast/pretty_printer.go
+++ b/ast/pretty_printer.go
@@ -2140,12 +2140,16 @@ func (p *PrettyPrinter) printService(node *BLangService) {
 		p.indentLevel++
 		p.PrintInner(node.AttachPointLiteral)
 		p.indentLevel--
-	} else if len(node.AbsoluteResourcePath) > 0 {
+	} else if node.AbsoluteResourcePath != nil {
 		p.indentLevel++
 		p.StartNode()
 		p.PrintString("absolute-resource-path")
-		for i := range node.AbsoluteResourcePath {
-			p.PrintString(node.AbsoluteResourcePath[i].Value)
+		if len(node.AbsoluteResourcePath) == 0 {
+			p.PrintString("/")
+		} else {
+			for i := range node.AbsoluteResourcePath {
+				p.PrintString(node.AbsoluteResourcePath[i].Value)
+			}
 		}
 		p.EndNode()
 		p.indentLevel--

--- a/corpus/ast/subset9/09-bug/listener-union-attach-point1-v.txt
+++ b/corpus/ast/subset9/09-bug/listener-union-attach-point1-v.txt
@@ -1,0 +1,66 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (type-definition S
+    (object-type service))
+  (class-definition L
+    (function attach (
+      (variable svc (type
+        (user-defined-type S)))
+      (variable attachPoint (type
+        (union-type
+          (tuple-type
+            (value-type string))
+          (tuple-type
+            (value-type string)
+            (value-type string)))))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (assignment
+          (wildcard-binding-pattern)
+          (simple-var-ref svc))
+        (assignment
+          (wildcard-binding-pattern)
+          (simple-var-ref attachPoint))))
+    (function detach (
+      (variable svc (type
+        (user-defined-type S)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (assignment
+          (wildcard-binding-pattern)
+          (simple-var-ref svc))))
+    (function gracefulStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function immediateStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function start () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body)))
+  (variable l (type
+    (user-defined-type L)) (expr
+    (new ())))
+  (service
+    (user-defined-type S)
+    (absolute-resource-path foo)
+    (on
+    (simple-var-ref l)))
+  (service
+    (user-defined-type S)
+    (absolute-resource-path foo bar)
+    (on
+    (simple-var-ref l)))
+  (function main () (
+    (value-type null))
+    (block-function-body)))

--- a/corpus/ast/subset9/09-object/service-distinct-type1-v.txt
+++ b/corpus/ast/subset9/09-object/service-distinct-type1-v.txt
@@ -1,0 +1,165 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition ServiceType
+    (object-type service
+      (method-decl value public () (
+        (value-type int)))))
+  (class-definition Listener
+    (function attach (
+      (variable svc (type
+        (user-defined-type ServiceType)))
+      (variable attachPoint (type
+        (array-type
+          (value-type string) dimensions: 1 ([]))))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable broad (type
+            (object-type service)) (expr
+            (simple-var-ref svc))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref broad)
+              (user-defined-type ServiceType)))))
+        (expression-stmt
+          (invocation io println (
+            (invocation value expr:
+              (simple-var-ref svc) ()))))
+        (expression-stmt
+          (invocation io println (
+            (invocation length expr:
+              (simple-var-ref attachPoint) ()))))))
+    (function detach (
+      (variable svc (type
+        (user-defined-type ServiceType)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable _ (expr
+            (simple-var-ref svc))))))
+    (function gracefulStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function immediateStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function start () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body)))
+  (variable l (type
+    (user-defined-type Listener)) (expr
+    (new ())))
+  (service
+    (absolute-resource-path /)
+    (on
+    (simple-var-ref l))
+    (variable base (type
+      (value-type int)) (expr
+      (literal 40)))
+    (function increment () (
+      (value-type int))
+      (block-function-body
+        (return
+          (binary-expr +
+            (field-based-access base
+              (simple-var-ref self))
+            (literal 1)))))
+    (function value () (
+      (value-type int))
+      (block-function-body
+        (return
+          (invocation increment expr:
+            (simple-var-ref self) ())))))
+  (class-definition ExplicitListener
+    (function attach (
+      (variable svc (type
+        (user-defined-type ServiceType)))
+      (variable attachPoint (type
+        (array-type
+          (value-type string) dimensions: 1 ([]))))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable broad (type
+            (object-type service)) (expr
+            (simple-var-ref svc))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref broad)
+              (user-defined-type ServiceType)))))
+        (expression-stmt
+          (invocation io println (
+            (invocation value expr:
+              (simple-var-ref svc) ()))))
+        (expression-stmt
+          (invocation io println (
+            (invocation length expr:
+              (simple-var-ref attachPoint) ()))))))
+    (function detach (
+      (variable svc (type
+        (user-defined-type ServiceType)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable _ (expr
+            (simple-var-ref svc))))))
+    (function gracefulStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function immediateStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function start () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body)))
+  (variable explicitListener (type
+    (user-defined-type ExplicitListener)) (expr
+    (new ())))
+  (service
+    (user-defined-type ServiceType)
+    (absolute-resource-path /)
+    (on
+    (simple-var-ref explicitListener))
+    (variable base (type
+      (value-type int)) (expr
+      (literal 41)))
+    (function increment () (
+      (value-type int))
+      (block-function-body
+        (return
+          (binary-expr +
+            (field-based-access base
+              (simple-var-ref self))
+            (literal 1)))))
+    (function value () (
+      (value-type int))
+      (block-function-body
+        (return
+          (invocation increment expr:
+            (simple-var-ref self) ())))))
+  (function main () (
+    (value-type null))
+    (block-function-body)))

--- a/corpus/ast/subset9/09-object/service-isolated-resource-remote-1-v.txt
+++ b/corpus/ast/subset9/09-object/service-isolated-resource-remote-1-v.txt
@@ -46,6 +46,7 @@
         (value-type null)))
       (block-function-body)))
   (service isolated
+    (absolute-resource-path /)
     (on
     (new
       (user-defined-type SimpleListener) ()))

--- a/corpus/ast/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/ast/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -1,0 +1,103 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (type-definition FirstService
+    (object-type service))
+  (type-definition SecondService
+    (object-type service))
+  (class-definition FirstListener
+    (function attach (
+      (variable svc (type
+        (user-defined-type FirstService)))
+      (variable attachPoint (type
+        (value-type null)) (expr
+        (literal <nil>)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable _ (expr
+            (simple-var-ref svc))))
+        (var-def
+          (variable _ (expr
+            (simple-var-ref attachPoint))))))
+    (function detach (
+      (variable svc (type
+        (user-defined-type FirstService)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable _ (expr
+            (simple-var-ref svc))))))
+    (function gracefulStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function immediateStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function start () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body)))
+  (class-definition SecondListener
+    (function attach (
+      (variable svc (type
+        (user-defined-type SecondService)))
+      (variable attachPoint (type
+        (value-type null)) (expr
+        (literal <nil>)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable _ (expr
+            (simple-var-ref svc))))
+        (var-def
+          (variable _ (expr
+            (simple-var-ref attachPoint))))))
+    (function detach (
+      (variable svc (type
+        (user-defined-type SecondService)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable _ (expr
+            (simple-var-ref svc))))))
+    (function gracefulStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function immediateStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function start () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body)))
+  (variable first (type
+    (user-defined-type FirstListener)) (expr
+    (new ())))
+  (variable second (type
+    (user-defined-type SecondListener)) (expr
+    (new ())))
+  (service
+    (on
+    (simple-var-ref first)
+    (simple-var-ref second)))
+  (function main () (
+    (value-type null))
+    (block-function-body)))

--- a/corpus/ast/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/ast/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -1,5 +1,6 @@
 (compilation-unit  regular-source
 (package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
   (type-definition FirstService
     (object-type service))
   (type-definition SecondService
@@ -15,9 +16,16 @@
         (error-type)
         (value-type null)))
       (block-function-body
-        (var-def
-          (variable _ (expr
-            (simple-var-ref svc))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref svc)
+              (user-defined-type FirstService)))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref svc)
+              (user-defined-type SecondService)))))
         (var-def
           (variable _ (expr
             (simple-var-ref attachPoint))))))
@@ -57,9 +65,16 @@
         (error-type)
         (value-type null)))
       (block-function-body
-        (var-def
-          (variable _ (expr
-            (simple-var-ref svc))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref svc)
+              (user-defined-type FirstService)))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref svc)
+              (user-defined-type SecondService)))))
         (var-def
           (variable _ (expr
             (simple-var-ref attachPoint))))))

--- a/corpus/bal/subset9/09-bug/listener-union-attach-point1-e.bal
+++ b/corpus/bal/subset9/09-bug/listener-union-attach-point1-e.bal
@@ -1,0 +1,59 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type S service object {};
+
+class AmbiguousListener {
+    public function attach(S svc, [string] | string[] attachPoint) returns error? {
+        _ = svc;
+        _ = attachPoint;
+    }
+
+    public function detach(S svc) returns error? {
+        _ = svc;
+    }
+
+    public function 'start() returns error? {}
+
+    public function gracefulStop() returns error? {}
+
+    public function immediateStop() returns error? {}
+}
+
+class UnsupportedListener {
+    public function attach(S svc, [string] | [string, string] attachPoint) returns error? {
+        _ = svc;
+        _ = attachPoint;
+    }
+
+    public function detach(S svc) returns error? {
+        _ = svc;
+    }
+
+    public function 'start() returns error? {}
+
+    public function gracefulStop() returns error? {}
+
+    public function immediateStop() returns error? {}
+}
+
+listener AmbiguousListener ambiguousListener = new;
+listener UnsupportedListener unsupportedListener = new;
+
+service S /foo on ambiguousListener { // @error multiple applicable attach-point list types
+}
+
+service S /foo/bar/baz on unsupportedListener { // @error unsupported attach point
+}

--- a/corpus/bal/subset9/09-bug/listener-union-attach-point1-v.bal
+++ b/corpus/bal/subset9/09-bug/listener-union-attach-point1-v.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type S service object {};
+
+class L {
+    public function attach(S svc, [string] | [string, string] attachPoint) returns error? {
+        _ = svc;
+        _ = attachPoint;
+    }
+
+    public function detach(S svc) returns error? {
+        _ = svc;
+    }
+
+    public function 'start() returns error? {}
+
+    public function gracefulStop() returns error? {}
+
+    public function immediateStop() returns error? {}
+}
+
+listener L l = new;
+
+service S /foo on l {
+}
+
+service S /foo/bar on l {
+}
+
+public function main() {
+}

--- a/corpus/bal/subset9/09-object/service-distinct-type1-v.bal
+++ b/corpus/bal/subset9/09-object/service-distinct-type1-v.bal
@@ -1,0 +1,95 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public type ServiceType distinct service object {
+    public function value() returns int;
+};
+
+class Listener {
+    public function attach(ServiceType svc, string[] attachPoint) returns error? {
+        service object {} broad = svc;
+        io:println(broad is ServiceType); // @output true
+        io:println(svc.value()); // @output 41
+        io:println(attachPoint.length()); // @output 0
+    }
+
+    public function detach(ServiceType svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+    }
+
+    public function immediateStop() returns error? {
+    }
+}
+
+listener Listener l = new;
+
+service / on l {
+    private int base = 40;
+
+    private function increment() returns int {
+        return self.base + 1;
+    }
+
+    public function value() returns int {
+        return self.increment();
+    }
+}
+
+class ExplicitListener {
+    public function attach(ServiceType svc, string[] attachPoint) returns error? {
+        service object {} broad = svc;
+        io:println(broad is ServiceType); // @output true
+        io:println(svc.value()); // @output 42
+        io:println(attachPoint.length()); // @output 0
+    }
+
+    public function detach(ServiceType svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+    }
+
+    public function immediateStop() returns error? {
+    }
+}
+
+listener ExplicitListener explicitListener = new;
+
+service ServiceType / on explicitListener {
+    private int base = 41;
+
+    private function increment() returns int {
+        return self.base + 1;
+    }
+
+    public function value() returns int {
+        return self.increment();
+    }
+}
+
+public function main() {
+}

--- a/corpus/bal/subset9/09-object/service-explicit-bad-listener1-e.bal
+++ b/corpus/bal/subset9/09-object/service-explicit-bad-listener1-e.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type S service object {};
+
+int notAListener = 1;
+error listenerError = error("listener error");
+
+service S on notAListener { // @error non-listener expression
+}
+
+service S on listenerError { // @error error-only expression
+}
+
+public function main() {
+}

--- a/corpus/bal/subset9/09-object/service-listener-type-mismatch1-e.bal
+++ b/corpus/bal/subset9/09-object/service-listener-type-mismatch1-e.bal
@@ -1,0 +1,59 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type FirstService distinct service object {};
+type SecondService distinct service object {};
+
+class SecondServiceListener {
+    public function attach(SecondService svc, () attachPoint = ()) returns error? {
+        var _ = svc;
+        var _ = attachPoint;
+    }
+
+    public function detach(SecondService svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {}
+    public function gracefulStop() returns error? {}
+    public function immediateStop() returns error? {}
+}
+
+class StringAttachPointListener {
+    public function attach(FirstService svc, string attachPoint) returns error? {
+        var _ = svc;
+        var _ = attachPoint;
+    }
+
+    public function detach(FirstService svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {}
+    public function gracefulStop() returns error? {}
+    public function immediateStop() returns error? {}
+}
+
+listener SecondServiceListener secondServiceListener = new;
+listener StringAttachPointListener stringAttachPointListener = new;
+
+service FirstService on secondServiceListener { // @error service type mismatch
+}
+
+service FirstService on stringAttachPointListener { // @error attach point mismatch
+}
+
+public function main() {
+}

--- a/corpus/bal/subset9/09-object/service-non-atomic-type1-e.bal
+++ b/corpus/bal/subset9/09-object/service-non-atomic-type1-e.bal
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type FirstService distinct service object {};
+type SecondService distinct service object {};
+type ServiceUnion FirstService|SecondService;
+
+class UnionListener {
+    public function attach(ServiceUnion svc, () attachPoint = ()) returns error? {
+        var _ = svc;
+        var _ = attachPoint;
+    }
+
+    public function detach(ServiceUnion svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {}
+    public function gracefulStop() returns error? {}
+    public function immediateStop() returns error? {}
+}
+
+listener UnionListener explicitListener = new;
+listener UnionListener inferredListener = new;
+
+service ServiceUnion on explicitListener { // @error explicit service type is not atomic
+}
+
+service on inferredListener { // @error inferred service type is not atomic
+}
+
+public function main() {
+}

--- a/corpus/bal/subset9/09-object/service-on-distinct-listeners-distinct-v.bal
+++ b/corpus/bal/subset9/09-object/service-on-distinct-listeners-distinct-v.bal
@@ -1,0 +1,60 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type FirstService distinct service object {
+    // Structurally compatible with SecondService but nominally unrelated.
+};
+type SecondService distinct service object {
+    // Structurally compatible with FirstService but nominally unrelated.
+};
+
+class FirstListener {
+    public function attach(FirstService svc, () attachPoint = ()) returns error? {
+        var _ = svc;
+        var _ = attachPoint;
+    }
+
+    public function detach(FirstService svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {}
+    public function gracefulStop() returns error? {}
+    public function immediateStop() returns error? {}
+}
+
+class SecondListener {
+    public function attach(SecondService svc, () attachPoint = ()) returns error? {
+        var _ = svc;
+        var _ = attachPoint;
+    }
+
+    public function detach(SecondService svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {}
+    public function gracefulStop() returns error? {}
+    public function immediateStop() returns error? {}
+}
+
+listener FirstListener first = new;
+listener SecondListener second = new;
+
+service on first, second {
+}
+
+public function main() {
+}

--- a/corpus/bal/subset9/09-object/service-on-distinct-listeners-distinct-v.bal
+++ b/corpus/bal/subset9/09-object/service-on-distinct-listeners-distinct-v.bal
@@ -13,6 +13,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/io;
+
 type FirstService distinct service object {
     // Structurally compatible with SecondService but nominally unrelated.
 };
@@ -22,7 +24,8 @@ type SecondService distinct service object {
 
 class FirstListener {
     public function attach(FirstService svc, () attachPoint = ()) returns error? {
-        var _ = svc;
+        io:println(svc is FirstService); // @output true
+        io:println(svc is SecondService); // @output true
         var _ = attachPoint;
     }
 
@@ -37,7 +40,8 @@ class FirstListener {
 
 class SecondListener {
     public function attach(SecondService svc, () attachPoint = ()) returns error? {
-        var _ = svc;
+        io:println(svc is FirstService); // @output true
+        io:println(svc is SecondService); // @output true
         var _ = attachPoint;
     }
 

--- a/corpus/bal/subset9/09-object/service-type-resolution1-e.bal
+++ b/corpus/bal/subset9/09-object/service-type-resolution1-e.bal
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type IntValueService service object {
+    int value;
+};
+
+type StringValueService service object {
+    string value;
+};
+
+class IntValueListener {
+    public function attach(IntValueService svc, () attachPoint = ()) returns error? {
+        var _ = svc;
+        var _ = attachPoint;
+    }
+
+    public function detach(IntValueService svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {}
+    public function gracefulStop() returns error? {}
+    public function immediateStop() returns error? {}
+}
+
+class StringValueListener {
+    public function attach(StringValueService svc, () attachPoint = ()) returns error? {
+        var _ = svc;
+        var _ = attachPoint;
+    }
+
+    public function detach(StringValueService svc) returns error? {
+        var _ = svc;
+    }
+
+    public function 'start() returns error? {}
+    public function gracefulStop() returns error? {}
+    public function immediateStop() returns error? {}
+}
+
+listener IntValueListener intValueListener = new;
+listener StringValueListener stringValueListener = new;
+
+service on intValueListener, stringValueListener { // @error listener service types have an empty intersection
+}
+
+service on intValueListener {
+    int value = 0;
+
+    resource function get items/[any path]() { // @error resource path parameter is not anydata
+    }
+}
+
+service on intValueListener {
+    int value = 0;
+    never impossible; // @error service definition is empty
+}
+
+public function main() {
+}

--- a/corpus/bir/subset9/09-bug/listener-union-attach-point1-v.txt
+++ b/corpus/bir/subset9/09-bug/listener-union-attach-point1-v.txt
@@ -1,0 +1,209 @@
+module $anon.. v 0.0.0;
+$moduleListeners  [object { public function attach(never, [string...]) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }|object { public function attach(never, string) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }|object { public function attach(never, nil) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }...];
+l  object { public function attach(service object, [string, never...]|[string, string, never...]) returns nil|error; public function detach(service object) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function init() returns nil; public function start() returns nil|error };
+class L {
+
+  attach(service object,[string, never...]|[string, string, never...]) -> nil|error{
+    bb0 {
+      %4 = svc;
+      %5 = attachPoint;
+      return;
+    }
+  }
+
+  detach(service object) -> nil|error{
+    bb0 {
+      %3 = svc;
+      return;
+    }
+  }
+
+  gracefulStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  immediateStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+
+  start() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+}
+class $service$0 {
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+}
+class $service$1 {
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+}
+main() -> nil{
+  bb0 {
+    return;
+  }
+}
+$start() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = start($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}
+$gracefulStop() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = gracefulStop($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}
+$immediateStop() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = immediateStop($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}

--- a/corpus/bir/subset9/09-object/service-distinct-type1-v.txt
+++ b/corpus/bir/subset9/09-object/service-distinct-type1-v.txt
@@ -1,0 +1,341 @@
+module $anon.. v 0.0.0;
+$moduleListeners  [object { public function attach(never, [string...]) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }|object { public function attach(never, string) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }|object { public function attach(never, nil) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }...];
+explicitListener  object { public function attach(object&service object { public function value() returns int }, [string...]) returns nil|error; public function detach(object&service object { public function value() returns int }) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function init() returns nil; public function start() returns nil|error };
+l  object { public function attach(object&service object { public function value() returns int }, [string...]) returns nil|error; public function detach(object&service object { public function value() returns int }) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function init() returns nil; public function start() returns nil|error };
+class Listener {
+
+  attach(object&service object { public function value() returns int },[string...]) -> nil|error{
+    bb0 {
+      broad = svc;
+      %5 = broad is object&service object { public function value() returns int }
+      %6 = %5;
+      %7 = println(%6) -> bb1;
+    }
+    bb1 {
+      %8 = value(svc) -> bb2;
+    }
+    bb2 {
+      %9 = %8;
+      %10 = println(%9) -> bb3;
+    }
+    bb3 {
+      %11 = length(attachPoint) -> bb4;
+    }
+    bb4 {
+      %12 = %11;
+      %13 = println(%12) -> bb5;
+    }
+    bb5 {
+      return;
+    }
+  }
+
+  detach(object&service object { public function value() returns int }) -> nil|error{
+    bb0 {
+      _ = svc;
+      return;
+    }
+  }
+
+  gracefulStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  immediateStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+
+  start() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+}
+class ExplicitListener {
+
+  attach(object&service object { public function value() returns int },[string...]) -> nil|error{
+    bb0 {
+      broad = svc;
+      %5 = broad is object&service object { public function value() returns int }
+      %6 = %5;
+      %7 = println(%6) -> bb1;
+    }
+    bb1 {
+      %8 = value(svc) -> bb2;
+    }
+    bb2 {
+      %9 = %8;
+      %10 = println(%9) -> bb3;
+    }
+    bb3 {
+      %11 = length(attachPoint) -> bb4;
+    }
+    bb4 {
+      %12 = %11;
+      %13 = println(%12) -> bb5;
+    }
+    bb5 {
+      return;
+    }
+  }
+
+  detach(object&service object { public function value() returns int }) -> nil|error{
+    bb0 {
+      _ = svc;
+      return;
+    }
+  }
+
+  gracefulStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  immediateStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+
+  start() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+}
+class $service$0 {
+  base int
+
+  increment() -> int{
+    bb0 {
+      %4 = ConstantLoad base
+      %3 = self[%4];
+      %5 = %3;
+      %6 = ConstantLoad 1
+      %7 = %6;
+      %2 = + %5 %7;
+      %0 = %2;
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      %2 = ConstantLoad 40
+      %3 = ConstantLoad base
+      self[%3] = %2;
+      return;
+    }
+  }
+
+  value() -> int{
+    bb0 {
+      %2 = increment(self) -> bb1;
+    }
+    bb1 {
+      %0 = %2;
+      return;
+    }
+  }
+}
+class $service$1 {
+  base int
+
+  increment() -> int{
+    bb0 {
+      %4 = ConstantLoad base
+      %3 = self[%4];
+      %5 = %3;
+      %6 = ConstantLoad 1
+      %7 = %6;
+      %2 = + %5 %7;
+      %0 = %2;
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      %2 = ConstantLoad 41
+      %3 = ConstantLoad base
+      self[%3] = %2;
+      return;
+    }
+  }
+
+  value() -> int{
+    bb0 {
+      %2 = increment(self) -> bb1;
+    }
+    bb1 {
+      %0 = %2;
+      return;
+    }
+  }
+}
+main() -> nil{
+  bb0 {
+    return;
+  }
+}
+$start() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = start($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}
+$gracefulStop() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = gracefulStop($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}
+$immediateStop() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = immediateStop($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}

--- a/corpus/bir/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/bir/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -1,0 +1,257 @@
+module $anon.. v 0.0.0;
+$moduleListeners  [object { public function attach(never, [string...]) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }|object { public function attach(never, string) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }|object { public function attach(never, nil) returns nil|error; public function detach(never) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function start() returns nil|error }...];
+first  object { public function attach(object&service object, nil) returns nil|error; public function detach(object&service object) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function init() returns nil; public function start() returns nil|error };
+second  object { public function attach(object&service object, nil) returns nil|error; public function detach(object&service object) returns nil|error; public function gracefulStop() returns nil|error; public function immediateStop() returns nil|error; public function init() returns nil; public function start() returns nil|error };
+class FirstListener {
+
+  attach(object&service object,nil) -> nil|error{
+    bb0 {
+      _ = svc;
+      _ = attachPoint;
+      return;
+    }
+  }
+
+  detach(object&service object) -> nil|error{
+    bb0 {
+      _ = svc;
+      return;
+    }
+  }
+
+  gracefulStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  immediateStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+
+  start() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+}
+class SecondListener {
+
+  attach(object&service object,nil) -> nil|error{
+    bb0 {
+      _ = svc;
+      _ = attachPoint;
+      return;
+    }
+  }
+
+  detach(object&service object) -> nil|error{
+    bb0 {
+      _ = svc;
+      return;
+    }
+  }
+
+  gracefulStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  immediateStop() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+
+  start() -> nil|error{
+    bb0 {
+      return;
+    }
+  }
+}
+class $service$0 {
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+}
+main() -> nil{
+  bb0 {
+    return;
+  }
+}
+$default$0(object&service object) -> nil{
+  bb0 {
+    %2 = ConstantLoad <nil>
+    %0 = %2;
+    return;
+  }
+}
+$default$1(object&service object) -> nil{
+  bb0 {
+    %2 = ConstantLoad <nil>
+    %0 = %2;
+    return;
+  }
+}
+$start() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = start($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}
+$gracefulStop() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = gracefulStop($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}
+$immediateStop() -> nil|error{
+  bb0 {
+    $desugar$0 = $moduleListeners;
+    %2 = ConstantLoad 0
+    $desugar$1 = %2;
+    %4 = length($desugar$0) -> bb1;
+  }
+  bb1 {
+    $desugar$2 = %4;
+    GOTO bb2;
+  }
+  bb2 {
+    %7 = $desugar$1;
+    %8 = $desugar$2;
+    %6 = < %7 %8;
+    %6 ? bb3 : bb4;
+  }
+  bb3 {
+    PushScopeFrame 9
+    %0 = (1, $desugar$0)[(1, $desugar$1)];
+    $listener = %0;
+    %2 = immediateStop($listener) -> bb5;
+  }
+  bb4 {
+    return;
+  }
+  bb5 {
+    $desugar$3 = %2;
+    %4 = $desugar$3 is error
+    %4 ? bb6 : bb7;
+  }
+  bb6 {
+    PushScopeFrame 0
+    (2, %0) = (1, $desugar$3);
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb7 {
+    %6 = (1, $desugar$1);
+    %7 = ConstantLoad 1
+    %8 = %7;
+    %5 = + %6 %8;
+    (1, $desugar$1) = %5;
+    PopScopeFrame
+    GOTO bb2;
+  }
+}

--- a/corpus/bir/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/bir/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -6,7 +6,16 @@ class FirstListener {
 
   attach(object&service object,nil) -> nil|error{
     bb0 {
-      _ = svc;
+      %4 = svc is object&service object
+      %5 = %4;
+      %6 = println(%5) -> bb1;
+    }
+    bb1 {
+      %7 = svc is object&service object
+      %8 = %7;
+      %9 = println(%8) -> bb2;
+    }
+    bb2 {
       _ = attachPoint;
       return;
     }
@@ -47,7 +56,16 @@ class SecondListener {
 
   attach(object&service object,nil) -> nil|error{
     bb0 {
-      _ = svc;
+      %4 = svc is object&service object
+      %5 = %4;
+      %6 = println(%5) -> bb1;
+    }
+    bb1 {
+      %7 = svc is object&service object
+      %8 = %7;
+      %9 = println(%8) -> bb2;
+    }
+    bb2 {
       _ = attachPoint;
       return;
     }

--- a/corpus/cfg/subset9/09-bug/listener-union-attach-point1-v.txt
+++ b/corpus/cfg/subset9/09-bug/listener-union-attach-point1-v.txt
@@ -1,0 +1,31 @@
+(L
+  (attach
+    (bb0 () ()
+      (assignment
+        (wildcard-binding-pattern)
+        (simple-var-ref svc))
+      (assignment
+        (wildcard-binding-pattern)
+        (simple-var-ref attachPoint))
+    )
+  )
+  (detach
+    (bb0 () ()
+      (assignment
+        (wildcard-binding-pattern)
+        (simple-var-ref svc))
+    )
+  )
+  (gracefulStop
+    (bb0 () ())
+  )
+  (immediateStop
+    (bb0 () ())
+  )
+  (start
+    (bb0 () ())
+  )
+)
+(main
+  (bb0 () ())
+)

--- a/corpus/cfg/subset9/09-object/service-distinct-type1-v.txt
+++ b/corpus/cfg/subset9/09-object/service-distinct-type1-v.txt
@@ -1,0 +1,113 @@
+(ExplicitListener
+  (attach
+    (bb0 () ()
+      (var-def
+        (variable broad (type
+          (object-type service)) (expr
+          (simple-var-ref svc))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref broad)
+            (user-defined-type ServiceType)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation value expr:
+            (simple-var-ref svc) ()))))
+      (expression-stmt
+        (invocation io println (
+          (invocation lang.array length (
+            (simple-var-ref attachPoint))))))
+    )
+  )
+  (detach
+    (bb0 () ()
+      (var-def
+        (variable _ (expr
+          (simple-var-ref svc))))
+    )
+  )
+  (gracefulStop
+    (bb0 () ())
+  )
+  (immediateStop
+    (bb0 () ())
+  )
+  (start
+    (bb0 () ())
+  )
+)
+(Listener
+  (attach
+    (bb0 () ()
+      (var-def
+        (variable broad (type
+          (object-type service)) (expr
+          (simple-var-ref svc))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref broad)
+            (user-defined-type ServiceType)))))
+      (expression-stmt
+        (invocation io println (
+          (invocation value expr:
+            (simple-var-ref svc) ()))))
+      (expression-stmt
+        (invocation io println (
+          (invocation lang.array length (
+            (simple-var-ref attachPoint))))))
+    )
+  )
+  (detach
+    (bb0 () ()
+      (var-def
+        (variable _ (expr
+          (simple-var-ref svc))))
+    )
+  )
+  (gracefulStop
+    (bb0 () ())
+  )
+  (immediateStop
+    (bb0 () ())
+  )
+  (start
+    (bb0 () ())
+  )
+)
+(increment
+  (bb0 () ()
+    (return
+      (binary-expr +
+        (field-based-access base
+          (simple-var-ref self))
+        (literal 1)))
+  )
+)
+(increment
+  (bb0 () ()
+    (return
+      (binary-expr +
+        (field-based-access base
+          (simple-var-ref self))
+        (literal 1)))
+  )
+)
+(main
+  (bb0 () ())
+)
+(value
+  (bb0 () ()
+    (return
+      (invocation increment expr:
+        (simple-var-ref self) ()))
+  )
+)
+(value
+  (bb0 () ()
+    (return
+      (invocation increment expr:
+        (simple-var-ref self) ()))
+  )
+)

--- a/corpus/cfg/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/cfg/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -1,0 +1,59 @@
+(FirstListener
+  (attach
+    (bb0 () ()
+      (var-def
+        (variable _ (expr
+          (simple-var-ref svc))))
+      (var-def
+        (variable _ (expr
+          (simple-var-ref attachPoint))))
+    )
+  )
+  (detach
+    (bb0 () ()
+      (var-def
+        (variable _ (expr
+          (simple-var-ref svc))))
+    )
+  )
+  (gracefulStop
+    (bb0 () ())
+  )
+  (immediateStop
+    (bb0 () ())
+  )
+  (start
+    (bb0 () ())
+  )
+)
+(SecondListener
+  (attach
+    (bb0 () ()
+      (var-def
+        (variable _ (expr
+          (simple-var-ref svc))))
+      (var-def
+        (variable _ (expr
+          (simple-var-ref attachPoint))))
+    )
+  )
+  (detach
+    (bb0 () ()
+      (var-def
+        (variable _ (expr
+          (simple-var-ref svc))))
+    )
+  )
+  (gracefulStop
+    (bb0 () ())
+  )
+  (immediateStop
+    (bb0 () ())
+  )
+  (start
+    (bb0 () ())
+  )
+)
+(main
+  (bb0 () ())
+)

--- a/corpus/cfg/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/cfg/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -1,9 +1,16 @@
 (FirstListener
   (attach
     (bb0 () ()
-      (var-def
-        (variable _ (expr
-          (simple-var-ref svc))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref svc)
+            (user-defined-type FirstService)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref svc)
+            (user-defined-type SecondService)))))
       (var-def
         (variable _ (expr
           (simple-var-ref attachPoint))))
@@ -29,9 +36,16 @@
 (SecondListener
   (attach
     (bb0 () ()
-      (var-def
-        (variable _ (expr
-          (simple-var-ref svc))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref svc)
+            (user-defined-type FirstService)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref svc)
+            (user-defined-type SecondService)))))
       (var-def
         (variable _ (expr
           (simple-var-ref attachPoint))))

--- a/corpus/desugared/subset9/09-bug/listener-union-attach-point1-v.txt
+++ b/corpus/desugared/subset9/09-bug/listener-union-attach-point1-v.txt
@@ -1,39 +1,43 @@
 (package
   (import-package ballerina lang array (as lang.array))
-  (variable $desugar$0)
+  (variable l (type
+    (user-defined-type L)))
   (variable $moduleListeners)
-  (class-definition SimpleListener
+  (type-definition S
+    (object-type service))
+  (class-definition L
     (function init () ()
       (block-function-body))
     (function attach (
       (variable svc (type
-        (object-type service)))
+        (user-defined-type S)))
       (variable attachPoint (type
         (union-type
-          (array-type
-            (value-type string) dimensions: 1 ([]))
-          (union-type
+          (tuple-type
+            (value-type string))
+          (tuple-type
             (value-type string)
-            (value-type null)))) (expr
-        (literal <nil>)))) (
-      (value-type null))
-      (block-function-body
-        (var-def
-          (variable _ (expr
-            (simple-var-ref svc))))
-        (var-def
-          (variable _ (expr
-            (simple-var-ref attachPoint))))))
-    (function detach (
-      (variable svc (type
-        (object-type service)))) (
+            (value-type string)))))) (
       (union-type
         (error-type)
         (value-type null)))
       (block-function-body
-        (var-def
-          (variable _ (expr
-            (simple-var-ref svc))))))
+        (assignment
+          (wildcard-binding-pattern)
+          (simple-var-ref svc))
+        (assignment
+          (wildcard-binding-pattern)
+          (simple-var-ref attachPoint))))
+    (function detach (
+      (variable svc (type
+        (user-defined-type S)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (assignment
+          (wildcard-binding-pattern)
+          (simple-var-ref svc))))
     (function gracefulStop () (
       (union-type
         (error-type)
@@ -49,73 +53,72 @@
         (error-type)
         (value-type null)))
       (block-function-body)))
-  (service isolated
-    (absolute-resource-path /)
+  (service
+    (user-defined-type S)
+    (absolute-resource-path foo)
     (on
-    (simple-var-ref $desugar$0))
-    (variable foo (type
-      (value-type string)))
+    (simple-var-ref l))
     (function init () ()
-      (block-function-body
-        (assignment
-          (index-based-access
-            (simple-var-ref self)
-            (literal foo))
-          (literal foo))))
-    (function $remote$greet () (
-      (value-type string))
-      (block-function-body
-        (lock
-          (block-stmt
-            (return
-              (index-based-access
-                (simple-var-ref self)
-                (literal foo)))))))
-    (resource-function get name:hello
-      (variable name (type
-        (value-type string)))
-      (value-type string)
-      (block-function-body
-        (var-def
-          (variable _ (expr
-            (simple-var-ref name))))
-        (lock
-          (block-stmt
-            (return
-              (binary-expr +
-                (literal Hello, )
-                (index-based-access
-                  (simple-var-ref self)
-                  (literal foo)))))))))
+      (block-function-body)))
+  (service
+    (user-defined-type S)
+    (absolute-resource-path foo bar)
+    (on
+    (simple-var-ref l))
+    (function init () ()
+      (block-function-body)))
   (function init () ()
     (block-function-body
       (assignment
         (simple-var-ref $moduleListeners)
         (list-constructor-expr))
       (assignment
-        (simple-var-ref $desugar$0)
-        (new
-          (user-defined-type SimpleListener) ()))
+        (simple-var-ref l)
+        (new ()))
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
-          (simple-var-ref $desugar$0))))
+          (simple-var-ref l))))
+      (var-def
+        (variable $desugar$0 (expr
+          (service-init))))
+      (var-def
+        (variable $desugar$0 (expr
+          (invocation attach expr:
+            (simple-var-ref l) (
+            (simple-var-ref $desugar$0)
+            (list-constructor-expr
+              (literal foo)))))))
+      (if
+        (type-test-expr is
+          (simple-var-ref $desugar$0))
+        (block-stmt
+          (return
+            (simple-var-ref $desugar$0))) ())
+      (expression-stmt
+        (simple-var-ref $desugar$0))
       (var-def
         (variable $desugar$1 (expr
           (service-init))))
+      (var-def
+        (variable $desugar$1 (expr
+          (invocation attach expr:
+            (simple-var-ref l) (
+            (simple-var-ref $desugar$1)
+            (list-constructor-expr
+              (literal foo)
+              (literal bar)))))))
+      (if
+        (type-test-expr is
+          (simple-var-ref $desugar$1))
+        (block-stmt
+          (return
+            (simple-var-ref $desugar$1))) ())
       (expression-stmt
-        (invocation attach expr:
-          (simple-var-ref $desugar$0) (
-          (simple-var-ref $desugar$1)
-          (list-constructor-expr))))))
+        (simple-var-ref $desugar$1))))
   (function main () (
     (value-type null))
     (block-function-body))
-  (function $default$0 (
-    (variable svc)) ()
-    (block-function-body
-      (return
-        (literal <nil>))))
   (function $start () ()
     (block-function-body
       (var-def

--- a/corpus/desugared/subset9/09-object/service-distinct-type1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-distinct-type1-v.txt
@@ -1,32 +1,49 @@
 (package
+  (import-package ballerina io (as io))
   (import-package ballerina lang array (as lang.array))
-  (variable $desugar$0)
+  (import-package ballerina lang array (as lang.array))
+  (variable l (type
+    (user-defined-type Listener)))
+  (variable explicitListener (type
+    (user-defined-type ExplicitListener)))
   (variable $moduleListeners)
-  (class-definition SimpleListener
+  (type-definition ServiceType
+    (object-type service
+      (method-decl value public () (
+        (value-type int)))))
+  (class-definition Listener
     (function init () ()
       (block-function-body))
     (function attach (
       (variable svc (type
-        (object-type service)))
+        (user-defined-type ServiceType)))
       (variable attachPoint (type
-        (union-type
-          (array-type
-            (value-type string) dimensions: 1 ([]))
-          (union-type
-            (value-type string)
-            (value-type null)))) (expr
-        (literal <nil>)))) (
-      (value-type null))
+        (array-type
+          (value-type string) dimensions: 1 ([]))))) (
+      (union-type
+        (error-type)
+        (value-type null)))
       (block-function-body
         (var-def
-          (variable _ (expr
+          (variable broad (type
+            (object-type service)) (expr
             (simple-var-ref svc))))
-        (var-def
-          (variable _ (expr
-            (simple-var-ref attachPoint))))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref broad)
+              (user-defined-type ServiceType)))))
+        (expression-stmt
+          (invocation io println (
+            (invocation value expr:
+              (simple-var-ref svc) ()))))
+        (expression-stmt
+          (invocation io println (
+            (invocation lang.array length (
+              (simple-var-ref attachPoint))))))))
     (function detach (
       (variable svc (type
-        (object-type service)))) (
+        (user-defined-type ServiceType)))) (
       (union-type
         (error-type)
         (value-type null)))
@@ -49,73 +66,174 @@
         (error-type)
         (value-type null)))
       (block-function-body)))
-  (service isolated
+  (class-definition ExplicitListener
+    (function init () ()
+      (block-function-body))
+    (function attach (
+      (variable svc (type
+        (user-defined-type ServiceType)))
+      (variable attachPoint (type
+        (array-type
+          (value-type string) dimensions: 1 ([]))))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable broad (type
+            (object-type service)) (expr
+            (simple-var-ref svc))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref broad)
+              (user-defined-type ServiceType)))))
+        (expression-stmt
+          (invocation io println (
+            (invocation value expr:
+              (simple-var-ref svc) ()))))
+        (expression-stmt
+          (invocation io println (
+            (invocation lang.array length (
+              (simple-var-ref attachPoint))))))))
+    (function detach (
+      (variable svc (type
+        (user-defined-type ServiceType)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable _ (expr
+            (simple-var-ref svc))))))
+    (function gracefulStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function immediateStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function start () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body)))
+  (service
     (absolute-resource-path /)
     (on
-    (simple-var-ref $desugar$0))
-    (variable foo (type
-      (value-type string)))
+    (simple-var-ref l))
+    (variable base (type
+      (value-type int)))
     (function init () ()
       (block-function-body
         (assignment
           (index-based-access
             (simple-var-ref self)
-            (literal foo))
-          (literal foo))))
-    (function $remote$greet () (
-      (value-type string))
+            (literal base))
+          (literal 40))))
+    (function increment () (
+      (value-type int))
       (block-function-body
-        (lock
-          (block-stmt
-            (return
-              (index-based-access
-                (simple-var-ref self)
-                (literal foo)))))))
-    (resource-function get name:hello
-      (variable name (type
-        (value-type string)))
-      (value-type string)
+        (return
+          (binary-expr +
+            (index-based-access
+              (simple-var-ref self)
+              (literal base))
+            (literal 1)))))
+    (function value () (
+      (value-type int))
       (block-function-body
-        (var-def
-          (variable _ (expr
-            (simple-var-ref name))))
-        (lock
-          (block-stmt
-            (return
-              (binary-expr +
-                (literal Hello, )
-                (index-based-access
-                  (simple-var-ref self)
-                  (literal foo)))))))))
+        (return
+          (invocation increment expr:
+            (simple-var-ref self) ())))))
+  (service
+    (user-defined-type ServiceType)
+    (absolute-resource-path /)
+    (on
+    (simple-var-ref explicitListener))
+    (variable base (type
+      (value-type int)))
+    (function init () ()
+      (block-function-body
+        (assignment
+          (index-based-access
+            (simple-var-ref self)
+            (literal base))
+          (literal 41))))
+    (function increment () (
+      (value-type int))
+      (block-function-body
+        (return
+          (binary-expr +
+            (index-based-access
+              (simple-var-ref self)
+              (literal base))
+            (literal 1)))))
+    (function value () (
+      (value-type int))
+      (block-function-body
+        (return
+          (invocation increment expr:
+            (simple-var-ref self) ())))))
   (function init () ()
     (block-function-body
       (assignment
         (simple-var-ref $moduleListeners)
         (list-constructor-expr))
       (assignment
-        (simple-var-ref $desugar$0)
-        (new
-          (user-defined-type SimpleListener) ()))
+        (simple-var-ref l)
+        (new ()))
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
-          (simple-var-ref $desugar$0))))
+          (simple-var-ref l))))
+      (assignment
+        (simple-var-ref explicitListener)
+        (new ()))
+      (expression-stmt
+        (invocation lang.array push (
+          (simple-var-ref $moduleListeners)
+          (simple-var-ref explicitListener))))
+      (var-def
+        (variable $desugar$0 (expr
+          (service-init))))
+      (var-def
+        (variable $desugar$0 (expr
+          (invocation attach expr:
+            (simple-var-ref l) (
+            (simple-var-ref $desugar$0)
+            (list-constructor-expr))))))
+      (if
+        (type-test-expr is
+          (simple-var-ref $desugar$0))
+        (block-stmt
+          (return
+            (simple-var-ref $desugar$0))) ())
+      (expression-stmt
+        (simple-var-ref $desugar$0))
       (var-def
         (variable $desugar$1 (expr
           (service-init))))
+      (var-def
+        (variable $desugar$1 (expr
+          (invocation attach expr:
+            (simple-var-ref explicitListener) (
+            (simple-var-ref $desugar$1)
+            (list-constructor-expr))))))
+      (if
+        (type-test-expr is
+          (simple-var-ref $desugar$1))
+        (block-stmt
+          (return
+            (simple-var-ref $desugar$1))) ())
       (expression-stmt
-        (invocation attach expr:
-          (simple-var-ref $desugar$0) (
-          (simple-var-ref $desugar$1)
-          (list-constructor-expr))))))
+        (simple-var-ref $desugar$1))))
   (function main () (
     (value-type null))
     (block-function-body))
-  (function $default$0 (
-    (variable svc)) ()
-    (block-function-body
-      (return
-        (literal <nil>))))
   (function $start () ()
     (block-function-body
       (var-def

--- a/corpus/desugared/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/desugared/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -1,22 +1,26 @@
 (package
   (import-package ballerina lang array (as lang.array))
-  (variable $desugar$0)
+  (variable first (type
+    (user-defined-type FirstListener)))
+  (variable second (type
+    (user-defined-type SecondListener)))
   (variable $moduleListeners)
-  (class-definition SimpleListener
+  (type-definition FirstService
+    (object-type service))
+  (type-definition SecondService
+    (object-type service))
+  (class-definition FirstListener
     (function init () ()
       (block-function-body))
     (function attach (
       (variable svc (type
-        (object-type service)))
+        (user-defined-type FirstService)))
       (variable attachPoint (type
-        (union-type
-          (array-type
-            (value-type string) dimensions: 1 ([]))
-          (union-type
-            (value-type string)
-            (value-type null)))) (expr
+        (value-type null)) (expr
         (literal <nil>)))) (
-      (value-type null))
+      (union-type
+        (error-type)
+        (value-type null)))
       (block-function-body
         (var-def
           (variable _ (expr
@@ -26,7 +30,7 @@
             (simple-var-ref attachPoint))))))
     (function detach (
       (variable svc (type
-        (object-type service)))) (
+        (user-defined-type FirstService)))) (
       (union-type
         (error-type)
         (value-type null)))
@@ -49,69 +53,115 @@
         (error-type)
         (value-type null)))
       (block-function-body)))
-  (service isolated
-    (absolute-resource-path /)
-    (on
-    (simple-var-ref $desugar$0))
-    (variable foo (type
-      (value-type string)))
+  (class-definition SecondListener
     (function init () ()
-      (block-function-body
-        (assignment
-          (index-based-access
-            (simple-var-ref self)
-            (literal foo))
-          (literal foo))))
-    (function $remote$greet () (
-      (value-type string))
-      (block-function-body
-        (lock
-          (block-stmt
-            (return
-              (index-based-access
-                (simple-var-ref self)
-                (literal foo)))))))
-    (resource-function get name:hello
-      (variable name (type
-        (value-type string)))
-      (value-type string)
+      (block-function-body))
+    (function attach (
+      (variable svc (type
+        (user-defined-type SecondService)))
+      (variable attachPoint (type
+        (value-type null)) (expr
+        (literal <nil>)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
       (block-function-body
         (var-def
           (variable _ (expr
-            (simple-var-ref name))))
-        (lock
-          (block-stmt
-            (return
-              (binary-expr +
-                (literal Hello, )
-                (index-based-access
-                  (simple-var-ref self)
-                  (literal foo)))))))))
+            (simple-var-ref svc))))
+        (var-def
+          (variable _ (expr
+            (simple-var-ref attachPoint))))))
+    (function detach (
+      (variable svc (type
+        (user-defined-type SecondService)))) (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body
+        (var-def
+          (variable _ (expr
+            (simple-var-ref svc))))))
+    (function gracefulStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function immediateStop () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body))
+    (function start () (
+      (union-type
+        (error-type)
+        (value-type null)))
+      (block-function-body)))
+  (service
+    (on
+    (simple-var-ref first)
+    (simple-var-ref second))
+    (function init () ()
+      (block-function-body)))
   (function init () ()
     (block-function-body
       (assignment
         (simple-var-ref $moduleListeners)
         (list-constructor-expr))
       (assignment
-        (simple-var-ref $desugar$0)
-        (new
-          (user-defined-type SimpleListener) ()))
+        (simple-var-ref first)
+        (new ()))
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
-          (simple-var-ref $desugar$0))))
+          (simple-var-ref first))))
+      (assignment
+        (simple-var-ref second)
+        (new ()))
+      (expression-stmt
+        (invocation lang.array push (
+          (simple-var-ref $moduleListeners)
+          (simple-var-ref second))))
+      (var-def
+        (variable $desugar$0 (expr
+          (service-init))))
+      (var-def
+        (variable $desugar$0 (expr
+          (invocation attach expr:
+            (simple-var-ref first) (
+            (simple-var-ref $desugar$0)
+            (literal <nil>))))))
+      (if
+        (type-test-expr is
+          (simple-var-ref $desugar$0))
+        (block-stmt
+          (return
+            (simple-var-ref $desugar$0))) ())
+      (expression-stmt
+        (simple-var-ref $desugar$0))
       (var-def
         (variable $desugar$1 (expr
-          (service-init))))
+          (invocation attach expr:
+            (simple-var-ref second) (
+            (simple-var-ref $desugar$0)
+            (literal <nil>))))))
+      (if
+        (type-test-expr is
+          (simple-var-ref $desugar$1))
+        (block-stmt
+          (return
+            (simple-var-ref $desugar$1))) ())
       (expression-stmt
-        (invocation attach expr:
-          (simple-var-ref $desugar$0) (
-          (simple-var-ref $desugar$1)
-          (list-constructor-expr))))))
+        (simple-var-ref $desugar$1))))
   (function main () (
     (value-type null))
     (block-function-body))
   (function $default$0 (
+    (variable svc)) ()
+    (block-function-body
+      (return
+        (literal <nil>))))
+  (function $default$1 (
     (variable svc)) ()
     (block-function-body
       (return

--- a/corpus/desugared/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/desugared/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -1,4 +1,5 @@
 (package
+  (import-package ballerina io (as io))
   (import-package ballerina lang array (as lang.array))
   (variable first (type
     (user-defined-type FirstListener)))
@@ -22,9 +23,16 @@
         (error-type)
         (value-type null)))
       (block-function-body
-        (var-def
-          (variable _ (expr
-            (simple-var-ref svc))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref svc)
+              (user-defined-type FirstService)))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref svc)
+              (user-defined-type SecondService)))))
         (var-def
           (variable _ (expr
             (simple-var-ref attachPoint))))))
@@ -66,9 +74,16 @@
         (error-type)
         (value-type null)))
       (block-function-body
-        (var-def
-          (variable _ (expr
-            (simple-var-ref svc))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref svc)
+              (user-defined-type FirstService)))))
+        (expression-stmt
+          (invocation io println (
+            (type-test-expr is
+              (simple-var-ref svc)
+              (user-defined-type SecondService)))))
         (var-def
           (variable _ (expr
             (simple-var-ref attachPoint))))))

--- a/corpus/integration/subset9/09-bug/listener-union-attach-point1-e.txtar
+++ b/corpus/integration/subset9/09-bug/listener-union-attach-point1-e.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: attach point does not have a single applicable listener list type
+  --> listener-union-attach-point1-e.bal:55:19
+   |
+55 | service S /foo on ambiguousListener { // @error multiple applicable attach-point list types
+   |                   ^^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: attach point is not supported by listener
+  --> listener-union-attach-point1-e.bal:58:27
+   |
+58 | service S /foo/bar/baz on unsupportedListener { // @error unsupported attach point
+   |                           ^^^^^^^^^^^^^^^^^^^

--- a/corpus/integration/subset9/09-bug/listener-union-attach-point1-v.txtar
+++ b/corpus/integration/subset9/09-bug/listener-union-attach-point1-v.txtar
@@ -1,0 +1,2 @@
+-- stdout --
+-- stderr --

--- a/corpus/integration/subset9/09-bug/numeric-literal-service-attach-point-e.txtar
+++ b/corpus/integration/subset9/09-bug/numeric-literal-service-attach-point-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: service body is not a subtype of the declared service type
+error[SEMANTIC_ERROR]: service type must be a subtype of service object {}
   --> numeric-literal-service-attach-point-e.bal:34:1
    |
 34 | service 123 on new Listener() { // @error numeric literals cannot be service attach points

--- a/corpus/integration/subset9/09-object/service-declared-type-missing-method1-e.txtar
+++ b/corpus/integration/subset9/09-object/service-declared-type-missing-method1-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: service body is not a subtype of the declared service type
+error[SEMANTIC_ERROR]: service body does not implement the service type
   --> service-declared-type-missing-method1-e.bal:43:1
    |
 43 | service RequiredService on l { // @error

--- a/corpus/integration/subset9/09-object/service-distinct-type1-v.txtar
+++ b/corpus/integration/subset9/09-object/service-distinct-type1-v.txtar
@@ -1,0 +1,8 @@
+-- stdout --
+true
+41
+0
+true
+42
+0
+-- stderr --

--- a/corpus/integration/subset9/09-object/service-explicit-bad-listener1-e.txtar
+++ b/corpus/integration/subset9/09-object/service-explicit-bad-listener1-e.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: expression in 'on' clause is not a listener
+  --> service-explicit-bad-listener1-e.bal:24:14
+   |
+24 | service S on listenerError { // @error error-only expression
+   |              ^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: listener expression type not resolved
+  --> service-explicit-bad-listener1-e.bal:21:14
+   |
+21 | service S on notAListener { // @error non-listener expression
+   |              ^^^^^^^^^^^^

--- a/corpus/integration/subset9/09-object/service-listener-type-mismatch1-e.txtar
+++ b/corpus/integration/subset9/09-object/service-listener-type-mismatch1-e.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: attach point is not supported by listener
+  --> service-listener-type-mismatch1-e.bal:55:25
+   |
+55 | service FirstService on stringAttachPointListener { // @error attach point mismatch
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: service type is not supported by listener
+  --> service-listener-type-mismatch1-e.bal:52:25
+   |
+52 | service FirstService on secondServiceListener { // @error service type mismatch
+   |                         ^^^^^^^^^^^^^^^^^^^^^

--- a/corpus/integration/subset9/09-object/service-non-atomic-type1-e.txtar
+++ b/corpus/integration/subset9/09-object/service-non-atomic-type1-e.txtar
@@ -1,0 +1,17 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: service type must be atomic
+  --> service-non-atomic-type1-e.bal:38:1
+   |
+38 | service ServiceUnion on explicitListener { // @error explicit service type is not atomic
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+39 | }
+   | ^
+
+error[SEMANTIC_ERROR]: service type must be atomic
+  --> service-non-atomic-type1-e.bal:41:1
+   |
+41 | service on inferredListener { // @error inferred service type is not atomic
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+42 | }
+   | ^

--- a/corpus/integration/subset9/09-object/service-on-distinct-listeners-distinct-v.txtar
+++ b/corpus/integration/subset9/09-object/service-on-distinct-listeners-distinct-v.txtar
@@ -1,0 +1,2 @@
+-- stdout --
+-- stderr --

--- a/corpus/integration/subset9/09-object/service-on-distinct-listeners-distinct-v.txtar
+++ b/corpus/integration/subset9/09-object/service-on-distinct-listeners-distinct-v.txtar
@@ -1,2 +1,6 @@
 -- stdout --
+true
+true
+true
+true
 -- stderr --

--- a/corpus/integration/subset9/09-object/service-on-multiple-listeners-incompatible1-e.txtar
+++ b/corpus/integration/subset9/09-object/service-on-multiple-listeners-incompatible1-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: service body is not a subtype of the listener's expected service type
+error[SEMANTIC_ERROR]: service body does not implement the service type
   --> service-on-multiple-listeners-incompatible1-e.bal:68:1
    |
 68 | service on fooListener, barListener { // @error service must satisfy both listener target service types

--- a/corpus/integration/subset9/09-object/service-type-resolution1-e.txtar
+++ b/corpus/integration/subset9/09-object/service-type-resolution1-e.txtar
@@ -1,0 +1,25 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: cannot derive a service type satisfying all listeners
+  --> service-type-resolution1-e.bal:57:12
+   |
+57 | service on intValueListener, stringValueListener { // @error listener service types have an empty intersection
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: resource path parameter type must be a subtype of anydata
+  --> service-type-resolution1-e.bal:63:33
+   |
+63 |     resource function get items/[any path]() { // @error resource path parameter is not anydata
+   |                                 ^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: service definition is empty
+  --> service-type-resolution1-e.bal:67:1
+   |
+67 | service on intValueListener {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+68 |     int value = 0;
+   |     ^^^^^^^^^^^^^^
+69 |     never impossible; // @error service definition is empty
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+70 | }
+   | ^

--- a/desugar/desugar.go
+++ b/desugar/desugar.go
@@ -943,17 +943,13 @@ func addModuleListenersGlobal(pkgCtx *packageContext, pkg *ast.BLangPackage, pos
 // service's `on` clause. The statements run in the module init function
 // after all module-level variable initializers.
 func buildServiceInitStmts(pkgCtx *packageContext, pkg *ast.BLangPackage, svc *ast.BLangService) []ast.StatementNode {
-	if svc.Definition == nil {
-		pkgCtx.internalError("service has no object definition at desugar")
-		return nil
-	}
-	svcTy := svc.Definition.GetSemType(pkgCtx.typeEnv())
-	if semtypes.IsZero(svcTy) {
-		pkgCtx.internalError("service object type unresolved at desugar")
+	svcTy := svc.GetTypeData().Type
+	if semtypes.IsZero(svcTy) || semtypes.IsZero(svc.ObjectBodyType) {
+		pkgCtx.internalError("service types unresolved at desugar")
 		return nil
 	}
 	initExpr := &BLangServiceInit{Service: svc}
-	initExpr.SetDeterminedType(serviceInitResultType(pkgCtx, svc, svcTy))
+	initExpr.SetDeterminedType(serviceInitResultType(pkgCtx, svc, svc.ObjectBodyType))
 	initExpr.SetPosition(svc.GetPosition())
 
 	varDef, svcRef := createDesugaredLocal(pkgCtx, pkg.InitFunction.Scope(), svcTy, wrapInCheck(initExpr), svc.GetPosition())
@@ -1110,13 +1106,22 @@ func buildListenerAttachInvocation(pkgCtx *packageContext, svc *ast.BLangService
 		pkgCtx.internalError("listener type has no attach method type at desugar")
 		return nil
 	}
-	attachPointExpr := buildAttachPointExpression(pkgCtx, svc)
+	paramListTy := semtypes.FunctionParamListType(tyCtx, attachFnTy)
+	attachPointParamTy := semtypes.ListMemberTypeInnerVal(tyCtx, paramListTy, semtypes.IntConst(1))
+	attachPointExpr := buildAttachPointExpression(pkgCtx, svc, attachPointParamTy)
+	if attachPointExpr == nil {
+		return nil
+	}
 	inv := &ast.BLangInvocation{}
 	inv.Name = &ast.BLangIdentifier{Value: "attach"}
 	inv.Expr = listenerExpr
 	inv.ArgExprs = []ast.BLangExpression{svcRef, attachPointExpr}
 	argListDefn := semtypes.NewListDefinition()
 	argListTy := argListDefn.DefineListTypeWrapped(pkgCtx.typeEnv(), []semtypes.SemType{svcRef.GetDeterminedType(), attachPointExpr.GetDeterminedType()}, 2, semtypes.NEVER, semtypes.CellMutability_CELL_MUT_NONE)
+	if !semtypes.IsSubtype(tyCtx, argListTy, paramListTy) {
+		pkgCtx.internalError("desugared listener attach arguments do not match the listener parameter types")
+		return nil
+	}
 	inv.SetDeterminedType(semtypes.FunctionReturnType(tyCtx, attachFnTy, argListTy))
 	inv.SetPosition(svc.GetPosition())
 	return inv
@@ -1125,31 +1130,56 @@ func buildListenerAttachInvocation(pkgCtx *packageContext, svc *ast.BLangService
 // buildAttachPointExpression returns an AST expression representing the
 // service's attach-point value: () for the absent case, the original string
 // literal, or an array literal of the resource path segments.
-func buildAttachPointExpression(pkgCtx *packageContext, svc *ast.BLangService) ast.BLangExpression {
+func buildAttachPointExpression(pkgCtx *packageContext, svc *ast.BLangService, attachPointParamTy semtypes.SemType) ast.BLangExpression {
+	attachPointTy := svc.AttachPointType
+	if semtypes.IsZero(attachPointTy) {
+		pkgCtx.internalError("service attach-point type unresolved at desugar")
+		return nil
+	}
 	if svc.AttachPointLiteral != nil {
+		svc.AttachPointLiteral.SetDeterminedType(attachPointTy)
 		return svc.AttachPointLiteral
 	}
-	if len(svc.AbsoluteResourcePath) == 0 {
+	if svc.AbsoluteResourcePath == nil {
 		lit := &ast.BLangLiteral{Value: nil}
-		lit.SetDeterminedType(semtypes.NIL)
+		lit.SetDeterminedType(attachPointTy)
 		lit.SetPosition(svc.GetPosition())
 		return lit
 	}
 	elements := make([]ast.BLangExpression, len(svc.AbsoluteResourcePath))
-	tupleMembers := make([]semtypes.SemType, len(svc.AbsoluteResourcePath))
+	members := make([]semtypes.ListMemberInfo, len(elements))
 	for i := range svc.AbsoluteResourcePath {
 		lit := &ast.BLangLiteral{Value: svc.AbsoluteResourcePath[i].Value}
-		litTy := semtypes.StringConst(svc.AbsoluteResourcePath[i].Value)
-		lit.SetDeterminedType(litTy)
+		lit.SetDeterminedType(semtypes.StringConst(svc.AbsoluteResourcePath[i].Value))
 		lit.SetPosition(svc.AbsoluteResourcePath[i].GetPosition())
 		elements[i] = lit
-		tupleMembers[i] = litTy
+		members[i] = semtypes.ListMemberInfo{Index: i, ValType: lit.GetDeterminedType()}
 	}
-	ld := semtypes.NewListDefinition()
-	listTy := ld.DefineListTypeWrapped(pkgCtx.typeEnv(), tupleMembers, len(tupleMembers), semtypes.NEVER, semtypes.CellMutability_CELL_MUT_LIMITED)
-	lat := semtypes.ToListAtomicType(pkgCtx.typeEnv(), listTy)
+	listTy := semtypes.Intersect(attachPointParamTy, semtypes.LIST)
+	var arrayTy semtypes.SemType
+	found := false
+	for _, alt := range semtypes.ListAlternatives(pkgCtx.typeCtx(), listTy) {
+		if !semtypes.ListAlternativeAllowsMembers(pkgCtx.typeCtx(), alt, members) {
+			continue
+		}
+		if found {
+			pkgCtx.internalError("listener attach-point parameter has multiple applicable list types")
+			return nil
+		}
+		arrayTy = alt.SemType
+		found = true
+	}
+	if !found {
+		pkgCtx.internalError("listener attach-point parameter has no applicable list type")
+		return nil
+	}
+	lat := semtypes.ToListAtomicType(pkgCtx.typeEnv(), arrayTy)
+	if lat == nil {
+		pkgCtx.internalError("applicable listener attach-point list type is not atomic")
+		return nil
+	}
 	arr := &ast.BLangListConstructorExpr{Exprs: elements, AtomicType: *lat}
-	arr.SetDeterminedType(listTy)
+	arr.SetDeterminedType(arrayTy)
 	arr.SetPosition(svc.GetPosition())
 	return arr
 }

--- a/semantics/listener_validation.go
+++ b/semantics/listener_validation.go
@@ -18,7 +18,7 @@ package semantics
 
 import "ballerina/semtypes"
 
-// validateListenerType structurally checks whether ty is a valid listener
+// listenerTypes structurally checks whether ty is a valid listener
 // object type and, on success, returns its projected service-target type T
 // and attach-point type A.
 //
@@ -31,7 +31,7 @@ import "ballerina/semtypes"
 // candidate's own `attach` signature, bounding them against the spec
 // constraints, and finally checking the candidate is a subtype of
 // `ListenerTy(T, A)` to pin down the remaining four methods.
-func validateListenerType(cx semtypes.Context, ty semtypes.SemType, attachPointBound semtypes.SemType) (semtypes.SemType, semtypes.SemType, bool) {
+func listenerTypes(cx semtypes.Context, ty semtypes.SemType, attachPointBound semtypes.SemType) (semtypes.SemType, semtypes.SemType, bool) {
 	attachFnTy := semtypes.ObjectMemberType(cx, semtypes.StringConst("attach"), ty)
 	if semtypes.IsZero(attachFnTy) {
 		return semtypes.SemType{}, semtypes.SemType{}, false

--- a/semantics/semantic_analyzer.go
+++ b/semantics/semantic_analyzer.go
@@ -1877,7 +1877,7 @@ func visitInner[A analyzer](a A, node ast.BLangNode) ast.Visitor {
 		for _, expr := range n.AttachedExprs {
 			ast.Walk(a, expr.(ast.BLangNode))
 		}
-		validateServiceDeclaredType(a, n)
+		validateServiceListenerTypes(a, n)
 		analyzeClassLikeDefn(a, n.Fields, n.InitFunction, n.Methods, n.ResourceMethods, n.Inclusions,
 			n.InclusionPositions, n.IsIsolated(), n.GetPosition(), enclosingFromService(n))
 		return nil
@@ -1886,20 +1886,54 @@ func visitInner[A analyzer](a A, node ast.BLangNode) ast.Visitor {
 	}
 }
 
-func validateServiceDeclaredType[A analyzer](a A, svc *ast.BLangService) {
-	typeData := svc.GetTypeData()
-	if typeData.TypeDescriptor == nil {
+func validateServiceListenerTypes[A analyzer](a A, svc *ast.BLangService) {
+	serviceTy := svc.GetTypeData().Type
+	attachPointTy := svc.AttachPointType
+	if semtypes.IsZero(serviceTy) || semtypes.IsZero(attachPointTy) {
+		a.internalErr("service types not resolved", svc.GetPosition())
 		return
 	}
-	bodyTy := typeData.Type
-	declaredTy := typeData.TypeDescriptor.(ast.BType).GetTypeData().Type
-	if semtypes.IsZero(bodyTy) || semtypes.IsZero(declaredTy) {
-		a.internalErr("service type not resolved", svc.GetPosition())
-		return
+	attachPointBound := listenerAttachPointBound(a.tyCtx())
+	for _, expr := range svc.AttachedExprs {
+		listenerTy := semtypes.Diff(expr.GetDeterminedType(), semtypes.ERROR)
+		if semtypes.IsNever(listenerTy) {
+			a.semanticErr("expression in 'on' clause is not a listener", expr.GetPosition())
+			continue
+		}
+		listenerServiceTy, listenerAttachPointTy, ok := listenerTypes(a.tyCtx(), listenerTy, attachPointBound)
+		if !ok {
+			a.semanticErr("listener expression type not resolved", expr.GetPosition())
+			continue
+		}
+		if !semtypes.IsSubtype(a.tyCtx(), serviceTy, listenerServiceTy) {
+			a.semanticErr("service type is not supported by listener", expr.GetPosition())
+		}
+		if !semtypes.IsSubtype(a.tyCtx(), attachPointTy, listenerAttachPointTy) {
+			a.semanticErr("attach point is not supported by listener", expr.GetPosition())
+			continue
+		}
+		if svc.AbsoluteResourcePath != nil && !hasSingleApplicableAttachPointListType(a.tyCtx(), svc, listenerAttachPointTy) {
+			a.semanticErr("attach point does not have a single applicable listener list type", expr.GetPosition())
+		}
 	}
-	if !semtypes.IsSubtype(a.tyCtx(), bodyTy, declaredTy) {
-		a.semanticErr("service body is not a subtype of the declared service type", svc.GetPosition())
+}
+
+func hasSingleApplicableAttachPointListType(cx semtypes.Context, svc *ast.BLangService, attachPointTy semtypes.SemType) bool {
+	members := make([]semtypes.ListMemberInfo, len(svc.AbsoluteResourcePath))
+	for i, segment := range svc.AbsoluteResourcePath {
+		members[i] = semtypes.ListMemberInfo{Index: i, ValType: semtypes.StringConst(segment.Value)}
 	}
+	found := false
+	for _, alt := range semtypes.ListAlternatives(cx, semtypes.Intersect(attachPointTy, semtypes.LIST)) {
+		if !semtypes.ListAlternativeAllowsMembers(cx, alt, members) {
+			continue
+		}
+		if found {
+			return false
+		}
+		found = true
+	}
+	return found
 }
 
 func analyzeClassLikeDefn[A analyzer](a A, fields []ast.SimpleVariableNode, initFn *ast.BLangFunction, methods map[string]*ast.BLangFunction, resourceMethods []*ast.BLangResourceMethod, inclusions []model.SymbolRef, inclusionPositions []diagnostics.Location, isolated bool, pos diagnostics.Location, enclosing *enclosingClassBody) {

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -1082,11 +1082,6 @@ func (t *packageTypeResolver) resolveTopLevelTypes(pkg *ast.BLangPackage) {
 			return
 		}
 	}
-	for i := range pkg.Services {
-		if !resolveServiceType(t, &pkg.Services[i], 0) {
-			return
-		}
-	}
 	populateClassSymbolByType(t, pkg)
 	populateMappingAtomMaps(t, pkg, t.importedSymbols)
 	for i := range pkg.Functions {
@@ -1127,9 +1122,6 @@ func (t *packageTypeResolver) resolveTopLevelTypes(pkg *ast.BLangPackage) {
 		classDef.SetDeterminedType(semtypes.NEVER)
 		classDef.Name.SetDeterminedType(semtypes.NEVER)
 	}
-	for i := range pkg.Services {
-		pkg.Services[i].SetDeterminedType(semtypes.NEVER)
-	}
 	pkg.SetDeterminedType(semtypes.NEVER)
 	for i := range pkg.GlobalVars {
 		resolveGlobalVarInit(t, &pkg.GlobalVars[i])
@@ -1139,8 +1131,11 @@ func (t *packageTypeResolver) resolveTopLevelTypes(pkg *ast.BLangPackage) {
 	attachPointBound := listenerAttachPointBound(t.typeContext())
 	validateListenerVars(t, pkg, attachPointBound)
 	for i := range pkg.Services {
-		resolveServiceAttachedExpressions(t, &pkg.Services[i])
-		validateServiceDeclaration(t, &pkg.Services[i], attachPointBound)
+		svc := &pkg.Services[i]
+		if !resolveServiceAttachedExpressions(t, svc) || !resolveServiceType(t, svc, 0, attachPointBound) {
+			continue
+		}
+		svc.SetDeterminedType(semtypes.NEVER)
 	}
 	for i := range pkg.XmlnsList {
 		resolveXMLNS(t, nil, &pkg.XmlnsList[i])
@@ -2699,39 +2694,79 @@ func resolveClassDefinitionType(t typeResolver, classDef *ast.BLangClassDefiniti
 	return semType, true
 }
 
-func resolveServiceType(t typeResolver, svc *ast.BLangService, depth int) bool {
-	if !semtypes.IsZero(svc.GetDeterminedType()) {
-		return true
+func resolveServiceType(t typeResolver, svc *ast.BLangService, depth int, attachPointBound semtypes.SemType) bool {
+	typeData := svc.GetTypeData()
+	var serviceTy semtypes.SemType
+	if typeData.TypeDescriptor != nil {
+		var ok bool
+		serviceTy, ok = resolveBType(t, typeData.TypeDescriptor.(ast.BType), depth+1)
+		if !ok {
+			return false
+		}
+	} else {
+		listenerServiceTypes := make([]semtypes.SemType, 0, len(svc.AttachedExprs))
+		for _, expr := range svc.AttachedExprs {
+			listenerServiceTy, _, ok := listenerType(t, expr, attachPointBound)
+			if !ok {
+				return false
+			}
+			listenerServiceTypes = append(listenerServiceTypes, listenerServiceTy)
+		}
+
+		serviceTy = inferServiceType(listenerServiceTypes)
+		if semtypes.IsEmpty(t.typeContext(), serviceTy) {
+			pos := svc.AttachedExprsPosition
+			t.semanticError("cannot derive a service type satisfying all listeners", pos)
+			return false
+		}
 	}
-	if svc.Definition != nil {
-		return true
+	if !semtypes.IsSubtype(t.typeContext(), serviceTy, semtypes.CreateServiceObject(t.typeContext())) {
+		t.semanticError("service type must be a subtype of service object {}", svc.GetPosition())
+		return false
+	}
+
+	svc.AttachPointType = serviceAttachPointType(t, svc)
+	if semtypes.IsNever(svc.AttachPointType) {
+		return false
 	}
 
 	od := semtypes.NewObjectDefinition()
 	svc.Definition = &od
-
-	semType, ok := finishResolveObjectDefinitionType(t, &od, svc.Fields, svc.Methods, svc.ResourceMethods, svc.InitFunction,
-		nil, svc.GetPosition(), depth, svc.IsIsolated(), false, false, true, model.SymbolRef{})
-	if !ok {
-		return false
-	}
-
-	svc.SetDeterminedType(semType)
-	typeData := svc.GetTypeData()
-	if typeData.TypeDescriptor != nil {
-		if _, ok := resolveBType(t, typeData.TypeDescriptor.(ast.BType), depth+1); !ok {
+	var objectBodyTy semtypes.SemType
+	{
+		var ok bool
+		// We don't necessarily have a symbol ref for inclusion (type is derived or type is defined inline), so we need to manually include it and validate it
+		objectBodyTy, ok = finishResolveObjectDefinitionType(t, &od, svc.Fields, svc.Methods, svc.ResourceMethods, svc.InitFunction,
+			nil, svc.GetPosition(), depth, svc.IsIsolated(), false, false, true, model.SymbolRef{})
+		if !ok {
 			return false
 		}
+		structuralServiceTy := semtypes.StripObjectDistinctAtoms(serviceTy)
+		if !semtypes.IsSubtype(t.typeContext(), objectBodyTy, structuralServiceTy) {
+			t.semanticError("service body does not implement the service type", svc.GetPosition())
+			return false
+		}
+		objectBodyTy = semtypes.Intersect(objectBodyTy, serviceTy)
 	}
-	typeData.Type = semType
+
+	typeData.Type = serviceTy
 	svc.SetTypeData(typeData)
+	svc.ObjectBodyType = objectBodyTy
 	if selfRef, ok := svc.Scope().GetSymbol("self"); ok {
-		t.setSymbolType(selfRef, semType)
+		t.setSymbolType(selfRef, objectBodyTy)
 	}
-	t.ensureNotEmpty(semType, func() {
+	t.ensureNotEmpty(objectBodyTy, func() {
 		t.semanticError("service definition is empty", svc.GetPosition())
 	})
 	return true
+}
+
+func inferServiceType(listenerServiceTypes []semtypes.SemType) semtypes.SemType {
+	serviceTy := listenerServiceTypes[0]
+	for _, listenerServiceTy := range listenerServiceTypes[1:] {
+		serviceTy = semtypes.Intersect(serviceTy, listenerServiceTy)
+	}
+	return serviceTy
 }
 
 func finishResolveObjectDefinitionType(t typeResolver, od *semtypes.ObjectDefinition, fields []ast.SimpleVariableNode,
@@ -3349,12 +3384,14 @@ func resolveGlobalVarInit(t typeResolver, node *ast.BLangSimpleVariable) bool {
 }
 
 // resolveServiceAttachedExpressions type-checks the listener expressions in
-// a service's `on` clause so subsequent validation can read each expression's
-// determined type.
-func resolveServiceAttachedExpressions(t typeResolver, svc *ast.BLangService) {
+// a service's `on` clause so service type resolution can inspect them.
+func resolveServiceAttachedExpressions(t typeResolver, svc *ast.BLangService) bool {
 	for _, expr := range svc.AttachedExprs {
-		resolveActionOrExpression(t, nil, expr, semtypes.SemType{})
+		if _, _, ok := resolveActionOrExpression(t, nil, expr, semtypes.SemType{}); !ok {
+			return false
+		}
 	}
+	return true
 }
 
 // validateListenerVars verifies each module-level listener variable's
@@ -3372,56 +3409,20 @@ func validateListenerVars(t typeResolver, pkg *ast.BLangPackage, attachPointBoun
 			t.internalError("listener variable has no determined type", gv.GetPosition())
 			continue
 		}
-		if _, _, ok := validateListenerType(tyCtx, ty, attachPointBound); !ok {
+		if _, _, ok := listenerTypes(tyCtx, ty, attachPointBound); !ok {
 			t.semanticError("listener initializer is not a listener", gv.GetPosition())
 		}
 	}
 }
 
-// validateServiceDeclaration implements the type-resolver rules from the
-// service/listener design: the `on` expression list must consist of
-// listener variables, the attach-point type must be a subtype of the
-// listeners' attach-point union, and the service body must be a subtype
-// of the listeners' target object union (or the user-supplied service
-// type when present).
-func validateServiceDeclaration(t typeResolver, svc *ast.BLangService, attachPointBound semtypes.SemType) {
-	tyCtx := t.typeContext()
-
-	var expectedT semtypes.SemType
-	var expectedA semtypes.SemType
-	for i, expr := range svc.AttachedExprs {
-		targetTy, attachTy, ok := validateListenerOnExpression(t, expr, attachPointBound)
-		if !ok {
-			return
-		}
-		if i == 0 {
-			expectedT = targetTy
-			expectedA = attachTy
-			continue
-		}
-		expectedT = semtypes.Intersect(expectedT, targetTy)
-		expectedA = semtypes.Intersect(expectedA, attachTy)
-	}
-
-	attachPointTy := serviceAttachPointType(t, svc)
-	if !semtypes.IsSubtype(tyCtx, attachPointTy, expectedA) {
-		t.semanticError("attach point is not assignable to listener's attach-point type", svc.GetPosition())
-	}
-
-	bodyTy := svc.Definition.GetSemType(t.typeEnv())
-	if !semtypes.IsSubtype(tyCtx, bodyTy, expectedT) {
-		t.semanticError("service body is not a subtype of the listener's expected service type", svc.GetPosition())
-	}
-}
-
-func validateListenerOnExpression(t typeResolver, expr ast.BLangExpression, attachPointBound semtypes.SemType) (semtypes.SemType, semtypes.SemType, bool) {
+func listenerType(t typeResolver, expr ast.BLangExpression, attachPointBound semtypes.SemType) (semtypes.SemType, semtypes.SemType, bool) {
 	exprTy := expr.GetDeterminedType()
 	if semtypes.IsZero(exprTy) {
 		t.internalError("listener expression has no determined type", expr.GetPosition())
 		return semtypes.SemType{}, semtypes.SemType{}, false
 	}
 	checkedTy := semtypes.Diff(exprTy, semtypes.ERROR)
-	targetTy, attachTy, ok := validateListenerType(t.typeContext(), checkedTy, attachPointBound)
+	targetTy, attachTy, ok := listenerTypes(t.typeContext(), checkedTy, attachPointBound)
 	if !ok {
 		t.semanticError("expression in 'on' clause is not a listener", expr.GetPosition())
 		return semtypes.SemType{}, semtypes.SemType{}, false
@@ -3436,12 +3437,13 @@ func serviceAttachPointType(t typeResolver, svc *ast.BLangService) semtypes.SemT
 		}
 		return svc.AttachPointLiteral.GetDeterminedType()
 	}
-	if len(svc.AbsoluteResourcePath) == 0 {
+	if svc.AbsoluteResourcePath == nil {
 		return semtypes.NIL
 	}
 	segmentTypes := make([]semtypes.SemType, len(svc.AbsoluteResourcePath))
 	for i := range svc.AbsoluteResourcePath {
 		segmentTypes[i] = semtypes.StringConst(svc.AbsoluteResourcePath[i].Value)
+		svc.AbsoluteResourcePath[i].SetDeterminedType(semtypes.NEVER)
 	}
 	listDefn := semtypes.NewListDefinition()
 	return listDefn.DefineListTypeWrapped(t.typeEnv(), segmentTypes, len(segmentTypes), semtypes.NEVER, semtypes.CellMutability_CELL_MUT_NONE)

--- a/semantics/type_resolver.go
+++ b/semantics/type_resolver.go
@@ -2724,6 +2724,10 @@ func resolveServiceType(t typeResolver, svc *ast.BLangService, depth int, attach
 		t.semanticError("service type must be a subtype of service object {}", svc.GetPosition())
 		return false
 	}
+	if !semtypes.IsAtomicObjectType(t.typeContext(), serviceTy) {
+		t.semanticError("service type must be atomic", svc.GetPosition())
+		return false
+	}
 
 	svc.AttachPointType = serviceAttachPointType(t, svc)
 	if semtypes.IsNever(svc.AttachPointType) {

--- a/semtypes/object_alternative.go
+++ b/semtypes/object_alternative.go
@@ -21,6 +21,10 @@ type ObjectAlternative struct {
 	InitFnType SemType
 }
 
+func IsAtomicObjectType(cx Context, t SemType) bool {
+	return IsSubtype(cx, t, OBJECT) && len(ObjectAlternatives(cx, t)) == 1
+}
+
 func ObjectAlternatives(cx Context, t SemType) []ObjectAlternative {
 	mappingTy := convertObjectToMappingTy(cx, t)
 	mappingAlternatives := MappingAlternatives(cx, mappingTy)

--- a/semtypes/object_definition.go
+++ b/semtypes/object_definition.go
@@ -37,7 +37,7 @@ func ObjectDefinitionDistinct(distinctId int) SemType {
 	return getBasicSubtype(BTObject, bdd)
 }
 
-func stripObjectDistinctAtoms(ty SemType) SemType {
+func StripObjectDistinctAtoms(ty SemType) SemType {
 	return stripDistinctAtomsFromSemType(ty, BTObject, stripDistinctAtomsFromBdd)
 }
 

--- a/semtypes/type_pool.go
+++ b/semtypes/type_pool.go
@@ -67,7 +67,7 @@ func (pool *TypePool) Put(ty SemType) TypePoolIndex {
 }
 
 func (pool *TypePool) PutObjectDefinition(ty SemType) TypePoolIndex {
-	return pool.Put(stripObjectDistinctAtoms(ty))
+	return pool.Put(StripObjectDistinctAtoms(ty))
 }
 
 func (pool *TypePool) PutErrorDefinition(ty SemType) TypePoolIndex {


### PR DESCRIPTION
## Summary
- preserve distinct service types while validating service bodies structurally
- infer undeclared service types from listener target types and validate each listener's service and attach-point compatibility
- desugar listener attachment using the resolved service, body, and attach-point types
- add corpus coverage for distinct service types, multiple distinct listeners, and listener type mismatches

## Testing
- `go test ./...` 

Depends on #630
Closes #608


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced service attachment handling by capturing attach-point origin and semantic type details to improve support for distinct service object types and multiple listener bindings.
* **Bug Fixes**
  * Improved service–listener compatibility validation with stricter attach-point type checking.
  * Updated diagnostic wording for service type and attach-point mismatch scenarios.
  * Fixed rendering of root (`/`) versus empty resource paths for service attach information.
* **Tests**
  * Added new BAL modules and integration fixtures for distinct service/listener attachment cases; updated expected stdout/stderr and diagnostic messages accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->