### PR TITLE
ci(coverage): restore project check and update coverage scope

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,7 @@
 github_checks:
   annotations: true
 
-ignore:
-  - "test_util/**"
-
 coverage:
-  ignore:
-    - "test_util/**"
   status:
     project:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,9 @@ coverage:
   ignore:
     - "test_util/**"
   status:
+    project:
+      default:
+        target: auto
     patch:
       default:
         target: 80%

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,7 @@ github_checks:
   annotations: true
 
 coverage:
+  range: "60...80"
   status:
     project:
       default:


### PR DESCRIPTION
## Purpose
Re-add `project` status with `target: auto` (no flags needed since coverage is now a single aggregated run) so PRs show both `codecov/patch` and `codecov/project` again

## Summary by CodeRabbit

* **Chores**
  * Updated project quality monitoring to automatically establish a default coverage target.
  * No user-facing functionality or interface changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage reporting thresholds to provide more consistent visibility into overall and changed-code test coverage.
  * Added an automatic project coverage target while retaining the existing patch coverage requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->