### PR TITLE
Fix semtype to string rendering not showing builtin types in some contexts

### DIFF
--- a/corpus/bir/library/subset1/http-client-methods-v.txt
+++ b/corpus/bir/library/subset1/http-client-methods-v.txt
@@ -72,7 +72,7 @@ main() -> nil|error{
     $desugar$8 = %28;
     %30 = ConstantLoad key
     %31 = ConstantLoad val
-    %32 = newMap {| nil|boolean|int|float|decimal|string|...|...... |}{%30=%31}
+    %32 = newMap {| json... |}{%30=%31}
     $desugar$9 = %32;
     %34 = $default$22($desugar$8,$desugar$9) -> bb14;
   }

--- a/corpus/bir/library/subset1/http-client-post-v.txt
+++ b/corpus/bir/library/subset1/http-client-post-v.txt
@@ -100,7 +100,7 @@ main() -> nil|error{
     %44 = ConstantLoad test
     %45 = ConstantLoad count
     %46 = ConstantLoad 1
-    %47 = newMap {| nil|boolean|int|float|decimal|string|...|...... |}{%43=%44, %45=%46}
+    %47 = newMap {| json... |}{%43=%44, %45=%46}
     $desugar$10 = %47;
     %49 = $default$24($desugar$9,$desugar$10) -> bb18;
   }

--- a/corpus/bir/library/subset2/civil-functions-v.txt
+++ b/corpus/bir/library/subset2/civil-functions-v.txt
@@ -58,7 +58,7 @@ main() -> nil|error{
     %32 = ConstantLoad 6
     %33 = ConstantLoad day
     %34 = ConstantLoad 15
-    %35 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%29=%30, %31=%32, %33=%34}
+    %35 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, anydata... |}{%29=%30, %31=%32, %33=%34}
     %36 = dateValidate(%35) -> bb10;
   }
   bb10 {
@@ -74,7 +74,7 @@ main() -> nil|error{
     %44 = ConstantLoad 13
     %45 = ConstantLoad day
     %46 = ConstantLoad 1
-    %47 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%41=%42, %43=%44, %45=%46}
+    %47 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, anydata... |}{%41=%42, %43=%44, %45=%46}
     %48 = dateValidate(%47) -> bb12;
   }
   bb12 {
@@ -90,7 +90,7 @@ main() -> nil|error{
     %56 = ConstantLoad 6
     %57 = ConstantLoad day
     %58 = ConstantLoad 15
-    %59 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%53=%54, %55=%56, %57=%58}
+    %59 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, anydata... |}{%53=%54, %55=%56, %57=%58}
     %60 = dayOfWeek(%59) -> bb14;
   }
   bb14 {

--- a/corpus/bir/library/subset2/civil-zone-handling-v.txt
+++ b/corpus/bir/library/subset2/civil-zone-handling-v.txt
@@ -15,7 +15,7 @@ main() -> nil|error{
     %12 = ConstantLoad 50
     %13 = ConstantLoad timeAbbrev
     %14 = ConstantLoad Asia/Colombo
-    %15 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6, %7=%8, %9=%10, %11=%12, %13=%14}
+    %15 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%1=%2, %3=%4, %5=%6, %7=%8, %9=%10, %11=%12, %13=%14}
     %16 = civilToString(%15) -> bb1;
   }
   bb1 {
@@ -48,7 +48,7 @@ main() -> nil|error{
     %32 = ConstantLoad 50
     %33 = ConstantLoad timeAbbrev
     %34 = ConstantLoad +05:30
-    %35 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%21=%22, %23=%24, %25=%26, %27=%28, %29=%30, %31=%32, %33=%34}
+    %35 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%21=%22, %23=%24, %25=%26, %27=%28, %29=%30, %31=%32, %33=%34}
     %36 = civilToString(%35) -> bb5;
   }
   bb5 {
@@ -81,7 +81,7 @@ main() -> nil|error{
     %52 = ConstantLoad 50
     %53 = ConstantLoad timeAbbrev
     %54 = ConstantLoad Z
-    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%41=%42, %43=%44, %45=%46, %47=%48, %49=%50, %51=%52, %53=%54}
+    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%41=%42, %43=%44, %45=%46, %47=%48, %49=%50, %51=%52, %53=%54}
     %56 = civilToString(%55) -> bb9;
   }
   bb9 {
@@ -110,7 +110,7 @@ main() -> nil|error{
     %68 = ConstantLoad 17
     %69 = ConstantLoad minute
     %70 = ConstantLoad 50
-    %71 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%61=%62, %63=%64, %65=%66, %67=%68, %69=%70}
+    %71 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%61=%62, %63=%64, %65=%66, %67=%68, %69=%70}
     %72 = civilToString(%71) -> bb13;
   }
   bb13 {
@@ -140,7 +140,7 @@ main() -> nil|error{
     %94 = ConstantLoad seconds
     %95 = ConstantLoad 30
     %96 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%90=%91, %92=%93, %94=%95} defaults{minutes=ballerina/time:$desugar$0}
-    %97 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%77=%78, %79=%80, %81=%82, %83=%84, %85=%86, %87=%88, %89=%96}
+    %97 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%77=%78, %79=%80, %81=%82, %83=%84, %85=%86, %87=%88, %89=%96}
     %98 = civilToString(%97) -> bb15;
   }
   bb15 {
@@ -279,7 +279,7 @@ main() -> nil|error{
     %26 = ConstantLoad 0
     %27 = ConstantLoad timeAbbrev
     %28 = ConstantLoad Z
-    %29 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%17=%18, %19=%20, %21=%22, %23=%24, %25=%26, %27=%28}
+    %29 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%17=%18, %19=%20, %21=%22, %23=%24, %25=%26, %27=%28}
     %30 = utcFromCivil(utcZone,%29) -> bb41;
   }
   bb41 {
@@ -309,7 +309,7 @@ main() -> nil|error{
     %52 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%48=%49, %50=%51} defaults{minutes=ballerina/time:$desugar$0}
     %53 = ConstantLoad timeAbbrev
     %54 = ConstantLoad GMT
-    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%35=%36, %37=%38, %39=%40, %41=%42, %43=%44, %45=%46, %47=%52, %53=%54}
+    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%35=%36, %37=%38, %39=%40, %41=%42, %43=%44, %45=%46, %47=%52, %53=%54}
     %56 = ConstantLoad ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT
     %57 = civilToEmailString(%55,%56) -> bb43;
   }
@@ -348,7 +348,7 @@ main() -> nil|error{
     %77 = ConstantLoad minutes
     %78 = ConstantLoad 0
     %79 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%75=%76, %77=%78} defaults{minutes=ballerina/time:$desugar$0}
-    %80 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%62=%63, %64=%65, %66=%67, %68=%69, %70=%71, %72=%73, %74=%79}
+    %80 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%62=%63, %64=%65, %66=%67, %68=%69, %70=%71, %72=%73, %74=%79}
     %81 = ConstantLoad ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT
     %82 = civilToEmailString(%80,%81) -> bb47;
   }

