### PR TITLE
fix(ci): install wrk in nightly race detector workflow

### DIFF
--- a/.github/workflows/nightly-race.yml
+++ b/.github/workflows/nightly-race.yml
@@ -30,6 +30,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y hyperfine
 
+      - name: Install wrk
+        run: sudo apt-get install -y wrk
+
       - name: Run all modules with race detector
         run: python3 .github/scripts/run_native_tests.py --race
 


### PR DESCRIPTION
The compiler-tools/benchmark-http module's tests require wrk, but nightly-race.yml only installed hyperfine, causing TestMeasureOnceProducesSample to fail when run_native_tests.py walks that module.

Fixes: https://github.com/ballerina-nutcracker/ballerina/issues/691

Sample run: https://github.com/TharmiganK/ballerina-nutcracker/actions/runs/30508186941/job/90762384747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly testing infrastructure to include an additional performance-testing tool before race-detector tests run.
  * Scheduling, test execution, and failure notifications remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->