### PR TITLE
refactor(ci): rename release artifacts

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build the Ballerina CLI for all platforms
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -65,7 +67,7 @@ jobs:
             src_dir="dist/${GOOS}-${GOARCH}"
             ext=""
             [[ "$GOOS" == "windows" ]] && ext=".exe"
-            artifact_dir="artifacts/nutcracker-${GOOS}-${GOARCH}/ballerina-${VERSION}"
+            artifact_dir="artifacts/ballerina-nutcracker-${GOOS}-${GOARCH}/ballerina-${VERSION}"
             mkdir -p "$artifact_dir"
             cp "$src_dir/bal${ext}" "$artifact_dir/bal${ext}"
           done
@@ -73,29 +75,29 @@ jobs:
       - name: Upload linux-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-linux-amd64
-          path: artifacts/nutcracker-linux-amd64
+          name: ballerina-nutcracker-linux-amd64
+          path: artifacts/ballerina-nutcracker-linux-amd64
 
       - name: Upload linux-arm64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-linux-arm64
-          path: artifacts/nutcracker-linux-arm64
+          name: ballerina-nutcracker-linux-arm64
+          path: artifacts/ballerina-nutcracker-linux-arm64
 
       - name: Upload darwin-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-darwin-amd64
-          path: artifacts/nutcracker-darwin-amd64
+          name: ballerina-nutcracker-darwin-amd64
+          path: artifacts/ballerina-nutcracker-darwin-amd64
 
       - name: Upload darwin-arm64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-darwin-arm64
-          path: artifacts/nutcracker-darwin-arm64
+          name: ballerina-nutcracker-darwin-arm64
+          path: artifacts/ballerina-nutcracker-darwin-arm64
 
       - name: Upload windows-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-windows-amd64
-          path: artifacts/nutcracker-windows-amd64
+          name: ballerina-nutcracker-windows-amd64
+          path: artifacts/ballerina-nutcracker-windows-amd64

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,7 +65,7 @@ jobs:
             src_dir="dist/${GOOS}-${GOARCH}"
             ext=""
             [[ "$GOOS" == "windows" ]] && ext=".exe"
-            artifact_dir="artifacts/bal-${GOOS}-${GOARCH}/ballerina-${VERSION}"
+            artifact_dir="artifacts/nutcracker-${GOOS}-${GOARCH}/ballerina-${VERSION}"
             mkdir -p "$artifact_dir"
             cp "$src_dir/bal${ext}" "$artifact_dir/bal${ext}"
           done
@@ -73,29 +73,29 @@ jobs:
       - name: Upload linux-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-linux-amd64
-          path: artifacts/bal-linux-amd64
+          name: nutcracker-linux-amd64
+          path: artifacts/nutcracker-linux-amd64
 
       - name: Upload linux-arm64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-linux-arm64
-          path: artifacts/bal-linux-arm64
+          name: nutcracker-linux-arm64
+          path: artifacts/nutcracker-linux-arm64
 
       - name: Upload darwin-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-darwin-amd64
-          path: artifacts/bal-darwin-amd64
+          name: nutcracker-darwin-amd64
+          path: artifacts/nutcracker-darwin-amd64
 
       - name: Upload darwin-arm64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-darwin-arm64
-          path: artifacts/bal-darwin-arm64
+          name: nutcracker-darwin-arm64
+          path: artifacts/nutcracker-darwin-arm64
 
       - name: Upload windows-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-windows-amd64
-          path: artifacts/bal-windows-amd64
+          name: nutcracker-windows-amd64
+          path: artifacts/nutcracker-windows-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             src_dir="dist/${GOOS}-${GOARCH}"
             ext=""
             [[ "$GOOS" == "windows" ]] && ext=".exe"
-            artifact_dir="artifacts/bal-${GOOS}-${GOARCH}/ballerina-${VERSION}"
+            artifact_dir="artifacts/nutcracker-${GOOS}-${GOARCH}/ballerina-${VERSION}"
             mkdir -p "$artifact_dir"
             cp "$src_dir/bal${ext}" "$artifact_dir/bal${ext}"
           done
@@ -64,32 +64,32 @@ jobs:
       - name: Upload linux-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-linux-amd64
