### PR TITLE
fix(benchmark): look up the PR via the API instead of workflow_run.pull_requests

### DIFF
--- a/.github/scripts/post-http-benchmark-comment.js
+++ b/.github/scripts/post-http-benchmark-comment.js
@@ -7,21 +7,32 @@ module.exports = async ({ github, context, core }) => {
   // never from benchmark-meta.json — that file is written by the prepare
   // job while running PR-head code, so a malicious PR could forge it to
   // make this privileged (pull-requests: write) job comment on an
-  // unrelated PR. pull_requests is only populated for same-repo PRs and
-  // can be ambiguous in theory, so require exactly one association.
-  const pulls = context.payload.workflow_run.pull_requests || [];
-  if (pulls.length !== 1) {
-    core.info(`Skipping: workflow_run reports ${pulls.length} associated pull request(s); expected exactly 1.`);
+  // unrelated PR. workflow_run.pull_requests is documented but frequently
+  // empty in practice (always for fork PRs, and unreliably even for
+  // same-repo ones), so look the PR up via the API instead, keyed off the
+  // trusted head_repository/head_branch/head_sha.
+  const headBranch = context.payload.workflow_run.head_branch;
+  const headRepo = context.payload.workflow_run.head_repository?.full_name;
+  const workflowHeadSha = context.payload.workflow_run.head_sha;
+  if (!headBranch || !headRepo) {
+    core.info("Skipping: workflow_run is missing head branch/repository info.");
     return;
   }
-  const issueNumber = pulls[0].number;
-  const workflowHeadSha = context.payload.workflow_run.head_sha;
+  const headOwner = headRepo.split("/")[0];
+
+  const { data: candidates } = await github.rest.pulls.list({
+    ...context.repo,
+    state: "open",
+    head: `${headOwner}:${headBranch}`,
+  });
+  if (candidates.length !== 1) {
+    core.info(`Skipping: found ${candidates.length} open pull request(s) for ${headOwner}:${headBranch}; expected exactly 1.`);
+    return;
+  }
+  const pr = candidates[0];
+  const issueNumber = pr.number;
 
   // Bail out if a newer push has already superseded this run.
-  const { data: pr } = await github.rest.pulls.get({
-    ...context.repo,
-    pull_number: issueNumber,
-  });
   if (pr.head.sha !== workflowHeadSha) {
     core.info(`Skipping: workflow_run head ${workflowHeadSha} is not current PR head ${pr.head.sha}`);
     return;


### PR DESCRIPTION
## Summary
- `workflow_run.pull_requests` is documented but unreliable in practice — [run 30346997330](https://github.com/ballerina-nutcracker/ballerina/actions/runs/30346997330) confirms it comes back empty even for a normal same-repo PR (`perf-runtime-optimizations`), not just forks. Trusting it made `benchmark-pr-http-comment.yml`'s comment step silently skip on every run since #682 merged.
- Replace it with `pulls.list({ head: "<owner>:<branch>" })`, keyed off the trusted `head_repository`/`head_branch` fields from the `workflow_run` event context — never from the uploaded artifact, preserving the trust boundary from #682.
- This also fixes a case that was never actually exercised: fork-originated PRs, where `pull_requests` is documented to always be empty.

## Test plan
- [x] `node --check` on the updated script
- [x] Mock harness exercising: normal single match, zero matches, stale `head_sha`, fork-PR (cross-owner `head` filter), missing `head_repository` — all produce the expected create/update/skip behavior
- [x] Confirm the next real `workflow_run` for an HTTP benchmark PR successfully posts a comment