### PR TITLE
fix(desugar): avoid lazy initializing $moduleListeners position

### DIFF
--- a/desugar/desugar.go
+++ b/desugar/desugar.go
@@ -837,6 +837,7 @@ func addModuleListenersGlobal(pkgCtx *packageContext, pkg *ast.BLangPackage, pos
 	pkg.AddGlobalVariable(global)
 
 	ref := &ast.BLangSimpleVarRef{VariableName: &ast.BLangIdentifier{Value: moduleListenersGlobalName}}
+	ref.VariableName.SetPosition(pos)
 	ref.SetSymbol(symRef)
 	ref.SetDeterminedType(arrTy)
 	ref.SetPosition(pos)


### PR DESCRIPTION
## Purpose
Resolves #647 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-location tracking for module listener references, supporting more accurate tooling and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->