-          path: artifacts/bal-linux-amd64
+          name: nutcracker-linux-amd64
+          path: artifacts/nutcracker-linux-amd64
 
       - name: Upload linux-arm64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-linux-arm64
-          path: artifacts/bal-linux-arm64
+          name: nutcracker-linux-arm64
+          path: artifacts/nutcracker-linux-arm64
 
       - name: Upload darwin-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-darwin-amd64
-          path: artifacts/bal-darwin-amd64
+          name: nutcracker-darwin-amd64
+          path: artifacts/nutcracker-darwin-amd64
 
       - name: Upload darwin-arm64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-darwin-arm64
-          path: artifacts/bal-darwin-arm64
+          name: nutcracker-darwin-arm64
+          path: artifacts/nutcracker-darwin-arm64
 
       - name: Upload windows-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: bal-windows-amd64
-          path: artifacts/bal-windows-amd64
+          name: nutcracker-windows-amd64
+          path: artifacts/nutcracker-windows-amd64
 
   release:
     name: Create Release
@@ -114,7 +114,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           mkdir -p release
-          for artifact_dir in dist/bal-*; do
+          for artifact_dir in dist/nutcracker-*; do
             platform=$(basename "$artifact_dir")
             # Make the binary executable
             find "$artifact_dir" -name "bal*" -type f -exec chmod +x {} \;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build the Ballerina CLI for all platforms
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -56,7 +58,7 @@ jobs:
             src_dir="dist/${GOOS}-${GOARCH}"
             ext=""
             [[ "$GOOS" == "windows" ]] && ext=".exe"
-            artifact_dir="artifacts/nutcracker-${GOOS}-${GOARCH}/ballerina-${VERSION}"
+            artifact_dir="artifacts/ballerina-nutcracker-${GOOS}-${GOARCH}/ballerina-${VERSION}"
             mkdir -p "$artifact_dir"
             cp "$src_dir/bal${ext}" "$artifact_dir/bal${ext}"
           done
@@ -64,32 +66,32 @@ jobs:
       - name: Upload linux-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-linux-amd64
-          path: artifacts/nutcracker-linux-amd64
+          name: ballerina-nutcracker-linux-amd64
+          path: artifacts/ballerina-nutcracker-linux-amd64
 
       - name: Upload linux-arm64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-linux-arm64
-          path: artifacts/nutcracker-linux-arm64
+          name: ballerina-nutcracker-linux-arm64
+          path: artifacts/ballerina-nutcracker-linux-arm64
 
       - name: Upload darwin-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-darwin-amd64
-          path: artifacts/nutcracker-darwin-amd64
+          name: ballerina-nutcracker-darwin-amd64
+          path: artifacts/ballerina-nutcracker-darwin-amd64
 
       - name: Upload darwin-arm64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-darwin-arm64
-          path: artifacts/nutcracker-darwin-arm64
+          name: ballerina-nutcracker-darwin-arm64
+          path: artifacts/ballerina-nutcracker-darwin-arm64
 
       - name: Upload windows-amd64
         uses: actions/upload-artifact@v7
         with:
-          name: nutcracker-windows-amd64
-          path: artifacts/nutcracker-windows-amd64
+          name: ballerina-nutcracker-windows-amd64
+          path: artifacts/ballerina-nutcracker-windows-amd64
 
   release:
     name: Create Release
@@ -114,12 +116,12 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           mkdir -p release
-          for artifact_dir in dist/nutcracker-*; do
+          for artifact_dir in dist/ballerina-nutcracker-*; do
             platform=$(basename "$artifact_dir")
             # Make the binary executable
             find "$artifact_dir" -name "bal*" -type f -exec chmod +x {} \;
             cd "$artifact_dir"
-            zip -r "../../release/ballerina-${platform}-${VERSION}.zip" .
+            zip -r "../../release/${platform}-${VERSION}.zip" .
             cd ../..
           done
 


### PR DESCRIPTION
## Purpose
> Rename release artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release artifact naming across supported platforms.
  * Standardized packaged binary directories and uploaded artifact names.
  * Updated release asset preparation to use the new artifact structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->