### PR TITLE
fix(bir): distinguish `self` references from parameters named

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ parser/testdata/**/*.json
 # Coverage report and local agent/editor state
 coverage_report.html
 .claude/
+.pi/
 
 # Ephemeral report produced by the validate-stdlib-contract skill
 CONTRACT_VALIDATION.md

--- a/bir/codec/deserializer.go
+++ b/bir/codec/deserializer.go
@@ -439,7 +439,7 @@ func (br *birReader) readFunction() *bir.BIRFunction {
 	var restParams *bir.BIRParameter
 	if hasRestParam {
 		paramStart := 1
-		if len(localVars) > 1 && localVars[1].GetName() == "self" {
+		if flag.Has(model.FlagAttached) {
 			paramStart = 2
 		}
 		restIdx := paramStart + len(requiredParams)

--- a/bir/pretty_print.go
+++ b/bir/pretty_print.go
@@ -97,7 +97,7 @@ func (p *PrettyPrinter) PrintFunction(function BIRFunction) {
 	p.write(function.Name.Value())
 	p.write("(")
 	paramStart := 1
-	if len(function.LocalVars) > 1 && function.LocalVars[1].GetName() == "self" {
+	if function.Flags.Has(model.FlagAttached) {
 		paramStart = 2
 	}
 	for i, v := range function.LocalVars[paramStart:] {
@@ -112,7 +112,7 @@ func (p *PrettyPrinter) PrintFunction(function BIRFunction) {
 	}
 	if function.RestParams != nil {
 		variableIndex := paramStart + len(function.RequiredParams)
-		if variableIndex != 1 {
+		if variableIndex != paramStart {
 			p.write(",")
 		}
 		p.write(p.PrintSemType(function.LocalVars[variableIndex].Type))

--- a/corpus/ast/subset8/08-vararg/self-param-v.txt
+++ b/corpus/ast/subset8/08-vararg/self-param-v.txt
@@ -1,0 +1,22 @@
+(compilation-unit  regular-source
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (invocation first (
+            (literal 1)
+            (literal 2)
+            (literal 3))))))))
+  (function first (
+    (variable self (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (assignment
+        (wildcard-binding-pattern)
+        (simple-var-ref rest))
+      (return
+        (simple-var-ref self)))))

--- a/corpus/bal/subset8/08-vararg/self-param-v.bal
+++ b/corpus/bal/subset8/08-vararg/self-param-v.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println(first(1, 2, 3)); // @output 1
+}
+
+function first(int self, int... rest) returns int {
+    _ = rest;
+    return self;
+}

--- a/corpus/bir/subset8/08-object/rest1-v.txt
+++ b/corpus/bir/subset8/08-object/rest1-v.txt
@@ -10,7 +10,7 @@ class Adder {
     }
   }
 
-  sum(,[int...]...) -> int{
+  sum([int...]...) -> int{
     bb0 {
       %4 = ConstantLoad base
       %3 = self[%4];

--- a/corpus/bir/subset8/08-object/rest5-v.txt
+++ b/corpus/bir/subset8/08-object/rest5-v.txt
@@ -7,7 +7,7 @@ class IntAdder {
     }
   }
 
-  sum(,[int...]...) -> int{
+  sum([int...]...) -> int{
     bb0 {
       %3 = ConstantLoad 0
       total = %3;

--- a/corpus/bir/subset8/08-vararg/self-param-v.txt
+++ b/corpus/bir/subset8/08-vararg/self-param-v.txt
@@ -1,0 +1,26 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1
+    %2 = %1;
+    %3 = ConstantLoad 2
+    %4 = %3;
+    %5 = ConstantLoad 3
+    %6 = %5;
+    %7 = first(%2,%4,%6) -> bb1;
+  }
+  bb1 {
+    %8 = %7;
+    %9 = println(%8) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}
+first(int,[int...]...) -> int{
+  bb0 {
+    %3 = rest;
+    %0 = self;
+    return;
+  }
+}

--- a/corpus/bir/subset9/09-function/signature-type-defaults-v.txt
+++ b/corpus/bir/subset9/09-function/signature-type-defaults-v.txt
@@ -7,7 +7,7 @@ class Client {
     }
   }
 
-  resource get value Client.$resource$get$0(,[function(int) returns int...]...) -> {| value: int, never... |}{
+  resource get value Client.$resource$get$0([function(int) returns int...]...) -> {| value: int, never... |}{
     bb0 {
       _ = callbacks;
       %4 = ConstantLoad value

--- a/corpus/cfg/subset8/08-vararg/self-param-v.txt
+++ b/corpus/cfg/subset8/08-vararg/self-param-v.txt
@@ -1,0 +1,19 @@
+(first
+  (bb0 () ()
+    (assignment
+      (wildcard-binding-pattern)
+      (simple-var-ref rest))
+    (return
+      (simple-var-ref self))
+  )
+)
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (invocation first (
+          (literal 1)
+          (literal 2)
+          (literal 3))))))
+  )
+)

--- a/corpus/desugared/subset8/08-vararg/self-param-v.txt
+++ b/corpus/desugared/subset8/08-vararg/self-param-v.txt
@@ -1,0 +1,21 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (invocation first (
+            (literal 1)
+            (literal 2)
+            (literal 3))))))))
+  (function first (
+    (variable self (type
+      (value-type int)))) (
+    (value-type int))
+    (block-function-body
+      (assignment
+        (wildcard-binding-pattern)
+        (simple-var-ref rest))
+      (return
+        (simple-var-ref self)))))

--- a/corpus/integration/subset8/08-vararg/self-param-v.txtar
+++ b/corpus/integration/subset8/08-vararg/self-param-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+1
+-- stderr --


### PR DESCRIPTION
$subject
Resolves https://github.com/ballerina-nutcracker/ballerina/issues/717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of attached functions with variadic parameters.
  - Function display and deserialization now correctly recognize implicit receiver parameters.

- **Tests**
  - Added coverage for attached functions that combine a receiver parameter with variadic arguments.
  - Verified that the expected result is printed without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->