--- a/corpus/bir/library/subset2/http-request-response-v.txt
+++ b/corpus/bir/library/subset2/http-request-response-v.txt
@@ -180,7 +180,7 @@ main() -> nil|error{
   bb40 {
     %72 = ConstantLoad k
     %73 = ConstantLoad v
-    %74 = newMap {| nil|boolean|int|float|decimal|string|...|...... |}{%72=%73}
+    %74 = newMap {| json... |}{%72=%73}
     $desugar$6 = %74;
     %76 = $default$11($desugar$6) -> bb41;
   }
@@ -417,7 +417,7 @@ main() -> nil|error{
     %173 = ConstantLoad 2
     %174 = ConstantLoad 3
     %175 = ConstantLoad 3
-    %176 = newArray [nil|boolean|int|float|decimal|string|...|......][%175]{%172, %173, %174}
+    %176 = newArray [json...][%175]{%172, %173, %174}
     $desugar$28 = %176;
     %178 = $default$8($desugar$28) -> bb91;
   }

--- a/corpus/bir/library/subset2/io-file-json-types-v.txt
+++ b/corpus/bir/library/subset2/io-file-json-types-v.txt
@@ -117,7 +117,7 @@ main() -> nil|error{
     %42 = ConstantLoad <nil>
     %43 = ConstantLoad x
     %44 = ConstantLoad 5
-    %45 = newArray [nil|boolean|int|float|decimal|string|...|......][%44]{%39, %40, %41, %42, %43}
+    %45 = newArray [json...][%44]{%39, %40, %41, %42, %43}
     arr = %45;
     %47 = fileWriteJson(arrPath,arr) -> bb22;
   }

--- a/corpus/bir/library/subset2/io-file-json1-v.txt
+++ b/corpus/bir/library/subset2/io-file-json1-v.txt
@@ -7,7 +7,7 @@ main() -> nil|error{
     %4 = ConstantLoad Alice
     %5 = ConstantLoad age
     %6 = ConstantLoad 30
-    %7 = newMap {| nil|boolean|int|float|decimal|string|...|...... |}{%3=%4, %5=%6}
+    %7 = newMap {| json... |}{%3=%4, %5=%6}
     data = %7;
     %9 = fileWriteJson(path,data) -> bb1;
   }
@@ -38,7 +38,7 @@ main() -> nil|error{
   }
   bb6 {
     result = $desugar$1;
-    %16 = <{| nil|boolean|int|float|decimal|string|[nil|boolean|int|float|decimal|string|...|......]|{| nil|boolean|int|float|decimal|string|...|...... |}... |}>(result)
+    %16 = <{| json... |}>(result)
     m = %16;
     %19 = ConstantLoad name
     %18 = m[%19];

--- a/corpus/bir/library/subset2/io-file-json2-v.txt
+++ b/corpus/bir/library/subset2/io-file-json2-v.txt
@@ -8,7 +8,7 @@ main() -> nil|error{
     %5 = ConstantLoad hello
     %6 = ConstantLoad <nil>
     %7 = ConstantLoad 4
-    %8 = newArray [nil|boolean|int|float|decimal|string|...|......][%7]{%3, %4, %5, %6}
+    %8 = newArray [json...][%7]{%3, %4, %5, %6}
     data = %8;
     %10 = fileWriteJson(path,data) -> bb1;
   }
@@ -39,7 +39,7 @@ main() -> nil|error{
   }
   bb6 {
     result = $desugar$1;
-    %17 = <[nil|boolean|int|float|decimal|string|[nil|boolean|int|float|decimal|string|...|......]|{| nil|boolean|int|float|decimal|string|...|...... |}...]>(result)
+    %17 = <[json...]>(result)
     arr = %17;
     %19 = length(arr) -> bb7;
   }

--- a/corpus/bir/library/subset2/io-file-mkdir-v.txt
+++ b/corpus/bir/library/subset2/io-file-mkdir-v.txt
@@ -132,7 +132,7 @@ main() -> nil|error{
     jsonPath = %50;
     %52 = ConstantLoad k
     %53 = ConstantLoad v
-    %54 = newMap {| nil|boolean|int|float|decimal|string|...|...... |}{%52=%53}
+    %54 = newMap {| json... |}{%52=%53}
     %55 = fileWriteJson(jsonPath,%54) -> bb25;
   }
   bb25 {

--- a/corpus/bir/library/subset2/log-debug-filtered1-v.txt
+++ b/corpus/bir/library/subset2/log-debug-filtered1-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newMap {| 'error: never, msg: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %5 = newMap {| 'error: never, msg: never, anydata... |}{}
     %6 = printDebug($desugar$0,$desugar$1,%5) -> bb2;
   }
   bb2 {

--- a/corpus/bir/library/subset2/log-emit-v.txt
+++ b/corpus/bir/library/subset2/log-emit-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newMap {| 'error: never, msg: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %5 = newMap {| 'error: never, msg: never, anydata... |}{}
     %6 = printInfo($desugar$0,$desugar$1,%5) -> bb2;
   }
   bb2 {
@@ -19,14 +19,14 @@ main() -> nil{
     $desugar$3 = %9;
     %11 = ConstantLoad diskPct
     %12 = ConstantLoad 12
-    %13 = newMap {| 'error: never, msg: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%11=%12}
+    %13 = newMap {| 'error: never, msg: never, anydata... |}{%11=%12}
     %14 = printWarn($desugar$2,$desugar$3,%13) -> bb4;
   }
   bb4 {
     %15 = ConstantLoad request failed
     %16 = ConstantLoad disk full
     %17 = newError error(%16)
-    %18 = newMap {| 'error: never, msg: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %18 = newMap {| 'error: never, msg: never, anydata... |}{}
     %19 = printError(%15,%17,%18) -> bb5;
   }
   bb5 {

--- a/corpus/bir/library/subset2/log-kv1-v.txt
+++ b/corpus/bir/library/subset2/log-kv1-v.txt
@@ -11,7 +11,7 @@ main() -> nil{
     %6 = ConstantLoad 845315
     %7 = ConstantLoad path
     %8 = ConstantLoad /api/v1
-    %9 = newMap {| 'error: never, msg: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%5=%6, %7=%8}
+    %9 = newMap {| 'error: never, msg: never, anydata... |}{%5=%6, %7=%8}
     %10 = printDebug($desugar$0,$desugar$1,%9) -> bb2;
   }
   bb2 {
@@ -27,7 +27,7 @@ main() -> nil{
     %18 = ConstantLoad true
     %19 = ConstantLoad score
     %20 = ConstantLoad 9.8
-    %21 = newMap {| 'error: never, msg: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%15=%16, %17=%18, %19=%20}
+    %21 = newMap {| 'error: never, msg: never, anydata... |}{%15=%16, %17=%18, %19=%20}
     %22 = printDebug($desugar$2,$desugar$3,%21) -> bb4;
   }
   bb4 {

--- a/corpus/bir/library/subset2/os-exec-v.txt
+++ b/corpus/bir/library/subset2/os-exec-v.txt
@@ -8,7 +8,7 @@ main() -> nil|error{
     %5 = ConstantLoad 1
     %6 = newArray [string...][%5]{%4}
     %7 = newMap {| arguments: [string...], value: string, never... |}{%1=%2, %3=%6} defaults{arguments=ballerina/os:$desugar$0}
-    %8 = newMap {| command: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %8 = newMap {| command: never, anydata... |}{}
     %9 = exec(%7,%8) -> bb1;
   }
   bb1 {
@@ -81,7 +81,7 @@ main() -> nil|error{
     %37 = ConstantLoad 1
     %38 = newArray [string...][%37]{%36}
     %39 = newMap {| arguments: [string...], value: string, never... |}{%33=%34, %35=%38} defaults{arguments=ballerina/os:$desugar$0}
-    %40 = newMap {| command: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %40 = newMap {| command: never, anydata... |}{}
     %41 = exec(%39,%40) -> bb14;
   }
   bb14 {
@@ -145,7 +145,7 @@ main() -> nil|error{
     %64 = ConstantLoad 2
     %65 = newArray [string...][%64]{%63, dirWithSpace}
     %66 = newMap {| arguments: [string...], value: string, never... |}{%60=%61, %62=%65} defaults{arguments=ballerina/os:$desugar$0}
-    %67 = newMap {| command: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %67 = newMap {| command: never, anydata... |}{}
     %68 = exec(%66,%67) -> bb25;
   }
   bb25 {
@@ -184,7 +184,7 @@ main() -> nil|error{
     %79 = ConstantLoad 1
     %80 = newArray [string...][%79]{dirWithSpace}
     %81 = newMap {| arguments: [string...], value: string, never... |}{%76=%77, %78=%80} defaults{arguments=ballerina/os:$desugar$0}
-    %82 = newMap {| command: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %82 = newMap {| command: never, anydata... |}{}
     %83 = exec(%81,%82) -> bb32;
   }
   bb32 {
@@ -225,7 +225,7 @@ main() -> nil|error{
     %96 = ConstantLoad 2
     %97 = newArray [string...][%96]{%94, %95}
     %98 = newMap {| arguments: [string...], value: string, never... |}{%91=%92, %93=%97} defaults{arguments=ballerina/os:$desugar$0}
-    %99 = newMap {| command: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %99 = newMap {| command: never, anydata... |}{}
     %100 = exec(%98,%99) -> bb39;
   }
   bb39 {
@@ -259,7 +259,7 @@ main() -> nil|error{
     %108 = ConstantLoad value
     %109 = ConstantLoad no_such_command_xyz_123
     %110 = newMap {| arguments: [string...], value: string, never... |}{%108=%109} defaults{arguments=ballerina/os:$desugar$0}
-    %111 = newMap {| command: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %111 = newMap {| command: never, anydata... |}{}
     %112 = exec(%110,%111) -> bb45;
   }
   bb45 {
@@ -276,7 +276,7 @@ main() -> nil|error{
     %121 = ConstantLoad 1
     %122 = newArray [string...][%121]{%120}
     %123 = newMap {| arguments: [string...], value: string, never... |}{%117=%118, %119=%122} defaults{arguments=ballerina/os:$desugar$0}
-    %124 = newMap {| command: never, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{}
+    %124 = newMap {| command: never, anydata... |}{}
     %125 = exec(%123,%124) -> bb47;
   }
   bb47 {

--- a/corpus/bir/library/subset2/time-error-cases-v.txt
+++ b/corpus/bir/library/subset2/time-error-cases-v.txt
@@ -37,7 +37,7 @@ main() -> nil|error{
     %22 = ConstantLoad 2
     %23 = ConstantLoad day
     %24 = ConstantLoad 30
-    %25 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%19=%20, %21=%22, %23=%24}
+    %25 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, anydata... |}{%19=%20, %21=%22, %23=%24}
     %26 = dateValidate(%25) -> bb7;
   }
   bb7 {
@@ -75,7 +75,7 @@ main() -> nil|error{
     %52 = ConstantLoad minutes
     %53 = ConstantLoad 30
     %54 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%50=%51, %52=%53} defaults{minutes=ballerina/time:$desugar$0}
-    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%37=%38, %39=%40, %41=%42, %43=%44, %45=%46, %47=%48, %49=%54}
+    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%37=%38, %39=%40, %41=%42, %43=%44, %45=%46, %47=%48, %49=%54}
     %56 = utcFromCivil(%55) -> bb11;
   }
   bb11 {
@@ -111,7 +111,7 @@ main() -> nil|error{
     %73 = ConstantLoad 50
     %74 = ConstantLoad timeAbbrev
     %75 = ConstantLoad Z
-    %76 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%62=%63, %64=%65, %66=%67, %68=%69, %70=%71, %72=%73, %74=%75}
+    %76 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%62=%63, %64=%65, %66=%67, %68=%69, %70=%71, %72=%73, %74=%75}
     %77 = utcFromCivil(%76) -> bb16;
   }
   bb16 {
@@ -143,7 +143,7 @@ main() -> nil|error{
     %90 = ConstantLoad 17
     %91 = ConstantLoad minute
     %92 = ConstantLoad 50
-    %93 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%83=%84, %85=%86, %87=%88, %89=%90, %91=%92}
+    %93 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%83=%84, %85=%86, %87=%88, %89=%90, %91=%92}
     %94 = utcFromCivil(%93) -> bb21;
   }
   bb21 {
@@ -163,7 +163,7 @@ main() -> nil|error{
     %106 = ConstantLoad 10
     %107 = ConstantLoad minute
     %108 = ConstantLoad 0
-    %109 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%99=%100, %101=%102, %103=%104, %105=%106, %107=%108}
+    %109 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%99=%100, %101=%102, %103=%104, %105=%106, %107=%108}
     %110 = ConstantLoad hours
     %111 = ConstantLoad 1
     %112 = newMap {| days: int, hours: int, minutes: int, months: int, seconds: decimal, weeks: int, years: int, never... |}{%110=%111} defaults{years=ballerina/time:$desugar$2, months=ballerina/time:$desugar$3, weeks=ballerina/time:$desugar$4, days=ballerina/time:$desugar$5, hours=ballerina/time:$desugar$6, minutes=ballerina/time:$desugar$7, seconds=ballerina/time:$desugar$8}

--- a/corpus/bir/library/subset2/time-offset-parsing-v.txt
+++ b/corpus/bir/library/subset2/time-offset-parsing-v.txt
@@ -235,7 +235,7 @@ main() -> nil|error{
     %56 = ConstantLoad 50
     %57 = ConstantLoad timeAbbrev
     %58 = ConstantLoad +12:99
-    %59 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%45=%46, %47=%48, %49=%50, %51=%52, %53=%54, %55=%56, %57=%58}
+    %59 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%45=%46, %47=%48, %49=%50, %51=%52, %53=%54, %55=%56, %57=%58}
     %60 = civilToString(%59) -> bb47;
   }
   bb47 {
@@ -259,7 +259,7 @@ main() -> nil|error{
     %76 = ConstantLoad 50
     %77 = ConstantLoad timeAbbrev
     %78 = ConstantLoad Bogus/Zone
-    %79 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%65=%66, %67=%68, %69=%70, %71=%72, %73=%74, %75=%76, %77=%78}
+    %79 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%65=%66, %67=%68, %69=%70, %71=%72, %73=%74, %75=%76, %77=%78}
     %80 = civilToString(%79) -> bb49;
   }
   bb49 {
@@ -287,7 +287,7 @@ main() -> nil|error{
     %100 = ConstantLoad minutes
     %101 = ConstantLoad 30
     %102 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%98=%99, %100=%101} defaults{minutes=ballerina/time:$desugar$0}
-    %103 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%85=%86, %87=%88, %89=%90, %91=%92, %93=%94, %95=%96, %97=%102}
+    %103 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%85=%86, %87=%88, %89=%90, %91=%92, %93=%94, %95=%96, %97=%102}
     %104 = utcFromCivil(%103) -> bb51;
   }
   bb51 {
@@ -309,7 +309,7 @@ main() -> nil|error{
     %118 = ConstantLoad 20
     %119 = ConstantLoad timeAbbrev
     %120 = ConstantLoad +05:30
-    %121 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%109=%110, %111=%112, %113=%114, %115=%116, %117=%118, %119=%120}
+    %121 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%109=%110, %111=%112, %113=%114, %115=%116, %117=%118, %119=%120}
     %122 = civilToString(%121) -> bb53;
   }
   bb53 {

--- a/corpus/bir/library/subset2/time-subsecond-v.txt
+++ b/corpus/bir/library/subset2/time-subsecond-v.txt
@@ -103,7 +103,7 @@ main() -> nil|error{
     %40 = ConstantLoad 45.5
     %41 = ConstantLoad timeAbbrev
     %42 = ConstantLoad -08:00
-    %43 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%29=%30, %31=%32, %33=%34, %35=%36, %37=%38, %39=%40, %41=%42}
+    %43 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%29=%30, %31=%32, %33=%34, %35=%36, %37=%38, %39=%40, %41=%42}
     %44 = civilToString(%43) -> bb21;
   }
   bb21 {
@@ -141,7 +141,7 @@ main() -> nil|error{
     %65 = ConstantLoad minutes
     %66 = ConstantLoad 0
     %67 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%62=%64, %65=%66} defaults{minutes=ballerina/time:$desugar$0}
-    %68 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%49=%50, %51=%52, %53=%54, %55=%56, %57=%58, %59=%60, %61=%67}
+    %68 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%49=%50, %51=%52, %53=%54, %55=%56, %57=%58, %59=%60, %61=%67}
     %69 = utcFromCivil(%68) -> bb25;
   }
   bb25 {

--- a/corpus/bir/library/subset2/timezone-invalid-v.txt
+++ b/corpus/bir/library/subset2/timezone-invalid-v.txt
@@ -63,7 +63,7 @@ main() -> nil|error{
     %25 = ConstantLoad 10
     %26 = ConstantLoad minute
     %27 = ConstantLoad 0
-    %28 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%18=%19, %20=%21, %22=%23, %24=%25, %26=%27}
+    %28 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%18=%19, %20=%21, %22=%23, %24=%25, %26=%27}
     civil = %28;
     %30 = utcFromCivil(utcZone,civil) -> bb12;
   }

--- a/corpus/bir/subset3/03-function/call-v.txt
+++ b/corpus/bir/subset3/03-function/call-v.txt
@@ -13,7 +13,7 @@ main() -> nil{
 test1() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     x = %2;
     %4 = foo(x) -> bb1;
   }
@@ -32,7 +32,7 @@ test1() -> nil{
 test2() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     x = %2;
     %4 = foo(x) -> bb1;
   }
@@ -70,7 +70,7 @@ test2() -> nil{
     return;
   }
 }
-foo([nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]) -> [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]{
+foo([any...]) -> [any...]{
   bb0 {
     %0 = x;
     return;

--- a/corpus/bir/subset3/03-function/direct-call-v.txt
+++ b/corpus/bir/subset3/03-function/direct-call-v.txt
@@ -13,7 +13,7 @@ main() -> nil{
 test1() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     x = %2;
     %4 = foo(x) -> bb1;
   }
@@ -32,7 +32,7 @@ test1() -> nil{
 test2() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     x = %2;
     %4 = foo(x) -> bb1;
   }
@@ -70,7 +70,7 @@ test2() -> nil{
     return;
   }
 }
-foo([nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]) -> [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]{
+foo([any...]) -> [any...]{
   bb0 {
     %0 = x;
     return;

--- a/corpus/bir/subset3/03-list/11-p.txt
+++ b/corpus/bir/subset3/03-list/11-p.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 1
     val = %4;

--- a/corpus/bir/subset3/03-list/12-v.txt
+++ b/corpus/bir/subset3/03-list/12-v.txt
@@ -6,7 +6,7 @@ main() -> nil{
     %3 = ConstantLoad 11
     %4 = unknown %3;
     %5 = ConstantLoad 3
-    %6 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%5]{%1, %2, %4}
+    %6 = newArray [any...][%5]{%1, %2, %4}
     v = %6;
     %8 = ConstantLoad 0
     i = %8;

--- a/corpus/bir/subset3/03-list/13-p.txt
+++ b/corpus/bir/subset3/03-list/13-p.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 1
     %5 = unknown %4;

--- a/corpus/bir/subset3/03-list/14-v.txt
+++ b/corpus/bir/subset3/03-list/14-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 1234567890123456789
     %3 = ConstantLoad true
     %4 = ConstantLoad 3
-    %5 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%4]{%1, %2, %3}
+    %5 = newArray [any...][%4]{%1, %2, %3}
     v = %5;
     %8 = ConstantLoad 2
     %7 = v[%8];

--- a/corpus/bir/subset3/03-list/16-v.txt
+++ b/corpus/bir/subset3/03-list/16-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad false
     %3 = ConstantLoad <nil>
     %4 = ConstantLoad 3
-    %5 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%4]{%1, %2, %3}
+    %5 = newArray [any...][%4]{%1, %2, %3}
     v = %5;
     %7 = length(v) -> bb1;
   }

--- a/corpus/bir/subset3/03-list/18-v.txt
+++ b/corpus/bir/subset3/03-list/18-v.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 0
     %5 = %4;

--- a/corpus/bir/subset3/03-list/19-v.txt
+++ b/corpus/bir/subset3/03-list/19-v.txt
@@ -6,7 +6,7 @@ main() -> nil{
     %3 = ConstantLoad 3
     %4 = ConstantLoad 4
     %5 = ConstantLoad 4
-    %6 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%5]{%1, %2, %3, %4}
+    %6 = newArray [any...][%5]{%1, %2, %3, %4}
     v = %6;
     %8 = ConstantLoad 5
     %9 = %8;

--- a/corpus/bir/subset3/03-list/2-p.txt
+++ b/corpus/bir/subset3/03-list/2-p.txt
@@ -6,7 +6,7 @@ main() -> nil{
     %3 = ConstantLoad 11
     %4 = unknown %3;
     %5 = ConstantLoad 3
-    %6 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%5]{%1, %2, %4}
+    %6 = newArray [any...][%5]{%1, %2, %4}
     v = %6;
     %8 = ConstantLoad 3
     i = %8;

--- a/corpus/bir/subset3/03-list/20-v.txt
+++ b/corpus/bir/subset3/03-list/20-v.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = push(v,v) -> bb1;
   }

--- a/corpus/bir/subset3/03-list/21-v.txt
+++ b/corpus/bir/subset3/03-list/21-v.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad 1
     %2 = ConstantLoad 1
-    %3 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%2]{%1}
+    %3 = newArray [any...][%2]{%1}
     v = %3;
     %5 = ConstantLoad 2
     n = %5;

--- a/corpus/bir/subset3/03-list/22-v.txt
+++ b/corpus/bir/subset3/03-list/22-v.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 1
     %5 = ConstantLoad 0

--- a/corpus/bir/subset3/03-list/23-v.txt
+++ b/corpus/bir/subset3/03-list/23-v.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 2
     %5 = ConstantLoad 1

--- a/corpus/bir/subset3/03-list/24-v.txt
+++ b/corpus/bir/subset3/03-list/24-v.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 0
     i = %4;

--- a/corpus/bir/subset3/03-list/5-p.txt
+++ b/corpus/bir/subset3/03-list/5-p.txt
@@ -6,7 +6,7 @@ main() -> nil{
     %3 = ConstantLoad 11
     %4 = unknown %3;
     %5 = ConstantLoad 3
-    %6 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%5]{%1, %2, %4}
+    %6 = newArray [any...][%5]{%1, %2, %4}
     v = %6;
     %8 = ConstantLoad 1
     %9 = unknown %8;

--- a/corpus/bir/subset3/03-list/8-p.txt
+++ b/corpus/bir/subset3/03-list/8-p.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 0
     i = %4;

--- a/corpus/bir/subset3/03-list/9-v.txt
+++ b/corpus/bir/subset3/03-list/9-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 2
     %3 = ConstantLoad false
     %4 = ConstantLoad 3
-    %5 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%4]{%1, %2, %3}
+    %5 = newArray [any...][%4]{%1, %2, %3}
     v = %5;
     %7 = foo(v) -> bb1;
   }
@@ -13,7 +13,7 @@ main() -> nil{
     return;
   }
 }
-foo([nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]) -> nil{
+foo([any...]) -> nil{
   bb0 {
     %2 = println(v) -> bb1;
   }

--- a/corpus/bir/subset3/03-loop/list-1-v.txt
+++ b/corpus/bir/subset3/03-loop/list-1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 2
     %3 = ConstantLoad 3
     %4 = ConstantLoad 3
-    %5 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%4]{%1, %2, %3}
+    %5 = newArray [any...][%4]{%1, %2, %3}
     arr = %5;
     $desugar$0 = arr;
     %8 = ConstantLoad 0

--- a/corpus/bir/subset4/04-int/hex-v.txt
+++ b/corpus/bir/subset4/04-int/hex-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 229354698
     %3 = ConstantLoad 2898971338
     %4 = ConstantLoad 3
-    %5 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%4]{%1, %2, %3}
+    %5 = newArray [any...][%4]{%1, %2, %3}
     answers = %5;
     %8 = ConstantLoad 1
     %7 = answers[%8];

--- a/corpus/bir/subset4/04-map/11-v.txt
+++ b/corpus/bir/subset4/04-map/11-v.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad hello
     s = %1;
-    %3 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %3 = newMap {| any... |}{}
     m = %3;
     %5 = ConstantLoad 42
     m[s] = %5;

--- a/corpus/bir/subset4/04-map/12-v.txt
+++ b/corpus/bir/subset4/04-map/12-v.txt
@@ -1,7 +1,7 @@
 module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
-    %1 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %1 = newMap {| any... |}{}
     m = %1;
     %3 = ConstantLoad five
     %4 = ConstantLoad 5
@@ -20,13 +20,13 @@ main() -> nil{
     return;
   }
 }
-put({| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |},string,int) -> nil{
+put({| any... |},string,int) -> nil{
   bb0 {
     m[k] = v;
     return;
   }
 }
-get({| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |},string) -> int{
+get({| any... |},string) -> int{
   bb0 {
     %3 = m[k];
     %4 = <int>(%3)

--- a/corpus/bir/subset4/04-map/4-v.txt
+++ b/corpus/bir/subset4/04-map/4-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad true
     %3 = ConstantLoad bar
     %4 = ConstantLoad <nil>
-    %5 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%2, %3=%4}
+    %5 = newMap {| any... |}{%1=%2, %3=%4}
     m = %5;
     %7 = println(m) -> bb1;
   }

--- a/corpus/bir/subset4/04-map/5-v.txt
+++ b/corpus/bir/subset4/04-map/5-v.txt
@@ -13,7 +13,7 @@ main() -> nil{
     %10 = ConstantLoad y
     %11 = ConstantLoad 2
     %12 = newMap mapping{%8=%9, %10=%11}
-    %13 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%6, %7=%12}
+    %13 = newMap {| any... |}{%1=%6, %7=%12}
     m = %13;
     %15 = println(m) -> bb1;
   }

--- a/corpus/bir/subset4/04-map/6-v.txt
+++ b/corpus/bir/subset4/04-map/6-v.txt
@@ -1,7 +1,7 @@
 module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
-    %1 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %1 = newMap {| any... |}{}
     m = %1;
     x = m;
     %4 = println(x) -> bb1;

--- a/corpus/bir/subset4/04-map/7-v.txt
+++ b/corpus/bir/subset4/04-map/7-v.txt
@@ -23,10 +23,10 @@ main() -> nil{
     return;
   }
 }
-wrap(any) -> {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{
+wrap(any) -> {| any... |}{
   bb0 {
     %2 = ConstantLoad value
-    %3 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%2=x}
+    %3 = newMap {| any... |}{%2=x}
     %0 = %3;
     return;
   }

--- a/corpus/bir/subset4/04-map/8-v.txt
+++ b/corpus/bir/subset4/04-map/8-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 17
     %3 = ConstantLoad bar
     %4 = ConstantLoad 42
-    %5 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%2, %3=%4}
+    %5 = newMap {| any... |}{%1=%2, %3=%4}
     m = %5;
     %8 = ConstantLoad foo
     %7 = m[%8];

--- a/corpus/bir/subset4/04-map/simple-v.txt
+++ b/corpus/bir/subset4/04-map/simple-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 1
     %3 = ConstantLoad b
     %4 = ConstantLoad b
-    %5 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%2, %3=%4}
+    %5 = newMap {| any... |}{%1=%2, %3=%4}
     foo = %5;
     %7 = println(foo) -> bb1;
   }

--- a/corpus/bir/subset5/05-record/field-access-1-v.txt
+++ b/corpus/bir/subset5/05-record/field-access-1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 1
     %3 = ConstantLoad y
     %4 = ConstantLoad 2
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %8 = ConstantLoad x
     %7 = r[%8];

--- a/corpus/bir/subset5/05-record/field-access-2-v.txt
+++ b/corpus/bir/subset5/05-record/field-access-2-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 1
     %3 = ConstantLoad y
     %4 = ConstantLoad 2
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %8 = ConstantLoad x
     %7 = r[%8];

--- a/corpus/bir/subset6/06-intersect/mapping15-v.txt
+++ b/corpus/bir/subset6/06-intersect/mapping15-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 2
     %5 = ConstantLoad l3
     %6 = ConstantLoad l
-    %7 = newMap {| l1: int:Unsigned8, l2: 2, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| l1: int:Unsigned8, l2: 2, anydata... |}{%1=%2, %3=%4, %5=%6}
     r = %7;
     %10 = ConstantLoad l1
     %9 = r[%10];

--- a/corpus/bir/subset6/06-intersect/mapping2-v.txt
+++ b/corpus/bir/subset6/06-intersect/mapping2-v.txt
@@ -3,9 +3,9 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad l1
     %2 = ConstantLoad 1
-    %3 = newMap {| l1: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2}
+    %3 = newMap {| l1: int, anydata... |}{%1=%2}
     r = %3;
-    %5 = r is {| l1: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %5 = r is {| l1: int, anydata... |}
     %5 ? bb1 : bb3;
   }
   bb1 {

--- a/corpus/bir/subset6/06-map/foreach1-v.txt
+++ b/corpus/bir/subset6/06-map/foreach1-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 2
     %5 = ConstantLoad c
     %6 = ConstantLoad 3
-    %7 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| any... |}{%1=%2, %3=%4, %5=%6}
     m = %7;
     $desugar$0 = m;
     %10 = keys($desugar$0) -> bb1;

--- a/corpus/bir/subset6/06-map/foreach9-v.txt
+++ b/corpus/bir/subset6/06-map/foreach9-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad John
     %3 = ConstantLoad age
     %4 = ConstantLoad 30
-    %5 = newMap {| name: string, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| name: string, anydata... |}{%1=%2, %3=%4}
     r = %5;
     $desugar$0 = r;
     %8 = keys($desugar$0) -> bb1;

--- a/corpus/bir/subset6/06-map/length2-v.txt
+++ b/corpus/bir/subset6/06-map/length2-v.txt
@@ -9,9 +9,9 @@ main() -> nil{
     %6 = ConstantLoad Saturday
     %7 = ConstantLoad Sunday
     %8 = ConstantLoad 7
-    %9 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%8]{%1, %2, %3, %4, %5, %6, %7}
+    %9 = newArray [any...][%8]{%1, %2, %3, %4, %5, %6, %7}
     days = %9;
-    %11 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %11 = newMap {| any... |}{}
     dayNumber = %11;
     %13 = ConstantLoad 0
     i = %13;

--- a/corpus/bir/subset6/06-map/lib1-v.txt
+++ b/corpus/bir/subset6/06-map/lib1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad a
     %3 = ConstantLoad b
     %4 = ConstantLoad b
-    %5 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%2, %3=%4}
+    %5 = newMap {| any... |}{%1=%2, %3=%4}
     foo = %5;
     %7 = length(foo) -> bb1;
   }

--- a/corpus/bir/subset6/06-map/lib2-v.txt
+++ b/corpus/bir/subset6/06-map/lib2-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad a
     %3 = ConstantLoad b
     %4 = ConstantLoad b
-    %5 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%2, %3=%4}
+    %5 = newMap {| any... |}{%1=%2, %3=%4}
     foo = %5;
     %7 = length(foo) -> bb1;
   }

