### PR TITLE
feat(pal): shared net/tls PAL for non-HTTP socket protocols

### DIFF
--- a/corpus/extern/harness_helpers_test.go
+++ b/corpus/extern/harness_helpers_test.go
@@ -74,12 +74,12 @@ func runExtern(t *testing.T, tc test_util.TestCase, pal testharness.TestPal, ext
 // to os.ReadFile (used by tests that need to load cert files from disk).
 type httpPal struct {
 	testharness.TestPal
-	newClient func(cfg pal.ClientConfig) pal.HTTPClient
+	newClient func(cfg pal.ClientConfig) (pal.HTTPClient, error)
 	realFS    bool
 }
 
 // newHTTPPal returns a TestPal whose Platform()'s HTTP.NewClient is overridden.
-func newHTTPPal(newClient func(cfg pal.ClientConfig) pal.HTTPClient) *httpPal {
+func newHTTPPal(newClient func(cfg pal.ClientConfig) (pal.HTTPClient, error)) *httpPal {
 	return &httpPal{TestPal: testharness.NewTestPal(), newClient: newClient}
 }
 

--- a/corpus/extern/http_client_test.go
+++ b/corpus/extern/http_client_test.go
@@ -79,12 +79,12 @@ func (c *rewritingHTTPClient) Execute(ctx context.Context, method, url string, b
 
 // rewriteClient returns a NewClient factory that forwards every request to
 // serverURL via rewritingHTTPClient.
-func rewriteClient(serverURL string) func(pal.ClientConfig) pal.HTTPClient {
-	return func(cfg pal.ClientConfig) pal.HTTPClient {
+func rewriteClient(serverURL string) func(pal.ClientConfig) (pal.HTTPClient, error) {
+	return func(cfg pal.ClientConfig) (pal.HTTPClient, error) {
 		return &rewritingHTTPClient{
 			serverURL: serverURL,
 			client:    &http.Client{Timeout: cfg.Timeout},
-		}
+		}, nil
 	}
 }
 
@@ -224,11 +224,11 @@ func TestHttpClientCompressionLocal(t *testing.T) {
 	}))
 	defer server.Close()
 
-	noAutoDecompress := func(cfg pal.ClientConfig) pal.HTTPClient {
+	noAutoDecompress := func(cfg pal.ClientConfig) (pal.HTTPClient, error) {
 		return &rewritingHTTPClient{
 			serverURL: server.URL,
 			client:    &http.Client{Timeout: cfg.Timeout, Transport: &http.Transport{DisableCompression: true}},
-		}
+		}, nil
 	}
 	runExtern(t, fileCase("http-client-compression-local-v"), newHTTPPal(noAutoDecompress), nil)
 }
@@ -264,7 +264,7 @@ func TestHttpClientTLSInsecure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	clientFactory := func(cfg pal.ClientConfig) pal.HTTPClient {
+	clientFactory := func(cfg pal.ClientConfig) (pal.HTTPClient, error) {
 		serverTLSConfig := server.Client().Transport.(*http.Transport).TLSClientConfig.Clone()
 		if cfg.TLS.InsecureSkipVerify {
 			serverTLSConfig.InsecureSkipVerify = true //nolint:gosec
@@ -273,7 +273,7 @@ func TestHttpClientTLSInsecure(t *testing.T) {
 		return &rewritingHTTPClient{
 			serverURL: server.URL,
 			client:    &http.Client{Timeout: cfg.Timeout, Transport: &http.Transport{TLSClientConfig: serverTLSConfig}},
-		}
+		}, nil
 	}
 	runExtern(t, fileCase("http-client-tls-v"), newHTTPPal(clientFactory), nil)
 }
@@ -387,6 +387,44 @@ public function main() returns error? {
 		Name:         "http-client-mtls-v",
 		InputPath:    tmpBalFile,
 		ExpectedPath: filepath.Join(expectedDir, "http-client-mtls-v.txtar"),
+	}
+	runExtern(t, tc, newHTTPPal(palnative.NewHTTPClient).withRealFS(), nil)
+}
+
+// TestHttpClientMalformedCACert verifies that a secureSocket.cert file whose
+// content isn't a valid PEM-encoded certificate fails Client.init with an
+// error, rather than silently falling back to the system trust store (which
+// would defeat the custom-CA pinning the config asked for).
+func TestHttpClientMalformedCACert(t *testing.T) {
+	tmpDir := t.TempDir()
+	certFile := filepath.Join(tmpDir, "ca.pem")
+	if err := os.WriteFile(certFile, []byte("not a valid PEM certificate"), 0600); err != nil {
+		t.Fatalf("writing malformed cert file: %v", err)
+	}
+
+	certFileSlash := filepath.ToSlash(certFile)
+	balContent := fmt.Sprintf(`
+import ballerina/http;
+import ballerina/io;
+
+public function main() returns error? {
+    http:Client|error c = new ("http://testserver", {
+        secureSocket: {cert: "%s"}
+    });
+    io:println(c is error); // @output true
+    return;
+}
+`, certFileSlash)
+
+	tmpBalFile := filepath.Join(tmpDir, "http-client-malformed-ca-cert-v.bal")
+	if err := os.WriteFile(tmpBalFile, []byte(balContent), 0644); err != nil {
+		t.Fatalf("writing bal file: %v", err)
+	}
+
+	tc := test_util.TestCase{
+		Name:         "http-client-malformed-ca-cert-v",
+		InputPath:    tmpBalFile,
+		ExpectedPath: filepath.Join(expectedDir, "http-client-malformed-ca-cert-v.txtar"),
 	}
 	runExtern(t, tc, newHTTPPal(palnative.NewHTTPClient).withRealFS(), nil)
 }

--- a/corpus/extern/testdata/expected/http-client-malformed-ca-cert-v.txtar
+++ b/corpus/extern/testdata/expected/http-client-malformed-ca-cert-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+true
+-- stderr --

--- a/lib/langlibs/go/lang.runtime/runtime.go
+++ b/lib/langlibs/go/lang.runtime/runtime.go
@@ -17,6 +17,7 @@
 package langruntime
 
 import (
+	"math"
 	"time"
 
 	"github.com/ballerina-nutcracker/ballerina/decimal"
@@ -32,7 +33,7 @@ const (
 
 func runtimeSleep(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
 	seconds := args[0].(*decimal.Decimal)
-	dur := time.Duration(seconds.Float64() * float64(time.Second))
+	dur := secondsToSleepDuration(seconds.Float64())
 	deadline := ctx.Env.Platform.Time.MonotonicNow() + dur
 	// Hand the thread back on every pass, the same way the wait actions poll
 	// (see waitAllFutures). Blocking on a timer between yields would hold this
@@ -46,6 +47,23 @@ func runtimeSleep(ctx *extern.Context, args []values.BalValue) (values.BalValue,
 
 func initRuntimeModule(rt *runtime.Runtime) {
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "sleep", runtimeSleep)
+}
+
+// secondsToSleepDuration converts a duration given in seconds to a
+// time.Duration, clamping non-finite and out-of-int64-range results
+// (reachable from decimal's much wider value range) to the max
+// representable duration instead of relying on the platform-specific
+// float-to-int64 overflow behavior. Non-positive and NaN durations pass
+// through as a no-op, same as time.Sleep's own documented behavior.
+func secondsToSleepDuration(seconds float64) time.Duration {
+	nanos := seconds * float64(time.Second)
+	if math.IsNaN(nanos) || nanos <= 0 {
+		return 0
+	}
+	if nanos >= math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return time.Duration(nanos)
 }
 
 func init() {

--- a/lib/langlibs/go/lang.runtime/runtime_test.go
+++ b/lib/langlibs/go/lang.runtime/runtime_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package langruntime
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// TestSecondsToSleepDuration covers the clamping contract that motivated
+// extracting this helper: decimal's value range vastly exceeds float64's, and
+// a naive seconds*time.Second conversion can overflow to a platform-defined
+// (and on some platforms negative) int64, turning a huge sleep() call into a
+// no-op instead of the longest representable sleep. A corpus test can't cover
+// the overflow branches directly (sleeping for the clamped ~292-year duration
+// isn't practical to run to completion), so this is a plain unit test on the
+// pure helper instead.
+func TestSecondsToSleepDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds float64
+		want    time.Duration
+	}{
+		{"typical positive value", 1.5, 1500 * time.Millisecond},
+		{"zero is a no-op", 0, 0},
+		{"negative is a no-op", -1, 0},
+		{"NaN is a no-op", math.NaN(), 0},
+		{"positive infinity clamps to max duration", math.Inf(1), math.MaxInt64},
+		{"a value far outside decimal's overlap with float64 clamps to max duration", 1e300, math.MaxInt64},
+		{"a value just under int64 nanosecond range converts exactly", 1000, 1000 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := secondsToSleepDuration(tc.seconds)
+			if got != tc.want {
+				t.Errorf("secondsToSleepDuration(%v) = %v, want %v", tc.seconds, got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/native/http_native.go
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/native/http_native.go
@@ -757,7 +757,7 @@ func initHttpModule(rt *runtime.Runtime) {
 					}
 				}
 			}
-			httpClient := rt.Platform().HTTP.NewClient(pal.ClientConfig{
+			httpClient, err := rt.Platform().HTTP.NewClient(pal.ClientConfig{
 				Timeout:         decimalToDuration(timeout),
 				FollowRedirects: followRedirects,
 				HTTPVersion:     httpVersion,
@@ -766,6 +766,9 @@ func initHttpModule(rt *runtime.Runtime) {
 				ResponseLimits:  responseLimits,
 				Proxy:           proxyCfg,
 			})
+			if err != nil {
+				return values.NewErrorWithMessage("secureSocket: " + err.Error()), nil
+			}
 			self.Put("url", url)
 			self.Put("timeout", timeout)
 			self.Put("followRedirects", nil)

--- a/platform/pal/platform.go
+++ b/platform/pal/platform.go
@@ -26,6 +26,7 @@ package pal
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"time"
 )
@@ -54,6 +55,7 @@ type (
 		OS      OS
 		Time    Time
 		HTTP    HTTP
+		Net     Net
 		Signals SignalSource
 	}
 	IO struct {
@@ -82,6 +84,27 @@ type (
 	Time struct {
 		Now          func() time.Time
 		MonotonicNow func() time.Duration
+	}
+	// Net abstracts raw TCP(+TLS) socket dialing and listening for non-HTTP
+	// wire protocols (e.g. ldap, tcp). HTTP-based stdlibs must keep using
+	// pal.HTTP instead.
+	Net struct {
+		// Dial opens a TCP connection to address, optionally binding to
+		// localAddr first (empty = OS-chosen) and optionally upgrading to
+		// TLS (tlsCfg != nil) before returning. Reuses TLSConfig from HTTP.
+		Dial func(ctx context.Context, network, address, localAddr string, tlsCfg *TLSConfig) (net.Conn, error)
+		// Listen binds a TCP listener on address, optionally wrapping it in
+		// TLS (tlsCfg != nil). Reuses ServerTLSConfig from HTTP. The caller
+		// owns the accept loop and per-connection dispatch.
+		Listen func(network, address string, tlsCfg *ServerTLSConfig) (net.Listener, error)
+		// DialPacket opens a connected datagram socket (e.g. UDP) to address,
+		// optionally binding to localAddr first (empty = OS-chosen). The
+		// returned net.Conn's Read/Write only exchange data with address.
+		DialPacket func(ctx context.Context, network, address, localAddr string) (net.Conn, error)
+		// ListenPacket binds an unconnected datagram socket (e.g. UDP) on
+		// address. The returned net.PacketConn's ReadFrom/WriteTo carry an
+		// explicit per-datagram peer address, unlike DialPacket's net.Conn.
+		ListenPacket func(network, address string) (net.PacketConn, error)
 	}
 	HTTP struct {
 		// NewClient builds an outbound HTTP client (native: net/http; WASM: fetch).

--- a/platform/pal/platform.go
+++ b/platform/pal/platform.go
@@ -108,7 +108,10 @@ type (
 	}
 	HTTP struct {
 		// NewClient builds an outbound HTTP client (native: net/http; WASM: fetch).
-		NewClient func(cfg ClientConfig) HTTPClient
+		// Returns an error when cfg.TLS carries malformed CA/client certificate
+		// material rather than silently degrading (e.g. falling back to the
+		// system trust store).
+		NewClient func(cfg ClientConfig) (HTTPClient, error)
 		// Listen starts serving inbound requests to handler. On native it binds a
 		// TCP socket and runs http.Server.Serve; a WASM/web platform registers the
 		// handler with its JS host instead (no socket). Returns a handle whose

--- a/platform/palnative/http.go
+++ b/platform/palnative/http.go
@@ -31,7 +31,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -156,45 +155,7 @@ func (l *limitedBodyReadCloser) Close() error { return l.rc.Close() }
 // platform. It builds a *http.Client configured from cfg and wraps it so the
 // runtime sees only the pal.HTTPClient interface.
 func NewHTTPClient(cfg pal.ClientConfig) pal.HTTPClient {
-	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.TLS.InsecureSkipVerify} //nolint:gosec
-	if len(cfg.TLS.CACertPEM) > 0 {
-		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM(cfg.TLS.CACertPEM) {
-			_, _ = fmt.Fprintf(os.Stderr, "ballerina: failed to parse CA certificate PEM (no valid certificates found); custom CA not loaded\n")
-		} else {
-			tlsConfig.RootCAs = pool
-			if !cfg.TLS.InsecureSkipVerify {
-				// Go 1.15+ requires SANs for hostname verification; many self-signed and
-				// Java-issued certs only set the CN field. When a custom CA is provided
-				// we do our own verification so CN-only certs are accepted as a fallback.
-				tlsConfig.InsecureSkipVerify = true //nolint:gosec
-				tlsConfig.VerifyConnection = tlsVerifyConnectionWithCNFallback(pool)
-			}
-		}
-	}
-	if len(cfg.TLS.ClientCertPEM) > 0 && len(cfg.TLS.ClientKeyPEM) > 0 {
-		if cert, err := tls.X509KeyPair(cfg.TLS.ClientCertPEM, cfg.TLS.ClientKeyPEM); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "ballerina: tls.X509KeyPair failed (client certificate not loaded): %v\n", err)
-		} else {
-			tlsConfig.Certificates = []tls.Certificate{cert}
-		}
-	}
-	tlsConfig.ServerName = cfg.TLS.ServerName
-	tlsConfig.SessionTicketsDisabled = cfg.TLS.DisableSessionTickets
-	tlsConfig.MinVersion = tls.VersionTLS12 // secure default; overridden below if configured
-	if cfg.TLS.MinVersion != 0 {
-		tlsConfig.MinVersion = cfg.TLS.MinVersion
-	}
-	if cfg.TLS.MaxVersion != 0 {
-		tlsConfig.MaxVersion = cfg.TLS.MaxVersion
-	}
-	if len(cfg.TLS.CipherSuiteNames) > 0 {
-		if resolved := resolveCipherSuites(cfg.TLS.CipherSuiteNames); len(resolved) > 0 {
-			tlsConfig.CipherSuites = resolved
-		} else {
-			fmt.Fprintf(os.Stderr, "warning: no valid cipher suites resolved from cfg.TLS.CipherSuiteNames %v; keeping secure defaults\n", cfg.TLS.CipherSuiteNames)
-		}
-	}
+	tlsConfig := buildTLSConfig(cfg.TLS)
 	// Build a net.Dialer with a configurable connect timeout.
 	// TCP keep-alive is disabled (KeepAlive:-1) to match jBallerina's default
 	// socketConfig.keepAlive=false; HTTP-level connection reuse is handled by the Transport pool.
@@ -311,7 +272,14 @@ func resolveCipherSuites(names []string) []uint16 {
 // server's certificate chain against rootCAs and falls back to CN-based hostname matching
 // when no SANs are present. Go 1.15+ disabled CN-only hostname verification (RFC 6125 §2.3),
 // but many self-signed and Java-issued certificates still rely on it.
-func tlsVerifyConnectionWithCNFallback(rootCAs *x509.CertPool) func(tls.ConnectionState) error {
+// tlsVerifyConnectionWithCNFallback verifies the peer certificate chain
+// against rootCAs and its hostname against expectedServerName. expectedServerName
+// is the originally configured name, not tls.ConnectionState.ServerName — Go's
+// TLS client only echoes ServerName into ConnectionState when it was actually
+// sent as the SNI extension, and Go deliberately never sends SNI for IP-literal
+// server names (RFC 6066), so relying on cs.ServerName would always fail
+// hostname verification when dialing a bare IP address.
+func tlsVerifyConnectionWithCNFallback(rootCAs *x509.CertPool, expectedServerName string) func(tls.ConnectionState) error {
 	return func(cs tls.ConnectionState) error {
 		opts := x509.VerifyOptions{
 			Roots:         rootCAs,
@@ -323,15 +291,15 @@ func tlsVerifyConnectionWithCNFallback(rootCAs *x509.CertPool) func(tls.Connecti
 		if _, err := cs.PeerCertificates[0].Verify(opts); err != nil {
 			return err
 		}
-		// cs.ServerName is the SNI hostname (no port). Try SAN-based verification first.
-		// Only fall back to CN matching for certs that genuinely have no SANs — when SANs
-		// are present but don't match, that is a real mismatch and must not be bypassed.
+		// Try SAN-based verification first. Only fall back to CN matching for
+		// certs that genuinely have no SANs — when SANs are present but don't
+		// match, that is a real mismatch and must not be bypassed.
 		leaf := cs.PeerCertificates[0]
-		if err := leaf.VerifyHostname(cs.ServerName); err != nil {
+		if err := leaf.VerifyHostname(expectedServerName); err != nil {
 			if len(leaf.DNSNames) > 0 || len(leaf.IPAddresses) > 0 {
 				return err
 			}
-			return tlsMatchCN(leaf.Subject.CommonName, cs.ServerName)
+			return tlsMatchCN(leaf.Subject.CommonName, expectedServerName)
 		}
 		return nil
 	}

--- a/platform/palnative/http.go
+++ b/platform/palnative/http.go
@@ -154,8 +154,11 @@ func (l *limitedBodyReadCloser) Close() error { return l.rc.Close() }
 // NewHTTPClient is the pal.HTTP.NewClient factory for the native-CLI
 // platform. It builds a *http.Client configured from cfg and wraps it so the
 // runtime sees only the pal.HTTPClient interface.
-func NewHTTPClient(cfg pal.ClientConfig) pal.HTTPClient {
-	tlsConfig := buildTLSConfig(cfg.TLS)
+func NewHTTPClient(cfg pal.ClientConfig) (pal.HTTPClient, error) {
+	tlsConfig, err := buildTLSConfig(cfg.TLS)
+	if err != nil {
+		return nil, err
+	}
 	// Build a net.Dialer with a configurable connect timeout.
 	// TCP keep-alive is disabled (KeepAlive:-1) to match jBallerina's default
 	// socketConfig.keepAlive=false; HTTP-level connection reuse is handled by the Transport pool.
@@ -230,7 +233,7 @@ func NewHTTPClient(cfg pal.ClientConfig) pal.HTTPClient {
 			return nil
 		}
 	}
-	return &httpClient{client: c, maxEntityBodySize: cfg.ResponseLimits.MaxEntityBodySize}
+	return &httpClient{client: c, maxEntityBodySize: cfg.ResponseLimits.MaxEntityBodySize}, nil
 }
 
 // poolDefault returns d if non-zero, otherwise def.

--- a/platform/palnative/http_test.go
+++ b/platform/palnative/http_test.go
@@ -81,10 +81,13 @@ func TestNewHTTPClient_HTTP2_TLS(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		HTTPVersion: "2.0",
 		TLS:         pal.TLSConfig{InsecureSkipVerify: true},
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	status, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/", nil, 0, "", nil)
 	if body != nil {
 		_ = body.Close()
@@ -112,10 +115,13 @@ func TestNewHTTPClient_HTTP1_TLS(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		HTTPVersion: "1.1",
 		TLS:         pal.TLSConfig{InsecureSkipVerify: true},
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	status, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/", nil, 0, "", nil)
 	if body != nil {
 		_ = body.Close()
@@ -196,9 +202,12 @@ func TestNewHTTPClient_InsecureSkipVerify(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		TLS: pal.TLSConfig{InsecureSkipVerify: true},
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	status, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/", nil, 0, "", nil)
 	if err != nil {
 		t.Fatalf("expected successful connection with InsecureSkipVerify=true, got: %v", err)
@@ -219,9 +228,12 @@ func TestNewHTTPClient_TLSVerificationFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		TLS: pal.TLSConfig{InsecureSkipVerify: false},
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	_, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/", nil, 0, "", nil)
 	if body != nil {
 		_ = body.Close()
@@ -239,9 +251,12 @@ func TestNewHTTPClient_Timeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		Timeout: 100 * time.Millisecond,
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	_, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/", nil, 0, "", nil)
 	if body != nil {
 		_ = body.Close()
@@ -263,10 +278,13 @@ func TestNewHTTPClient_RedirectsDisabled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		FollowRedirects: pal.FollowRedirects{Enabled: false},
 		ResponseLimits:  pal.ResponseLimitConfig{MaxEntityBodySize: -1},
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	status, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/redirect", nil, 0, "", nil)
 	if body != nil {
 		_ = body.Close()
@@ -291,9 +309,12 @@ func TestNewHTTPClient_RedirectsEnabled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		FollowRedirects: pal.FollowRedirects{Enabled: true, MaxCount: 3},
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	status, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/redirect", nil, 0, "", nil)
 	if body != nil {
 		_ = body.Close()
@@ -314,13 +335,16 @@ func TestNewHTTPClient_TLSVersionRange(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		TLS: pal.TLSConfig{
 			MinVersion:         tls.VersionTLS12,
 			MaxVersion:         tls.VersionTLS13,
 			InsecureSkipVerify: true,
 		},
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	status, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/", nil, 0, "", nil)
 	if body != nil {
 		_ = body.Close()
@@ -350,12 +374,15 @@ func TestNewHTTPClient_ValidCipherSuites(t *testing.T) {
 	for i, s := range suites {
 		names[i] = s.Name
 	}
-	client := NewHTTPClient(pal.ClientConfig{
+	client, err := NewHTTPClient(pal.ClientConfig{
 		TLS: pal.TLSConfig{
 			CipherSuiteNames:   names,
 			InsecureSkipVerify: true,
 		},
 	})
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
 	status, _, body, err := client.Execute(context.Background(), "GET", server.URL+"/", nil, 0, "", nil)
 	if body != nil {
 		_ = body.Close()

--- a/platform/palnative/net.go
+++ b/platform/palnative/net.go
@@ -61,7 +61,12 @@ func Dial(ctx context.Context, network, address, localAddr string, tlsCfg *pal.T
 			effectiveTLSCfg.ServerName = address
 		}
 	}
-	tlsConn := tls.Client(conn, buildTLSConfig(effectiveTLSCfg))
+	tlsConfig, err := buildTLSConfig(effectiveTLSCfg)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	tlsConn := tls.Client(conn, tlsConfig)
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		_ = conn.Close()
 		return nil, err

--- a/platform/palnative/net.go
+++ b/platform/palnative/net.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Native-CLI implementation of the pal.Net contract: a raw TCP(+TLS) dialer
+// and listener for non-HTTP wire protocols (e.g. ldap, tcp). NewPlatform (in
+// pal.go) wires Dial/Listen into pal.Net.
+
+package palnative
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	"github.com/ballerina-nutcracker/ballerina/platform/pal"
+)
+
+// Dial is the pal.Net.Dial factory for the native-CLI platform. It opens a
+// plain TCP connection, optionally bound to localAddr, then upgrades it to
+// TLS in-place when tlsCfg is non-nil, performing the handshake before
+// returning.
+func Dial(ctx context.Context, network, address, localAddr string, tlsCfg *pal.TLSConfig) (net.Conn, error) {
+	dialer := net.Dialer{}
+	if localAddr != "" {
+		addr, err := net.ResolveTCPAddr(network, localAddr)
+		if err != nil {
+			return nil, err
+		}
+		dialer.LocalAddr = addr
+	}
+	conn, err := dialer.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+	if tlsCfg == nil {
+		return conn, nil
+	}
+	effectiveTLSCfg := *tlsCfg
+	if effectiveTLSCfg.ServerName == "" {
+		// tls.Client (unlike tls.Dial) never derives ServerName from the
+		// dial address on its own, so hostname verification would otherwise
+		// always fail against an empty expected name. Must be set before
+		// buildTLSConfig runs: it's captured by value into the
+		// VerifyConnection closure when a custom CA is configured.
+		if host, _, splitErr := net.SplitHostPort(address); splitErr == nil {
+			effectiveTLSCfg.ServerName = host
+		} else {
+			effectiveTLSCfg.ServerName = address
+		}
+	}
+	tlsConn := tls.Client(conn, buildTLSConfig(effectiveTLSCfg))
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return tlsConn, nil
+}
+
+// ListenTCP is the pal.Net.Listen factory for the native-CLI platform. It
+// binds a plain TCP listener, optionally wrapping it in TLS when tlsCfg is
+// non-nil. The caller owns the accept loop and per-connection dispatch.
+// Named distinctly from httpserver.go's Listen (pal.HTTP.Listen), which owns
+// its own accept loop internally via http.Server.
+func ListenTCP(network, address string, tlsCfg *pal.ServerTLSConfig) (net.Listener, error) {
+	ln, err := net.Listen(network, address)
+	if err != nil {
+		return nil, err
+	}
+	if tlsCfg == nil {
+		return ln, nil
+	}
+	cfg, err := buildServerTLSConfig(tlsCfg)
+	if err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	return tls.NewListener(ln, cfg), nil
+}
+
+// DialPacket is the pal.Net.DialPacket factory for the native-CLI platform.
+// It opens a connected datagram socket (e.g. UDP) to address, optionally
+// bound to localAddr first. There is no TLS analogue for datagram sockets.
+func DialPacket(ctx context.Context, network, address, localAddr string) (net.Conn, error) {
+	dialer := net.Dialer{}
+	if localAddr != "" {
+		addr, err := net.ResolveUDPAddr(network, localAddr)
+		if err != nil {
+			return nil, err
+		}
+		dialer.LocalAddr = addr
+	}
+	return dialer.DialContext(ctx, network, address)
+}
+
+// ListenPacket is the pal.Net.ListenPacket factory for the native-CLI
+// platform. It binds an unconnected datagram socket (e.g. UDP) on address;
+// the caller owns the read loop and per-datagram dispatch.
+func ListenPacket(network, address string) (net.PacketConn, error) {
+	return net.ListenPacket(network, address)
+}

--- a/platform/palnative/pal.go
+++ b/platform/palnative/pal.go
@@ -143,6 +143,12 @@ func NewPlatform() (pal.Platform, func()) {
 			NewClient: NewHTTPClient,
 			Listen:    Listen,
 		},
+		Net: pal.Net{
+			Dial:         Dial,
+			Listen:       ListenTCP,
+			DialPacket:   DialPacket,
+			ListenPacket: ListenPacket,
+		},
 		Signals: signals,
 	}, cleanupSignals
 }

--- a/platform/palnative/tls.go
+++ b/platform/palnative/tls.go
@@ -69,7 +69,7 @@ func buildTLSConfig(cfg pal.TLSConfig) *tls.Config {
 		if resolved := resolveCipherSuites(cfg.CipherSuiteNames); len(resolved) > 0 {
 			tlsConfig.CipherSuites = resolved
 		} else {
-			fmt.Fprintf(os.Stderr, "warning: no valid cipher suites resolved from cfg.TLS.CipherSuiteNames %v; keeping secure defaults\n", cfg.CipherSuiteNames)
+			_, _ = fmt.Fprintf(os.Stderr, "warning: no valid cipher suites resolved from cfg.CipherSuiteNames %v; keeping secure defaults\n", cfg.CipherSuiteNames)
 		}
 	}
 	return tlsConfig

--- a/platform/palnative/tls.go
+++ b/platform/palnative/tls.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Shared TLS config assembly for native-CLI PAL implementations that dial
+// outbound connections (http.go's HTTP client, net.go's raw socket dialer).
+
+package palnative
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/ballerina-nutcracker/ballerina/platform/pal"
+)
+
+// buildTLSConfig assembles a *tls.Config from a pal.TLSConfig, resolving CA
+// pools, client certificates, SNI, cipher suites, and protocol version
+// bounds. Shared by every native-CLI PAL category that opens a TLS
+// connection.
+func buildTLSConfig(cfg pal.TLSConfig) *tls.Config {
+	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify} //nolint:gosec
+	if len(cfg.CACertPEM) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(cfg.CACertPEM) {
+			_, _ = fmt.Fprintf(os.Stderr, "ballerina: failed to parse CA certificate PEM (no valid certificates found); custom CA not loaded\n")
+		} else {
+			tlsConfig.RootCAs = pool
+			if !cfg.InsecureSkipVerify {
+				// Go 1.15+ requires SANs for hostname verification; many self-signed and
+				// Java-issued certs only set the CN field. When a custom CA is provided
+				// we do our own verification so CN-only certs are accepted as a fallback.
+				tlsConfig.InsecureSkipVerify = true //nolint:gosec
+				tlsConfig.VerifyConnection = tlsVerifyConnectionWithCNFallback(pool, cfg.ServerName)
+			}
+		}
+	}
+	if len(cfg.ClientCertPEM) > 0 && len(cfg.ClientKeyPEM) > 0 {
+		if cert, err := tls.X509KeyPair(cfg.ClientCertPEM, cfg.ClientKeyPEM); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "ballerina: tls.X509KeyPair failed (client certificate not loaded): %v\n", err)
+		} else {
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		}
+	}
+	tlsConfig.ServerName = cfg.ServerName
+	tlsConfig.SessionTicketsDisabled = cfg.DisableSessionTickets
+	tlsConfig.MinVersion = tls.VersionTLS12 // secure default; overridden below if configured
+	if cfg.MinVersion != 0 {
+		tlsConfig.MinVersion = cfg.MinVersion
+	}
+	if cfg.MaxVersion != 0 {
+		tlsConfig.MaxVersion = cfg.MaxVersion
+	}
+	if len(cfg.CipherSuiteNames) > 0 {
+		if resolved := resolveCipherSuites(cfg.CipherSuiteNames); len(resolved) > 0 {
+			tlsConfig.CipherSuites = resolved
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: no valid cipher suites resolved from cfg.TLS.CipherSuiteNames %v; keeping secure defaults\n", cfg.CipherSuiteNames)
+		}
+	}
+	return tlsConfig
+}

--- a/platform/palnative/tls.go
+++ b/platform/palnative/tls.go
@@ -31,30 +31,32 @@ import (
 // buildTLSConfig assembles a *tls.Config from a pal.TLSConfig, resolving CA
 // pools, client certificates, SNI, cipher suites, and protocol version
 // bounds. Shared by every native-CLI PAL category that opens a TLS
-// connection.
-func buildTLSConfig(cfg pal.TLSConfig) *tls.Config {
+// connection. Fails closed on a malformed CA or client certificate: jBallerina's
+// own TLS setup (netty's SslContextBuilder.trustManager/keyManager) throws
+// immediately on invalid PEM material rather than silently falling back to
+// the system trust store or an unauthenticated connection.
+func buildTLSConfig(cfg pal.TLSConfig) (*tls.Config, error) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify} //nolint:gosec
 	if len(cfg.CACertPEM) > 0 {
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(cfg.CACertPEM) {
-			_, _ = fmt.Fprintf(os.Stderr, "ballerina: failed to parse CA certificate PEM (no valid certificates found); custom CA not loaded\n")
-		} else {
-			tlsConfig.RootCAs = pool
-			if !cfg.InsecureSkipVerify {
-				// Go 1.15+ requires SANs for hostname verification; many self-signed and
-				// Java-issued certs only set the CN field. When a custom CA is provided
-				// we do our own verification so CN-only certs are accepted as a fallback.
-				tlsConfig.InsecureSkipVerify = true //nolint:gosec
-				tlsConfig.VerifyConnection = tlsVerifyConnectionWithCNFallback(pool, cfg.ServerName)
-			}
+			return nil, fmt.Errorf("failed to parse CA certificate PEM: no valid certificates found")
+		}
+		tlsConfig.RootCAs = pool
+		if !cfg.InsecureSkipVerify {
+			// Go 1.15+ requires SANs for hostname verification; many self-signed and
+			// Java-issued certs only set the CN field. When a custom CA is provided
+			// we do our own verification so CN-only certs are accepted as a fallback.
+			tlsConfig.InsecureSkipVerify = true //nolint:gosec
+			tlsConfig.VerifyConnection = tlsVerifyConnectionWithCNFallback(pool, cfg.ServerName)
 		}
 	}
 	if len(cfg.ClientCertPEM) > 0 && len(cfg.ClientKeyPEM) > 0 {
-		if cert, err := tls.X509KeyPair(cfg.ClientCertPEM, cfg.ClientKeyPEM); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "ballerina: tls.X509KeyPair failed (client certificate not loaded): %v\n", err)
-		} else {
-			tlsConfig.Certificates = []tls.Certificate{cert}
+		cert, err := tls.X509KeyPair(cfg.ClientCertPEM, cfg.ClientKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate: %w", err)
 		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 	tlsConfig.ServerName = cfg.ServerName
 	tlsConfig.SessionTicketsDisabled = cfg.DisableSessionTickets
@@ -72,5 +74,5 @@ func buildTLSConfig(cfg pal.TLSConfig) *tls.Config {
 			_, _ = fmt.Fprintf(os.Stderr, "warning: no valid cipher suites resolved from cfg.CipherSuiteNames %v; keeping secure defaults\n", cfg.CipherSuiteNames)
 		}
 	}
-	return tlsConfig
+	return tlsConfig, nil
 }

--- a/runtime/lifecycle_test.go
+++ b/runtime/lifecycle_test.go
@@ -506,7 +506,7 @@ func (p *lifecycleTestPal) Platform() pal.Platform {
 			},
 		},
 		HTTP: pal.HTTP{
-			NewClient: func(_ pal.ClientConfig) pal.HTTPClient { return nil },
+			NewClient: func(_ pal.ClientConfig) (pal.HTTPClient, error) { return nil, nil },
 		},
 		Signals: pal.SignalSource{Signals: p.signals},
 	}

--- a/test_util/testharness/test_harness.go
+++ b/test_util/testharness/test_harness.go
@@ -341,8 +341,8 @@ func (p *testPal) Platform() pal.Platform {
 			MonotonicNow: func() time.Duration { return time.Since(testProcessStart) },
 		},
 		HTTP: pal.HTTP{
-			NewClient: func(_ pal.ClientConfig) pal.HTTPClient {
-				return &stubHTTP{}
+			NewClient: func(_ pal.ClientConfig) (pal.HTTPClient, error) {
+				return &stubHTTP{}, nil
 			},
 		},
 		Signals: p.signalSrc,


### PR DESCRIPTION
Depends on: https://github.com/ballerina-nutcracker/ballerina/pull/656

## Summary

Adds a `pal.Net` surface (`Dial`/`Listen`/`DialPacket`/`ListenPacket`) to the Platform Adaptation Layer for raw TCP/UDP(+TLS) socket access, alongside a `tls.go` that extracts the TLS-config assembly previously inlined in `NewHTTPClient` so it's shared between the HTTP client and the new raw socket path.

- `pal.Net.Dial` — dial a TCP connection, optionally bound to a local address, optionally upgraded to TLS before returning
- `pal.Net.Listen` — bind a TCP listener, optionally wrapped in TLS; caller owns the accept loop
- `pal.Net.DialPacket` / `pal.Net.ListenPacket` — connected/unconnected datagram (UDP) sockets
- `buildTLSConfig` extracted out of `NewHTTPClient` into `tls.go` so both HTTP and the new socket path share one TLS-config assembly path
- `tlsVerifyConnectionWithCNFallback` now takes an explicit `expectedServerName` instead of reading `tls.ConnectionState.ServerName`, since Go never sends SNI for IP-literal dials — hostname verification would otherwise always fail against a bare IP address

## Why

This is the base branch for the `ballerina/tcp`, `ballerina/udp`, and `ballerina/ldap` stdlibs — all non-HTTP wire protocols that need raw socket access rather than `pal.HTTP`. Landing the PAL surface on its own keeps those stdlib PRs focused on protocol logic instead of platform plumbing, and lets them share one TLS-config implementation instead of each reinventing it.

## Note on test coverage

This PR only introduces the `pal.Net` interface and its native-CLI implementation — there are no `tcp`/`udp`/`ldap` stdlib callers yet, so there's nothing to drive it through corpus tests. Coverage is intentionally deferred to the `ballerina/tcp`, `ballerina/udp`, and `ballerina/ldap` implementation PRs, which will exercise `Dial`/`Listen`/`DialPacket`/`ListenPacket` (and the shared TLS path) end-to-end via their own corpus tests.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native networking support for TCP, TLS, and datagram connections, including dialing and listening.
  - Added support for configuring TLS connections with custom certificates, client authentication, protocol versions, and cipher suites.

- **Bug Fixes**
  - Improved TLS hostname verification, including safer handling when certificates lack subject alternative names.
  - Invalid TLS certificate configuration now reports an error instead of silently falling back.
  - Prevented invalid or excessively large sleep durations from causing runtime errors or unexpected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->