--- a/corpus/bir/subset7/07-function/assign25-v.txt
+++ b/corpus/bir/subset7/07-function/assign25-v.txt
@@ -19,7 +19,7 @@ main() -> nil{
     return;
   }
 }
-foo({| x: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},[{| x: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}...]...) -> int{
+foo({| x: int, anydata... |},[{| x: int, anydata... |}...]...) -> int{
   bb0 {
     %4 = ConstantLoad x
     %3 = init[%4];

--- a/corpus/bir/subset7/07-function/intersection10-v.txt
+++ b/corpus/bir/subset7/07-function/intersection10-v.txt
@@ -9,7 +9,7 @@ main() -> nil{
     %6 = ConstantLoad 20
     %7 = ConstantLoad colour
     %8 = ConstantLoad red
-    %9 = newMap {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%3=%4, %5=%6, %7=%8}
+    %9 = newMap {| colour: string, x: int, y: int, anydata... |}{%3=%4, %5=%6, %7=%8}
     cp = %9;
     %11 = ConstantLoad 10
     %12 = %11;
@@ -26,7 +26,7 @@ main() -> nil{
     %19 = ConstantLoad 10
     %20 = ConstantLoad y
     %21 = ConstantLoad 20
-    %22 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%18=%19, %20=%21}
+    %22 = newMap {| x: int, y: int, anydata... |}{%18=%19, %20=%21}
     p = %22;
     %24 = ConstantLoad 10
     %25 = %24;
@@ -42,9 +42,9 @@ main() -> nil{
     return;
   }
 }
-moveFn({| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},int,int) -> {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+moveFn({| x: int, y: int, anydata... |},int,int) -> {| colour: string, x: int, y: int, anydata... |}{
   bb0 {
-    %4 = p is {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %4 = p is {| colour: string, x: int, y: int, anydata... |}
     %4 ? bb1 : bb3;
   }
   bb1 {
@@ -74,13 +74,13 @@ moveFn({| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|b
     %8 = movedPoint[%9];
     %10 = ConstantLoad colour
     %11 = ConstantLoad white
-    %12 = newMap {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%4=%5, %7=%8, %10=%11}
+    %12 = newMap {| colour: string, x: int, y: int, anydata... |}{%4=%5, %7=%8, %10=%11}
     (1, %0) = %12;
     PopScopeFrame
     return;
   }
 }
-movePoint({| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},int,int) -> {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+movePoint({| x: int, y: int, anydata... |},int,int) -> {| x: int, y: int, anydata... |}{
   bb0 {
     %6 = ConstantLoad x
     %5 = p[%6];
@@ -100,7 +100,7 @@ movePoint({| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[ni
     return;
   }
 }
-moveColoredPoint({| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},int,int) -> {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+moveColoredPoint({| colour: string, x: int, y: int, anydata... |},int,int) -> {| colour: string, x: int, y: int, anydata... |}{
   bb0 {
     %6 = ConstantLoad colour
     %5 = p[%6];

--- a/corpus/bir/subset8/08-anydata/arr1-v.txt
+++ b/corpus/bir/subset8/08-anydata/arr1-v.txt
@@ -12,7 +12,7 @@ main() -> nil{
   }
   bb1 {
     %9 = ConstantLoad 2
-    %10 = newArray [nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table...][%9]{a, a}
+    %10 = newArray [anydata...][%9]{a, a}
     b = %10;
     val = b;
     %12 = println(val) -> bb2;

--- a/corpus/bir/subset8/08-anydata/map2-v.txt
+++ b/corpus/bir/subset8/08-anydata/map2-v.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad a
     %2 = ConstantLoad 5
-    %3 = newMap {| nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2}
+    %3 = newMap {| anydata... |}{%1=%2}
     m = %3;
     b = m;
     %6 = ConstantLoad a

--- a/corpus/bir/subset8/08-bug/whilenarrow1-v.txt
+++ b/corpus/bir/subset8/08-bug/whilenarrow1-v.txt
@@ -8,8 +8,8 @@ main() -> nil{
     %5 = ConstantLoad 20
     %6 = ConstantLoad next
     %7 = ConstantLoad <nil>
-    %8 = newMap {| i: int, next: nil|..., nil|boolean|int|float|decimal|string|regexp|xml|...|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%4=%5, %6=%7}
-    %9 = newMap {| i: int, next: nil|..., nil|boolean|int|float|decimal|string|regexp|xml|...|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%8}
+    %8 = newMap {| i: int, next: nil|..., anydata... |}{%4=%5, %6=%7}
+    %9 = newMap {| i: int, next: nil|..., anydata... |}{%1=%2, %3=%8}
     l = %9;
     %11 = sum(l) -> bb1;
   }
@@ -21,7 +21,7 @@ main() -> nil{
     return;
   }
 }
-sum(nil|{| i: int, next: nil|..., nil|boolean|int|float|decimal|string|regexp|xml|...|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}) -> int{
+sum(nil|{| i: int, next: nil|..., anydata... |}) -> int{
   bb0 {
     temp = intList;
     %3 = ConstantLoad 0

--- a/corpus/bir/subset8/08-bytearr/2-p.txt
+++ b/corpus/bir/subset8/08-bytearr/2-p.txt
@@ -10,7 +10,7 @@ main() -> nil{
     return;
   }
 }
-f([nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]) -> nil{
+f([any...]) -> nil{
   bb0 {
     %2 = ConstantLoad 2
     b = %2;

--- a/corpus/bir/subset8/08-bytearr/3-p.txt
+++ b/corpus/bir/subset8/08-bytearr/3-p.txt
@@ -10,7 +10,7 @@ main() -> nil{
     return;
   }
 }
-f([nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]) -> nil{
+f([any...]) -> nil{
   bb0 {
     %2 = ConstantLoad 1
     %3 = %2;

--- a/corpus/bir/subset8/08-decimal/any1-v.txt
+++ b/corpus/bir/subset8/08-decimal/any1-v.txt
@@ -27,7 +27,7 @@ main() -> nil{
   bb4 {
     %11 = ConstantLoad a
     %12 = ConstantLoad 2.345E+32
-    %13 = newMap {| a: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, never... |}{%11=%12}
+    %13 = newMap {| a: any, never... |}{%11=%12}
     r = %13;
     %16 = ConstantLoad a
     %15 = r[%16];
@@ -38,7 +38,7 @@ main() -> nil{
     %19 = ConstantLoad 1.2E+2
     %20 = ConstantLoad 1.21E+3
     %21 = ConstantLoad 3
-    %22 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%21]{%18, %19, %20}
+    %22 = newArray [any...][%21]{%18, %19, %20}
     arr = %22;
     %25 = ConstantLoad 0
     %24 = arr[%25];
@@ -58,13 +58,13 @@ main() -> nil{
     %33 = ConstantLoad 1.1
     %34 = ConstantLoad 2.1E+2
     %35 = ConstantLoad 2
-    %36 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%35]{%33, %34}
+    %36 = newArray [any...][%35]{%33, %34}
     %37 = ConstantLoad 4.2E+3
     %38 = ConstantLoad 3E+2
     %39 = ConstantLoad 2
-    %40 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%39]{%37, %38}
+    %40 = newArray [any...][%39]{%37, %38}
     %41 = ConstantLoad 2
-    %42 = newArray [[nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]...][%41]{%36, %40}
+    %42 = newArray [[any...]...][%41]{%36, %40}
     arr1 = %42;
     %45 = ConstantLoad 0
     %44 = arr1[%45];
@@ -88,7 +88,7 @@ main() -> nil{
     %57 = ConstantLoad 1.2
     %58 = ConstantLoad x2
     %59 = ConstantLoad 1.2E+2
-    %60 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%56=%57, %58=%59}
+    %60 = newMap {| any... |}{%56=%57, %58=%59}
     m1 = %60;
     %63 = ConstantLoad x1
     %62 = m1[%63];
@@ -104,12 +104,12 @@ main() -> nil{
     %69 = ConstantLoad 1
     %70 = ConstantLoad 2
     %71 = ConstantLoad 2
-    %72 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%71]{%69, %70}
-    %73 = newMap {| [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]... |}{%68=%72}
+    %72 = newArray [any...][%71]{%69, %70}
+    %73 = newMap {| [any...]... |}{%68=%72}
     m2 = %73;
     %76 = ConstantLoad x1
     %75 = m2[%76];
-    %77 = <[nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]>(%75)
+    %77 = <[any...]>(%75)
     x = %77;
     %80 = ConstantLoad 0
     %79 = x[%80];

--- a/corpus/bir/subset8/08-decimal/record1-v.txt
+++ b/corpus/bir/subset8/08-decimal/record1-v.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad d
     %2 = ConstantLoad 1.2E+34
-    %3 = newMap {| d: decimal, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2}
+    %3 = newMap {| d: decimal, anydata... |}{%1=%2}
     r1 = %3;
     %5 = println(r1) -> bb1;
   }
@@ -28,8 +28,8 @@ main() -> nil{
     %18 = ConstantLoad d
     %19 = ConstantLoad d1
     %20 = ConstantLoad 23
-    %21 = newMap {| d1: decimal, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%19=%20}
-    %22 = newMap {| d: {| d1: decimal, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%18=%21}
+    %21 = newMap {| d1: decimal, anydata... |}{%19=%20}
+    %22 = newMap {| d: {| d1: decimal, anydata... |}, anydata... |}{%18=%21}
     r3 = %22;
     %24 = println(r3) -> bb4;
   }

--- a/corpus/bir/subset8/08-exact/array1-p.txt
+++ b/corpus/bir/subset8/08-exact/array1-p.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = newArray [int...][%1]{}
     v1 = %2;
     %4 = ConstantLoad 0
-    %5 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%4]{}
+    %5 = newArray [any...][%4]{}
     v2 = %5;
     %7 = ConstantLoad 0
     v2[%7] = v1;

--- a/corpus/bir/subset8/08-exact/map1-p.txt
+++ b/corpus/bir/subset8/08-exact/map1-p.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = newMap {| int... |}{}
     m1 = %1;
-    %3 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %3 = newMap {| any... |}{}
     m2 = %3;
     %5 = ConstantLoad x
     m2[%5] = m1;

--- a/corpus/bir/subset8/08-exact/push1-p.txt
+++ b/corpus/bir/subset8/08-exact/push1-p.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = newArray [int...][%1]{}
     v1 = %2;
     %4 = ConstantLoad 0
-    %5 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%4]{}
+    %5 = newArray [any...][%4]{}
     v2 = %5;
     %7 = push(v2,v1) -> bb1;
   }

--- a/corpus/bir/subset8/08-exact/record1-p.txt
+++ b/corpus/bir/subset8/08-exact/record1-p.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad x
     %2 = ConstantLoad <nil>
-    %3 = newMap {| x: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, never... |}{%1=%2}
+    %3 = newMap {| x: any, never... |}{%1=%2}
     r = %3;
     %5 = ConstantLoad 0
     %6 = newArray [int...][%5]{}

--- a/corpus/bir/subset8/08-function/call-v.txt
+++ b/corpus/bir/subset8/08-function/call-v.txt
@@ -13,7 +13,7 @@ main() -> nil{
 test1() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     x = %2;
     %4 = foo(x) -> bb1;
   }
@@ -32,7 +32,7 @@ test1() -> nil{
 test2() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     x = %2;
     %4 = foo(x) -> bb1;
   }
@@ -48,7 +48,7 @@ test2() -> nil{
     return;
   }
 }
-foo([nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]) -> [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]{
+foo([any...]) -> [any...]{
   bb0 {
     %0 = x;
     return;

--- a/corpus/bir/subset8/08-function/incl-record-param-1-v.txt
+++ b/corpus/bir/subset8/08-function/incl-record-param-1-v.txt
@@ -1,5 +1,5 @@
 module $anon.. v 0.0.0;
-foo(int,{| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}) -> int{
+foo(int,{| bar: int, foo: int, anydata... |}) -> int{
   bb0 {
     %4 = base;
     %7 = ConstantLoad foo
@@ -19,7 +19,7 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad 1
     %2 = %1;
-    %3 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %3 = newMap {| bar: int, foo: int, anydata... |}{} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %4 = foo(%2,%3) -> bb1;
   }
   bb1 {
@@ -31,7 +31,7 @@ main() -> nil{
     %8 = %7;
     %9 = ConstantLoad foo
     %10 = ConstantLoad 10
-    %11 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%9=%10} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %11 = newMap {| bar: int, foo: int, anydata... |}{%9=%10} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %12 = foo(%8,%11) -> bb3;
   }
   bb3 {
@@ -43,7 +43,7 @@ main() -> nil{
     %16 = %15;
     %17 = ConstantLoad bar
     %18 = ConstantLoad 5
-    %19 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%17=%18} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %19 = newMap {| bar: int, foo: int, anydata... |}{%17=%18} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %20 = foo(%16,%19) -> bb5;
   }
   bb5 {
@@ -57,7 +57,7 @@ main() -> nil{
     %26 = ConstantLoad 1
     %27 = ConstantLoad bar
     %28 = ConstantLoad 5
-    %29 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%25=%26, %27=%28} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %29 = newMap {| bar: int, foo: int, anydata... |}{%25=%26, %27=%28} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %30 = foo(%24,%29) -> bb7;
   }
   bb7 {
@@ -71,7 +71,7 @@ main() -> nil{
     %36 = ConstantLoad 1
     %37 = ConstantLoad bar
     %38 = ConstantLoad 5
-    %39 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%35=%36, %37=%38} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %39 = newMap {| bar: int, foo: int, anydata... |}{%35=%36, %37=%38} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %40 = foo(%34,%39) -> bb9;
   }
   bb9 {

--- a/corpus/bir/subset8/08-function/incl-record-param-2-v.txt
+++ b/corpus/bir/subset8/08-function/incl-record-param-2-v.txt
@@ -1,5 +1,5 @@
 module $anon.. v 0.0.0;
-foo(int,{| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}) -> int{
+foo(int,{| bar: int, foo: int, anydata... |}) -> int{
   bb0 {
     %4 = base;
     %7 = ConstantLoad foo
@@ -25,7 +25,7 @@ main() -> nil{
     %6 = ConstantLoad 1
     %7 = ConstantLoad bar
     %8 = ConstantLoad 5
-    %9 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%5=%6, %7=%8} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %9 = newMap {| bar: int, foo: int, anydata... |}{%5=%6, %7=%8} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %10 = f(%4,%9) -> bb1;
   }
   bb1 {

--- a/corpus/bir/subset8/08-function/incl-record-param-5-v.txt
+++ b/corpus/bir/subset8/08-function/incl-record-param-5-v.txt
@@ -1,5 +1,5 @@
 module $anon.. v 0.0.0;
-foo(int,{| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},{| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}) -> int{
+foo(int,{| foo: int, anydata... |},{| bar: int, anydata... |}) -> int{
   bb0 {
     %5 = base;
     %8 = ConstantLoad foo
@@ -19,8 +19,8 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad 1
     %2 = %1;
-    %3 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{foo=$anon/.:$desugar$0}
-    %4 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{bar=$anon/.:$desugar$1}
+    %3 = newMap {| foo: int, anydata... |}{} defaults{foo=$anon/.:$desugar$0}
+    %4 = newMap {| bar: int, anydata... |}{} defaults{bar=$anon/.:$desugar$1}
     %5 = foo(%2,%3,%4) -> bb1;
   }
   bb1 {
@@ -32,8 +32,8 @@ main() -> nil{
     %9 = %8;
     %10 = ConstantLoad foo
     %11 = ConstantLoad 10
-    %12 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%10=%11} defaults{foo=$anon/.:$desugar$0}
-    %13 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{bar=$anon/.:$desugar$1}
+    %12 = newMap {| foo: int, anydata... |}{%10=%11} defaults{foo=$anon/.:$desugar$0}
+    %13 = newMap {| bar: int, anydata... |}{} defaults{bar=$anon/.:$desugar$1}
     %14 = foo(%9,%12,%13) -> bb3;
   }
   bb3 {
@@ -43,10 +43,10 @@ main() -> nil{
   bb4 {
     %17 = ConstantLoad 1
     %18 = %17;
-    %19 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{foo=$anon/.:$desugar$0}
+    %19 = newMap {| foo: int, anydata... |}{} defaults{foo=$anon/.:$desugar$0}
     %20 = ConstantLoad bar
     %21 = ConstantLoad 5
-    %22 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%20=%21} defaults{bar=$anon/.:$desugar$1}
+    %22 = newMap {| bar: int, anydata... |}{%20=%21} defaults{bar=$anon/.:$desugar$1}
     %23 = foo(%18,%19,%22) -> bb5;
   }
   bb5 {
@@ -58,10 +58,10 @@ main() -> nil{
     %27 = %26;
     %28 = ConstantLoad foo
     %29 = ConstantLoad 1
-    %30 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%28=%29} defaults{foo=$anon/.:$desugar$0}
+    %30 = newMap {| foo: int, anydata... |}{%28=%29} defaults{foo=$anon/.:$desugar$0}
     %31 = ConstantLoad bar
     %32 = ConstantLoad 5
-    %33 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%31=%32} defaults{bar=$anon/.:$desugar$1}
+    %33 = newMap {| bar: int, anydata... |}{%31=%32} defaults{bar=$anon/.:$desugar$1}
     %34 = foo(%27,%30,%33) -> bb7;
   }
   bb7 {
@@ -73,10 +73,10 @@ main() -> nil{
     %38 = %37;
     %39 = ConstantLoad foo
     %40 = ConstantLoad 1
-    %41 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%39=%40} defaults{foo=$anon/.:$desugar$0}
+    %41 = newMap {| foo: int, anydata... |}{%39=%40} defaults{foo=$anon/.:$desugar$0}
     %42 = ConstantLoad bar
     %43 = ConstantLoad 5
-    %44 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%42=%43} defaults{bar=$anon/.:$desugar$1}
+    %44 = newMap {| bar: int, anydata... |}{%42=%43} defaults{bar=$anon/.:$desugar$1}
     %45 = foo(%38,%41,%44) -> bb9;
   }
   bb9 {

--- a/corpus/bir/subset8/08-function/intersection10-v.txt
+++ b/corpus/bir/subset8/08-function/intersection10-v.txt
@@ -9,7 +9,7 @@ main() -> nil{
     %6 = ConstantLoad 20
     %7 = ConstantLoad colour
     %8 = ConstantLoad red
-    %9 = newMap {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%3=%4, %5=%6, %7=%8}
+    %9 = newMap {| colour: string, x: int, y: int, anydata... |}{%3=%4, %5=%6, %7=%8}
     cp = %9;
     %11 = ConstantLoad 10
     %12 = %11;
@@ -26,7 +26,7 @@ main() -> nil{
     %19 = ConstantLoad 10
     %20 = ConstantLoad y
     %21 = ConstantLoad 20
-    %22 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%18=%19, %20=%21}
+    %22 = newMap {| x: int, y: int, anydata... |}{%18=%19, %20=%21}
     p = %22;
     %24 = ConstantLoad 10
     %25 = %24;
@@ -42,9 +42,9 @@ main() -> nil{
     return;
   }
 }
-moveFn({| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},int,int) -> {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+moveFn({| x: int, y: int, anydata... |},int,int) -> {| colour: string, x: int, y: int, anydata... |}{
   bb0 {
-    %4 = p is {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %4 = p is {| colour: string, x: int, y: int, anydata... |}
     %4 ? bb1 : bb3;
   }
   bb1 {
@@ -74,13 +74,13 @@ moveFn({| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|b
     %8 = movedPoint[%9];
     %10 = ConstantLoad colour
     %11 = ConstantLoad white
-    %12 = newMap {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%4=%5, %7=%8, %10=%11}
+    %12 = newMap {| colour: string, x: int, y: int, anydata... |}{%4=%5, %7=%8, %10=%11}
     (1, %0) = %12;
     PopScopeFrame
     return;
   }
 }
-movePoint({| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},int,int) -> {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+movePoint({| x: int, y: int, anydata... |},int,int) -> {| x: int, y: int, anydata... |}{
   bb0 {
     %6 = ConstantLoad x
     %5 = p[%6];
@@ -100,7 +100,7 @@ movePoint({| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[ni
     return;
   }
 }
-moveColoredPoint({| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},int,int) -> {| colour: string, x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+moveColoredPoint({| colour: string, x: int, y: int, anydata... |},int,int) -> {| colour: string, x: int, y: int, anydata... |}{
   bb0 {
     %6 = ConstantLoad colour
     %5 = p[%6];

--- a/corpus/bir/subset8/08-inclusive/compoundassign1-v.txt
+++ b/corpus/bir/subset8/08-inclusive/compoundassign1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 1.5
     %3 = ConstantLoad n
     %4 = ConstantLoad 5
-    %5 = newMap {| n: int, x: float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| n: int, x: float, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %7 = ConstantLoad x
     %8 = r[%7];

--- a/corpus/bir/subset8/08-inclusive/construct1-v.txt
+++ b/corpus/bir/subset8/08-inclusive/construct1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 17
     %3 = ConstantLoad y
     %4 = ConstantLoad 42
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %7 = ConstantLoad x
     s = %7;

--- a/corpus/bir/subset8/08-inclusive/construct2-v.txt
+++ b/corpus/bir/subset8/08-inclusive/construct2-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 1
     %5 = ConstantLoad z
     %6 = ConstantLoad 10
-    %7 = newMap {| x: int, y: float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| x: int, y: float, anydata... |}{%1=%2, %3=%4, %5=%6}
     r = %7;
     %9 = ConstantLoad z
     s = %9;

--- a/corpus/bir/subset8/08-inclusive/construct3-v.txt
+++ b/corpus/bir/subset8/08-inclusive/construct3-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 17
     %3 = ConstantLoad y
     %4 = ConstantLoad 1
-    %5 = newMap {| x: int, y: float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: float, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %8 = ConstantLoad x
     %7 = r[%8];

--- a/corpus/bir/subset8/08-inclusive/construct6-v.txt
+++ b/corpus/bir/subset8/08-inclusive/construct6-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 2
     %5 = ConstantLoad w
     %6 = ConstantLoad 3
-    %7 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4, %5=%6}
     r = %7;
     %10 = ConstantLoad w
     %9 = r[%10];

--- a/corpus/bir/subset8/08-inclusive/fieldexpr1-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldexpr1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 44
     %3 = ConstantLoad y
     %4 = ConstantLoad 88
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %8 = ConstantLoad x
     %7 = p[%8];

--- a/corpus/bir/subset8/08-inclusive/fieldexpr4-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldexpr4-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 88
     %5 = ConstantLoad z
     %6 = ConstantLoad 48
-    %7 = newMap {| x: int, y: int, z: nil|int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| x: int, y: int, z: nil|int, anydata... |}{%1=%2, %3=%4, %5=%6}
     p = %7;
     %10 = ConstantLoad z
     %9 = p[%10];

--- a/corpus/bir/subset8/08-inclusive/fieldexpr5-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldexpr5-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 1.5
     %5 = ConstantLoad booleanField
     %6 = ConstantLoad false
-    %7 = newMap {| booleanField: boolean, floatField: float, intField: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| booleanField: boolean, floatField: float, intField: int, anydata... |}{%1=%2, %3=%4, %5=%6}
     r = %7;
     %11 = ConstantLoad floatField
     %10 = r[%11];

--- a/corpus/bir/subset8/08-inclusive/fieldexpr6-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldexpr6-v.txt
@@ -14,13 +14,13 @@ main() -> nil{
     return;
   }
 }
-origin() -> {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+origin() -> {| x: int, y: int, anydata... |}{
   bb0 {
     %1 = ConstantLoad x
     %2 = ConstantLoad 0
     %3 = ConstantLoad y
     %4 = ConstantLoad 0
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %0 = p;
     return;

--- a/corpus/bir/subset8/08-inclusive/fieldexpr7-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldexpr7-v.txt
@@ -12,7 +12,7 @@ main() -> nil{
     return;
   }
 }
-origin() -> {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+origin() -> {| x: int, y: int, anydata... |}{
   bb0 {
     %1 = ConstantLoad x
     %2 = ConstantLoad 0
@@ -20,7 +20,7 @@ origin() -> {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[
     %4 = ConstantLoad 0
     %5 = ConstantLoad z
     %6 = ConstantLoad 10
-    %7 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4, %5=%6}
     p = %7;
     %0 = p;
     return;

--- a/corpus/bir/subset8/08-inclusive/fieldexpr8-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldexpr8-v.txt
@@ -12,13 +12,13 @@ main() -> nil{
     return;
   }
 }
-origin() -> {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{
+origin() -> {| x: int, y: int, anydata... |}{
   bb0 {
     %1 = ConstantLoad x
     %2 = ConstantLoad 0
     %3 = ConstantLoad y
     %4 = ConstantLoad 0
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %0 = p;
     return;

--- a/corpus/bir/subset8/08-inclusive/fieldlvalue1-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldlvalue1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 44
     %3 = ConstantLoad y
     %4 = ConstantLoad 88
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %7 = ConstantLoad 22
     %8 = ConstantLoad x

--- a/corpus/bir/subset8/08-inclusive/fieldlvalue3-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldlvalue3-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 44
     %3 = ConstantLoad y
     %4 = ConstantLoad 88
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %7 = ConstantLoad x
     %8 = p[%7];

--- a/corpus/bir/subset8/08-inclusive/fieldlvalue4-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldlvalue4-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 3
     %3 = ConstantLoad y
     %4 = ConstantLoad 4
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %7 = ConstantLoad x
     %8 = p[%7];

--- a/corpus/bir/subset8/08-inclusive/fieldlvalue7-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldlvalue7-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 88
     %5 = ConstantLoad z
     %6 = ConstantLoad 10
-    %7 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4, %5=%6}
     p = %7;
     %9 = ConstantLoad 22
     %10 = ConstantLoad z

--- a/corpus/bir/subset8/08-inclusive/fieldlvalue8-v.txt
+++ b/corpus/bir/subset8/08-inclusive/fieldlvalue8-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 44
     %3 = ConstantLoad y
     %4 = ConstantLoad 88
-    %5 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| x: int, y: int, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %7 = ConstantLoad 22
     %8 = ConstantLoad z

--- a/corpus/bir/subset8/08-inclusive/inherent1-p.txt
+++ b/corpus/bir/subset8/08-inclusive/inherent1-p.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad James
     %3 = ConstantLoad age
     %4 = ConstantLoad 99
-    %5 = newMap {| age: int, name: string, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| age: int, name: string, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %7 = foo(p) -> bb1;
   }
@@ -19,7 +19,7 @@ main() -> nil{
     return;
   }
 }
-foo({| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}) -> nil{
+foo({| any... |}) -> nil{
   bb0 {
     %2 = ConstantLoad too old
     %3 = ConstantLoad age

--- a/corpus/bir/subset8/08-inclusive/inherent2-v.txt
+++ b/corpus/bir/subset8/08-inclusive/inherent2-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad James
     %3 = ConstantLoad age
     %4 = ConstantLoad 99
-    %5 = newMap {| age: int, name: string, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| age: int, name: string, anydata... |}{%1=%2, %3=%4}
     p = %5;
     %7 = foo(p) -> bb1;
   }
@@ -18,7 +18,7 @@ main() -> nil{
     return;
   }
 }
-foo({| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}) -> nil{
+foo({| any... |}) -> nil{
   bb0 {
     %2 = ConstantLoad long ago
     %3 = ConstantLoad dateOfBirth

--- a/corpus/bir/subset8/08-inclusive/inline1-v.txt
+++ b/corpus/bir/subset8/08-inclusive/inline1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad some string
     %3 = ConstantLoad aVeryLongFieldName
     %4 = ConstantLoad 0
-    %5 = newMap {| aVeryLongFieldName: int, anotherVeryLongFieldName: string, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| aVeryLongFieldName: int, anotherVeryLongFieldName: string, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %8 = ConstantLoad anotherVeryLongFieldName
     %7 = r[%8];

--- a/corpus/bir/subset8/08-inclusive/inline2-v.txt
+++ b/corpus/bir/subset8/08-inclusive/inline2-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 0
     %5 = ConstantLoad newFieldName
     %6 = ConstantLoad some other string
-    %7 = newMap {| aVeryLongFieldName: int, anotherVeryLongFieldName: string, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| aVeryLongFieldName: int, anotherVeryLongFieldName: string, anydata... |}{%1=%2, %3=%4, %5=%6}
     r = %7;
     %10 = ConstantLoad newFieldName
     %9 = r[%10];

--- a/corpus/bir/subset8/08-inclusive/typetest1-v.txt
+++ b/corpus/bir/subset8/08-inclusive/typetest1-v.txt
@@ -5,20 +5,20 @@ main() -> nil{
     %2 = ConstantLoad 1
     %3 = ConstantLoad x
     %4 = ConstantLoad 1.5
-    %5 = newMap {| n: int, x: float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| n: int, x: float, anydata... |}{%1=%2, %3=%4}
     r1 = %5;
     m = r1;
-    %8 = m is {| n: int, x: float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %8 = m is {| n: int, x: float, anydata... |}
     %9 = %8;
     %10 = println(%9) -> bb1;
   }
   bb1 {
-    %11 = m is {| n: nil|int, x: nil|float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %11 = m is {| n: nil|int, x: nil|float, anydata... |}
     %12 = %11;
     %13 = println(%12) -> bb2;
   }
   bb2 {
-    %14 = m is {| n: int, x: float, y: float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %14 = m is {| n: int, x: float, y: float, anydata... |}
     %15 = %14;
     %16 = println(%15) -> bb3;
   }
@@ -27,15 +27,15 @@ main() -> nil{
     %18 = ConstantLoad 1
     %19 = ConstantLoad x
     %20 = ConstantLoad 1.5
-    %21 = newMap {| n: nil|int, x: nil|float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%17=%18, %19=%20}
+    %21 = newMap {| n: nil|int, x: nil|float, anydata... |}{%17=%18, %19=%20}
     r2 = %21;
     m = r2;
-    %23 = m is {| n: int, x: float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %23 = m is {| n: int, x: float, anydata... |}
     %24 = %23;
     %25 = println(%24) -> bb4;
   }
   bb4 {
-    %26 = m is {| n: nil|int, x: nil|float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %26 = m is {| n: nil|int, x: nil|float, anydata... |}
     %27 = %26;
     %28 = println(%27) -> bb5;
   }
@@ -44,36 +44,36 @@ main() -> nil{
     %30 = ConstantLoad 1
     %31 = ConstantLoad x
     %32 = ConstantLoad 1.5
-    %33 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%29=%30, %31=%32}
+    %33 = newMap {| any... |}{%29=%30, %31=%32}
     m = %33;
-    %34 = m is {| n: int, x: float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %34 = m is {| n: int, x: float, anydata... |}
     %35 = %34;
     %36 = println(%35) -> bb6;
   }
   bb6 {
-    %37 = m is {| n: nil|int, x: nil|float, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %37 = m is {| n: nil|int, x: nil|float, anydata... |}
     %38 = %37;
     %39 = println(%38) -> bb7;
   }
   bb7 {
     v = r1;
-    %41 = v is {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}
+    %41 = v is {| any... |}
     %42 = %41;
     %43 = println(%42) -> bb8;
   }
   bb8 {
-    %44 = v is {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}
+    %44 = v is {| any... |}
     %45 = %44;
     %46 = println(%45) -> bb9;
   }
   bb9 {
     v = r2;
-    %47 = v is {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}
+    %47 = v is {| any... |}
     %48 = %47;
     %49 = println(%48) -> bb10;
   }
   bb10 {
-    %50 = v is {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}
+    %50 = v is {| any... |}
     %51 = %50;
     %52 = println(%51) -> bb11;
   }

--- a/corpus/bir/subset8/08-list/13-p.txt
+++ b/corpus/bir/subset8/08-list/13-p.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 1
     %5 = unknown %4;

--- a/corpus/bir/subset8/08-list/2-p.txt
+++ b/corpus/bir/subset8/08-list/2-p.txt
@@ -6,7 +6,7 @@ main() -> nil{
     %3 = ConstantLoad 11
     %4 = unknown %3;
     %5 = ConstantLoad 3
-    %6 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%5]{%1, %2, %4}
+    %6 = newArray [any...][%5]{%1, %2, %4}
     v = %6;
     %8 = ConstantLoad 3
     i = %8;

--- a/corpus/bir/subset8/08-list/3-v.txt
+++ b/corpus/bir/subset8/08-list/3-v.txt
@@ -11,10 +11,10 @@ main() -> nil{
     return;
   }
 }
-foo() -> [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]{
+foo() -> [any...]{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     %0 = %2;
     return;
   }

--- a/corpus/bir/subset8/08-list/5-p.txt
+++ b/corpus/bir/subset8/08-list/5-p.txt
@@ -6,7 +6,7 @@ main() -> nil{
     %3 = ConstantLoad 11
     %4 = unknown %3;
     %5 = ConstantLoad 3
-    %6 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%5]{%1, %2, %4}
+    %6 = newArray [any...][%5]{%1, %2, %4}
     v = %6;
     %8 = ConstantLoad 1
     %9 = unknown %8;

--- a/corpus/bir/subset8/08-list/8-p.txt
+++ b/corpus/bir/subset8/08-list/8-p.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
     %1 = ConstantLoad 0
-    %2 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%1]{}
+    %2 = newArray [any...][%1]{}
     v = %2;
     %4 = ConstantLoad 0
     i = %4;

--- a/corpus/bir/subset8/08-list/int9-v.txt
+++ b/corpus/bir/subset8/08-list/int9-v.txt
@@ -4,7 +4,7 @@ main() -> nil{
     %1 = ConstantLoad 0
     %2 = newArray [int...][%1]{}
     iv = %2;
-    %4 = iv is [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]
+    %4 = iv is [any...]
     %4 ? bb1 : bb3;
   }
   bb1 {

--- a/corpus/bir/subset8/08-list/union-v.txt
+++ b/corpus/bir/subset8/08-list/union-v.txt
@@ -4,7 +4,7 @@ main() -> nil{
     %1 = ConstantLoad 0
     %2 = newArray list[%1]{}
     x = %2;
-    %4 = x is [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]
+    %4 = x is [any...]
     %4 ? bb1 : bb3;
   }
   bb1 {

--- a/corpus/bir/subset8/08-map/10-v.txt
+++ b/corpus/bir/subset8/08-map/10-v.txt
@@ -9,9 +9,9 @@ main() -> nil{
     %6 = ConstantLoad Saturday
     %7 = ConstantLoad Sunday
     %8 = ConstantLoad 7
-    %9 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%8]{%1, %2, %3, %4, %5, %6, %7}
+    %9 = newArray [any...][%8]{%1, %2, %3, %4, %5, %6, %7}
     days = %9;
-    %11 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %11 = newMap {| any... |}{}
     dayNumber = %11;
     %13 = ConstantLoad 0
     i = %13;

--- a/corpus/bir/subset8/08-map/13-v.txt
+++ b/corpus/bir/subset8/08-map/13-v.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad 16
     max = %1;
-    %3 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %3 = newMap {| any... |}{}
     m = %3;
     %5 = max;
     %6 = populate(m,%5) -> bb1;
@@ -20,7 +20,7 @@ main() -> nil{
     return;
   }
 }
-populate({| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |},int) -> nil{
+populate({| any... |},int) -> nil{
   bb0 {
     %3 = ConstantLoad x
     x = %3;
@@ -114,7 +114,7 @@ populate({| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp
     return;
   }
 }
-retrieve({| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |},int) -> int{
+retrieve({| any... |},int) -> int{
   bb0 {
     %3 = ConstantLoad x
     x = %3;

--- a/corpus/bir/subset8/08-map/9-v.txt
+++ b/corpus/bir/subset8/08-map/9-v.txt
@@ -7,7 +7,7 @@ main() -> nil{
     %4 = ConstantLoad 17
     %5 = ConstantLoad z
     %6 = ConstantLoad hello
-    %7 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%2, %3=%4, %5=%6}
+    %7 = newMap {| any... |}{%1=%2, %3=%4, %5=%6}
     m = %7;
     %9 = length(m) -> bb1;
   }

--- a/corpus/bir/subset8/08-map/int6-v.txt
+++ b/corpus/bir/subset8/08-map/int6-v.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = newMap {| int... |}{}
     im = %1;
-    %3 = im is {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}
+    %3 = im is {| any... |}
     %3 ? bb1 : bb3;
   }
   bb1 {

--- a/corpus/bir/subset8/08-mapping/8-v.txt
+++ b/corpus/bir/subset8/08-mapping/8-v.txt
@@ -21,7 +21,7 @@ main() -> nil{
     %14 = ConstantLoad 2
     %15 = ConstantLoad b
     %16 = ConstantLoad 3
-    %17 = newMap {| a: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%13=%14, %15=%16}
+    %17 = newMap {| a: any, anydata... |}{%13=%14, %15=%16}
     %18 = foo1(%17) -> bb3;
   }
   bb3 {
@@ -29,7 +29,7 @@ main() -> nil{
     %20 = ConstantLoad 2
     %21 = ConstantLoad b
     %22 = ConstantLoad 3
-    %23 = newMap {| a: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, b: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, never... |}{%19=%20, %21=%22}
+    %23 = newMap {| a: any, b: any, never... |}{%19=%20, %21=%22}
     %24 = foo2(%23) -> bb4;
   }
   bb4 {
@@ -37,7 +37,7 @@ main() -> nil{
     %26 = ConstantLoad 2
     %27 = ConstantLoad b
     %28 = ConstantLoad 3
-    %29 = newMap {| a: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, b: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, never... |}{%25=%26, %27=%28}
+    %29 = newMap {| a: any, b: any, never... |}{%25=%26, %27=%28}
     %30 = foo2(%29) -> bb5;
   }
   bb5 {
@@ -84,7 +84,7 @@ foo(any) -> nil{
     return;
   }
 }
-foo1({| a: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}) -> nil{
+foo1({| a: any, anydata... |}) -> nil{
   bb0 {
     %2 = c is {| a: int, b: int, never... |}
     %2 ? bb1 : bb3;
@@ -123,7 +123,7 @@ foo1({| a: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|
     return;
   }
 }
-foo2({| a: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, b: nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object, never... |}) -> nil{
+foo2({| a: any, b: any, never... |}) -> nil{
   bb0 {
     %2 = c is {| a: int, b: int, never... |}
     %2 ? bb1 : bb3;

--- a/corpus/bir/subset8/08-misc/evalorder-v.txt
+++ b/corpus/bir/subset8/08-misc/evalorder-v.txt
@@ -208,7 +208,7 @@ main() -> nil{
   }
   bb34 {
     %115 = ConstantLoad 2
-    %116 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%115]{%113, %114}
+    %116 = newArray [any...][%115]{%113, %114}
     arr = %116;
     %118 = arr;
     %119 = one() -> bb35;

--- a/corpus/bir/subset8/08-mutate/mappingif2-v.txt
+++ b/corpus/bir/subset8/08-mutate/mappingif2-v.txt
@@ -3,10 +3,10 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad x
     %2 = ConstantLoad str
-    %3 = newMap {| x: string, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2}
+    %3 = newMap {| x: string, anydata... |}{%1=%2}
     s = %3;
     nOrS = s;
-    %6 = nOrS is {| x: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+    %6 = nOrS is {| x: int, anydata... |}
     %6 ? bb1 : bb3;
   }
   bb1 {

--- a/corpus/bir/subset8/08-narrowing/while1-v.txt
+++ b/corpus/bir/subset8/08-narrowing/while1-v.txt
@@ -8,8 +8,8 @@ main() -> nil{
     %5 = ConstantLoad 40
     %6 = ConstantLoad next
     %7 = ConstantLoad <nil>
-    %8 = newMap {| i: int, next: nil|..., nil|boolean|int|float|decimal|string|regexp|xml|...|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%4=%5, %6=%7}
-    %9 = newMap {| i: int, next: nil|..., nil|boolean|int|float|decimal|string|regexp|xml|...|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%8}
+    %8 = newMap {| i: int, next: nil|..., anydata... |}{%4=%5, %6=%7}
+    %9 = newMap {| i: int, next: nil|..., anydata... |}{%1=%2, %3=%8}
     l = %9;
     %11 = sum(l) -> bb1;
   }
@@ -21,7 +21,7 @@ main() -> nil{
     return;
   }
 }
-sum(nil|{| i: int, next: nil|..., nil|boolean|int|float|decimal|string|regexp|xml|...|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}) -> int{
+sum(nil|{| i: int, next: nil|..., anydata... |}) -> int{
   bb0 {
     temp = intList;
     %3 = ConstantLoad 0

--- a/corpus/bir/subset8/08-object/incl-record-param-1-v.txt
+++ b/corpus/bir/subset8/08-object/incl-record-param-1-v.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 class C {
   b int
 
-  foo(int,{| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}) -> int{
+  foo(int,{| bar: int, foo: int, anydata... |}) -> int{
     bb0 {
       %6 = base;
       %9 = ConstantLoad foo
@@ -54,7 +54,7 @@ main() -> nil{
     c = %3;
     %6 = ConstantLoad 1
     %7 = %6;
-    %8 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %8 = newMap {| bar: int, foo: int, anydata... |}{} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %9 = foo(c,%7,%8) -> bb5;
   }
   bb5 {
@@ -66,7 +66,7 @@ main() -> nil{
     %13 = %12;
     %14 = ConstantLoad foo
     %15 = ConstantLoad 10
-    %16 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%14=%15} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %16 = newMap {| bar: int, foo: int, anydata... |}{%14=%15} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %17 = foo(c,%13,%16) -> bb7;
   }
   bb7 {
@@ -78,7 +78,7 @@ main() -> nil{
     %21 = %20;
     %22 = ConstantLoad bar
     %23 = ConstantLoad 5
-    %24 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%22=%23} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %24 = newMap {| bar: int, foo: int, anydata... |}{%22=%23} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %25 = foo(c,%21,%24) -> bb9;
   }
   bb9 {
@@ -92,7 +92,7 @@ main() -> nil{
     %31 = ConstantLoad 1
     %32 = ConstantLoad bar
     %33 = ConstantLoad 5
-    %34 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%30=%31, %32=%33} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %34 = newMap {| bar: int, foo: int, anydata... |}{%30=%31, %32=%33} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %35 = foo(c,%29,%34) -> bb11;
   }
   bb11 {
@@ -106,7 +106,7 @@ main() -> nil{
     %41 = ConstantLoad 1
     %42 = ConstantLoad bar
     %43 = ConstantLoad 5
-    %44 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%40=%41, %42=%43} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
+    %44 = newMap {| bar: int, foo: int, anydata... |}{%40=%41, %42=%43} defaults{foo=$anon/.:$desugar$0, bar=$anon/.:$desugar$1}
     %45 = foo(c,%39,%44) -> bb13;
   }
   bb13 {

--- a/corpus/bir/subset8/08-object/incl-record-param-4-v.txt
+++ b/corpus/bir/subset8/08-object/incl-record-param-4-v.txt
@@ -2,7 +2,7 @@ module $anon.. v 0.0.0;
 class C {
   b int
 
-  foo(int,{| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |},{| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}) -> int{
+  foo(int,{| foo: int, anydata... |},{| bar: int, anydata... |}) -> int{
     bb0 {
       %7 = base;
       %10 = ConstantLoad foo
@@ -54,8 +54,8 @@ main() -> nil{
     c = %3;
     %6 = ConstantLoad 1
     %7 = %6;
-    %8 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{foo=$anon/.:$desugar$0}
-    %9 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{bar=$anon/.:$desugar$1}
+    %8 = newMap {| foo: int, anydata... |}{} defaults{foo=$anon/.:$desugar$0}
+    %9 = newMap {| bar: int, anydata... |}{} defaults{bar=$anon/.:$desugar$1}
     %10 = foo(c,%7,%8,%9) -> bb5;
   }
   bb5 {
@@ -67,8 +67,8 @@ main() -> nil{
     %14 = %13;
     %15 = ConstantLoad foo
     %16 = ConstantLoad 10
-    %17 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%15=%16} defaults{foo=$anon/.:$desugar$0}
-    %18 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{bar=$anon/.:$desugar$1}
+    %17 = newMap {| foo: int, anydata... |}{%15=%16} defaults{foo=$anon/.:$desugar$0}
+    %18 = newMap {| bar: int, anydata... |}{} defaults{bar=$anon/.:$desugar$1}
     %19 = foo(c,%14,%17,%18) -> bb7;
   }
   bb7 {
@@ -78,10 +78,10 @@ main() -> nil{
   bb8 {
     %22 = ConstantLoad 1
     %23 = %22;
-    %24 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{} defaults{foo=$anon/.:$desugar$0}
+    %24 = newMap {| foo: int, anydata... |}{} defaults{foo=$anon/.:$desugar$0}
     %25 = ConstantLoad bar
     %26 = ConstantLoad 5
-    %27 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%25=%26} defaults{bar=$anon/.:$desugar$1}
+    %27 = newMap {| bar: int, anydata... |}{%25=%26} defaults{bar=$anon/.:$desugar$1}
     %28 = foo(c,%23,%24,%27) -> bb9;
   }
   bb9 {
@@ -93,10 +93,10 @@ main() -> nil{
     %32 = %31;
     %33 = ConstantLoad foo
     %34 = ConstantLoad 1
-    %35 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%33=%34} defaults{foo=$anon/.:$desugar$0}
+    %35 = newMap {| foo: int, anydata... |}{%33=%34} defaults{foo=$anon/.:$desugar$0}
     %36 = ConstantLoad bar
     %37 = ConstantLoad 5
-    %38 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%36=%37} defaults{bar=$anon/.:$desugar$1}
+    %38 = newMap {| bar: int, anydata... |}{%36=%37} defaults{bar=$anon/.:$desugar$1}
     %39 = foo(c,%32,%35,%38) -> bb11;
   }
   bb11 {
@@ -108,10 +108,10 @@ main() -> nil{
     %43 = %42;
     %44 = ConstantLoad foo
     %45 = ConstantLoad 1
-    %46 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%44=%45} defaults{foo=$anon/.:$desugar$0}
+    %46 = newMap {| foo: int, anydata... |}{%44=%45} defaults{foo=$anon/.:$desugar$0}
     %47 = ConstantLoad bar
     %48 = ConstantLoad 5
-    %49 = newMap {| bar: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%47=%48} defaults{bar=$anon/.:$desugar$1}
+    %49 = newMap {| bar: int, anydata... |}{%47=%48} defaults{bar=$anon/.:$desugar$1}
     %50 = foo(c,%43,%46,%49) -> bb13;
   }
   bb13 {

--- a/corpus/bir/subset8/08-record/optional-field-1-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-1-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 10
     %3 = ConstantLoad bar
     %4 = ConstantLoad 10
-    %5 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| bar: int, foo: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %8 = ConstantLoad foo
     %7 = r[%8];

--- a/corpus/bir/subset8/08-record/optional-field-included-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-included-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 10
     %3 = ConstantLoad bar
     %4 = ConstantLoad 20
-    %5 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| bar: int, foo: int, anydata... |}{%1=%2, %3=%4}
     d = %5;
     %7 = println(d) -> bb1;
   }

--- a/corpus/bir/subset8/08-record/optional-field-index-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-index-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 10
     %3 = ConstantLoad bar
     %4 = ConstantLoad 10
-    %5 = newMap {| bar: nil|int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| bar: nil|int, foo: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %7 = println(r) -> bb1;
   }

--- a/corpus/bir/subset8/08-record/optional-field-read-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-read-v.txt
@@ -3,7 +3,7 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad foo
     %2 = ConstantLoad 7
-    %3 = newMap {| foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2}
+    %3 = newMap {| foo: int, anydata... |}{%1=%2}
     r = %3;
     %6 = ConstantLoad foo
     %5 = r[%6];

--- a/corpus/bir/subset8/08-record/optional-field-union-3-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-union-3-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 10
     %3 = ConstantLoad bar
     %4 = ConstantLoad 10
-    %5 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| bar: int, foo: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %7 = ConstantLoad <nil>
     %8 = ConstantLoad foo
@@ -17,7 +17,7 @@ main() -> nil{
     %11 = ConstantLoad 20
     %12 = ConstantLoad baz
     %13 = ConstantLoad gg
-    %14 = newMap {| baz: string, foo: nil|int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%10=%11, %12=%13}
+    %14 = newMap {| baz: string, foo: nil|int, anydata... |}{%10=%11, %12=%13}
     r = %14;
     %15 = ConstantLoad <nil>
     %16 = ConstantLoad foo

--- a/corpus/bir/subset8/08-record/optional-field-union-6-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-union-6-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 10
     %3 = ConstantLoad bar
     %4 = ConstantLoad 10
-    %5 = newMap {| bar: int, foo: nil|int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| bar: int, foo: nil|int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %8 = ConstantLoad foo
     %7 = r[%8];

--- a/corpus/bir/subset8/08-record/optional-field-union-9-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-union-9-v.txt
@@ -5,13 +5,13 @@ main() -> nil{
     %2 = ConstantLoad 10
     %3 = ConstantLoad bar
     %4 = ConstantLoad 10
-    %5 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| bar: int, foo: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %7 = ConstantLoad foo
     %8 = ConstantLoad 20
     %9 = ConstantLoad baz
     %10 = ConstantLoad 
-    %11 = newMap {| baz: string, foo: nil|int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%7=%8, %9=%10}
+    %11 = newMap {| baz: string, foo: nil|int, anydata... |}{%7=%8, %9=%10}
     r2 = %11;
     %15 = ConstantLoad foo
     %14 = r2[%15];

--- a/corpus/bir/subset8/08-record/optional-field-union-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-union-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 10
     %3 = ConstantLoad bar
     %4 = ConstantLoad 10
-    %5 = newMap {| bar: int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| bar: int, foo: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %7 = println(r) -> bb1;
   }

--- a/corpus/bir/subset8/08-record/optional-field-v.txt
+++ b/corpus/bir/subset8/08-record/optional-field-v.txt
@@ -5,7 +5,7 @@ main() -> nil{
     %2 = ConstantLoad 10
     %3 = ConstantLoad bar
     %4 = ConstantLoad 10
-    %5 = newMap {| bar: nil|int, foo: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%1=%2, %3=%4}
+    %5 = newMap {| bar: nil|int, foo: int, anydata... |}{%1=%2, %3=%4}
     r = %5;
     %7 = println(r) -> bb1;
   }

--- a/corpus/bir/subset8/08-string/17-v.txt
+++ b/corpus/bir/subset8/08-string/17-v.txt
@@ -74,7 +74,7 @@ main() -> nil{
     %45 = println(%44) -> bb14;
   }
   bb14 {
-    %46 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %46 = newMap {| any... |}{}
     m = %46;
     %48 = ConstantLoad 42
     m[s1] = %48;

--- a/corpus/bir/subset8/08-tuple/typetest1-v.txt
+++ b/corpus/bir/subset8/08-tuple/typetest1-v.txt
@@ -17,7 +17,7 @@ main() -> nil{
     %12 = println(%11) -> bb2;
   }
   bb2 {
-    %13 = v is [nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table...]
+    %13 = v is [anydata...]
     %14 = %13;
     %15 = println(%14) -> bb3;
   }

--- a/corpus/bir/subset8/08-tuple/typetest2-v.txt
+++ b/corpus/bir/subset8/08-tuple/typetest2-v.txt
@@ -18,7 +18,7 @@ main() -> nil{
     %13 = println(%12) -> bb2;
   }
   bb2 {
-    %14 = v is [nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table...]
+    %14 = v is [anydata...]
     %15 = %14;
     %16 = println(%15) -> bb3;
   }

--- a/corpus/bir/subset8/08-typecast/1-v.txt
+++ b/corpus/bir/subset8/08-typecast/1-v.txt
@@ -3,11 +3,11 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad 42
     %2 = ConstantLoad 1
-    %3 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%2]{%1}
+    %3 = newArray [any...][%2]{%1}
     x = %3;
     y = x;
     %7 = ConstantLoad 0
-    %8 = <[nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]>(y)
+    %8 = <[any...]>(y)
     %6 = %8[%7];
     %9 = println(%6) -> bb1;
   }

--- a/corpus/bir/subset8/08-typecast/2-v.txt
+++ b/corpus/bir/subset8/08-typecast/2-v.txt
@@ -3,11 +3,11 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad value
     %2 = ConstantLoad 42
-    %3 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{%1=%2}
+    %3 = newMap {| any... |}{%1=%2}
     x = %3;
     y = x;
     %7 = ConstantLoad value
-    %8 = <{| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}>(y)
+    %8 = <{| any... |}>(y)
     %6 = %8[%7];
     %9 = println(%6) -> bb1;
   }

--- a/corpus/bir/subset8/08-typetest/2-v.txt
+++ b/corpus/bir/subset8/08-typetest/2-v.txt
@@ -33,12 +33,12 @@ main() -> nil{
     %18 = ConstantLoad 1
     %19 = ConstantLoad 2
     %20 = ConstantLoad 2
-    %21 = newArray [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...][%20]{%18, %19}
+    %21 = newArray [any...][%20]{%18, %19}
     list = %21;
     %23 = p(list) -> bb7;
   }
   bb7 {
-    %24 = newMap {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}{}
+    %24 = newMap {| any... |}{}
     mapping = %24;
     %26 = p(mapping) -> bb8;
   }
@@ -90,7 +90,7 @@ p(any) -> nil{
   }
   bb9 {
     PushScopeFrame 1
-    %0 = (3, v) is [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]
+    %0 = (3, v) is [any...]
     %0 ? bb10 : bb12;
   }
   bb10 {
@@ -104,7 +104,7 @@ p(any) -> nil{
   }
   bb12 {
     PushScopeFrame 1
-    %0 = (4, v) is {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}
+    %0 = (4, v) is {| any... |}
     %0 ? bb13 : bb15;
   }
   bb13 {

--- a/corpus/bir/subset9/09-bug/mapping-constructor-v.txt
+++ b/corpus/bir/subset9/09-bug/mapping-constructor-v.txt
@@ -3,21 +3,21 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad hours
     %2 = ConstantLoad 0
-    %3 = newMap {| hours: int, minutes: int, nil|boolean|int|float|decimal|string|regexp|readonly&[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|readonly&{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>... |}{%1=%2}
+    %3 = newMap {| hours: int, minutes: int, nil|boolean|int|float|decimal|string|regexp|readonly&[anydata...]|readonly&{| anydata... |}|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>... |}{%1=%2}
     z = %3;
     %5 = println(z) -> bb1;
   }
   bb1 {
     %6 = ConstantLoad y
     %7 = ConstantLoad 1
-    %8 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%6=%7}
+    %8 = newMap {| x: int, y: int, anydata... |}{%6=%7}
     u1 = %8;
     %10 = println(u1) -> bb2;
   }
   bb2 {
     %11 = ConstantLoad x
     %12 = ConstantLoad 1
-    %13 = newMap {| x: int, y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}{%11=%12}
+    %13 = newMap {| x: int, y: int, anydata... |}{%11=%12}
     u2 = %13;
     %15 = println(u2) -> bb3;
   }

--- a/corpus/integration/subset3/03-list/1-e.txtar
+++ b/corpus/integration/subset3/03-list/1-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: incompatible type: expected [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...], got int
+error[SEMANTIC_ERROR]: incompatible type: expected [any...], got int
   --> 1-e.bal:20:15
    |
 20 |     any[] x = n; // @error

--- a/corpus/integration/subset3/03-list/15-e.txtar
+++ b/corpus/integration/subset3/03-list/15-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: incompatible type: expected [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...], got any
+error[SEMANTIC_ERROR]: incompatible type: expected [any...], got any
   --> 15-e.bal:19:12
    |
 19 |     return x; // @error

--- a/corpus/integration/subset7/07-function/union16-e.txtar
+++ b/corpus/integration/subset7/07-function/union16-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: incompatible type: expected function(int) returns int|function(int) returns string, got function(nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object) returns int|string
+error[SEMANTIC_ERROR]: incompatible type: expected function(int) returns int|function(int) returns string, got function(any) returns int|string
   --> union16-e.bal:24:12
    |
 24 |     FG f = fooBar; // @error

--- a/corpus/integration/subset8/08-anydata/arr3-e.txtar
+++ b/corpus/integration/subset8/08-anydata/arr3-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: incompatible type: expected anydata, got [nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object...]
+error[SEMANTIC_ERROR]: incompatible type: expected anydata, got [any...]
   --> arr3-e.bal:21:19
    |
 21 |     anydata val = a; // @error

--- a/corpus/integration/subset8/08-anydata/map1-e.txtar
+++ b/corpus/integration/subset8/08-anydata/map1-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: incompatible type: expected anydata, got {| nil|boolean|int|float|decimal|string|typedesc|handle|function|regexp|future|stream|list|mapping|table|xml|object... |}
+error[SEMANTIC_ERROR]: incompatible type: expected anydata, got {| any... |}
   --> map1-e.bal:23:17
    |
 23 |     anydata b = m; // @error

--- a/corpus/integration/subset8/08-tuple/construct4-e.txtar
+++ b/corpus/integration/subset8/08-tuple/construct4-e.txtar
@@ -1,6 +1,6 @@
 -- stdout --
 -- stderr --
-error[SEMANTIC_ERROR]: missing required member at index 0: type '{| x: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}' has no filler value
+error[SEMANTIC_ERROR]: missing required member at index 0: type '{| x: int, anydata... |}' has no filler value
   --> construct4-e.bal:20:27
    |
 20 |     [record {int x;}] v = []; // @error

--- a/corpus/integration/subset9/09-mapping/optional-field-access-e.txtar
+++ b/corpus/integration/subset9/09-mapping/optional-field-access-e.txtar
@@ -18,25 +18,25 @@ error[SEMANTIC_ERROR]: optional field access must be subtype of xml|map|()
 49 |     _ = value?.x; // @error
    |         ^^^^^^^^
 
+error[SEMANTIC_ERROR]: x is not an individual field descriptor in {| anydata... |}
+  --> optional-field-access-e.bal:60:9
+   |
+60 |     _ = value?.x; // @error
+   |         ^^^^^^^^
+
 error[SEMANTIC_ERROR]: x is not an individual field descriptor in {| never... |}
   --> optional-field-access-e.bal:65:9
    |
 65 |     _ = value?.x; // @error
    |         ^^^^^^^^
 
-error[SEMANTIC_ERROR]: x is not an individual field descriptor in {| nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
-  --> optional-field-access-e.bal:60:9
-   |
-60 |     _ = value?.x; // @error
-   |         ^^^^^^^^
-
-error[SEMANTIC_ERROR]: x is not an individual field descriptor in {| y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}|{| z: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+error[SEMANTIC_ERROR]: x is not an individual field descriptor in {| y: int, anydata... |}|{| z: int, anydata... |}
   --> optional-field-access-e.bal:54:9
    |
 54 |     _ = value?.x; // @error
    |         ^^^^^^^^
 
-error[SEMANTIC_ERROR]: z is not an individual field descriptor in {| x: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}&{| y: int, nil|boolean|int|float|decimal|string|regexp|xml|[nil|boolean|int|float|decimal|string|regexp|xml|...|...|table...]|{| nil|boolean|int|float|decimal|string|regexp|xml|...|...|table... |}|table... |}
+error[SEMANTIC_ERROR]: z is not an individual field descriptor in {| x: int, anydata... |}&{| y: int, anydata... |}
   --> optional-field-access-e.bal:70:9
    |
 70 |     _ = value?.z; // @error

--- a/semtypes/to_string.go
+++ b/semtypes/to_string.go
@@ -31,9 +31,6 @@ func newToStringState(cx Context) *toStringState {
 }
 
 func ToString(cx Context, ty SemType) string {
-	if res, ok := builtinUnion(cx, ty); ok {
-		return res
-	}
 	s := newToStringState(cx)
 	return s.semTypeToString(ty)
 }
@@ -52,6 +49,9 @@ func builtinUnion(cx Context, ty SemType) (string, bool) {
 }
 
 func (s *toStringState) semTypeToString(ty SemType) string {
+	if res, ok := builtinUnion(s.cx, ty); ok {
+		return res
+	}
 	if ty.some() == 0 {
 		return basicTypeToString(ty.all())
 	}


### PR DESCRIPTION
## Purpose
$subject
Fixes https://github.com/ballerina-nutcracker/ballerina/issues/642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic type error messages with shorter, clearer representations for unions, arrays, `anydata`, functions, records, and optional fields.
  * Preserved accurate source locations and highlighting for reported type errors.
  * Standardized type formatting across compiler diagnostics for more consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->