### PR TITLE
feat(stdlib): add MIME related API support in http

### DIFF
--- a/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
@@ -47,7 +47,7 @@ class $service$0 {
 
   $remote$greet() -> string{
     bb0 {
-      lock-start "$anon/.:$service.706.1.foo" GOTO bb1;
+      lock-start "$anon/.:$service.767.1.foo" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 2
@@ -55,7 +55,7 @@ class $service$0 {
       %0 = (1, self)[%1];
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.706.1.foo" GOTO bb2;
+      lock-end "$anon/.:$service.767.1.foo" GOTO bb2;
     }
     bb2 {
       return;
@@ -77,7 +77,7 @@ class $service$0 {
   resource get hello $resource$get$0(string) -> string{
     bb0 {
       _ = name;
-      lock-start "$anon/.:$service.706.1.foo" GOTO bb1;
+      lock-start "$anon/.:$service.767.1.foo" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 4
@@ -87,7 +87,7 @@ class $service$0 {
       %0 = + %1 %2;
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.706.1.foo" GOTO bb2;
+      lock-end "$anon/.:$service.767.1.foo" GOTO bb2;
     }
     bb2 {
       return;

--- a/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
@@ -47,7 +47,7 @@ class $service$0 {
 
   $remote$greet() -> string{
     bb0 {
-      lock-start "$anon/.:$service.590.1.foo" GOTO bb1;
+      lock-start "$anon/.:$service.706.1.foo" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 2
@@ -55,7 +55,7 @@ class $service$0 {
       %0 = (1, self)[%1];
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.590.1.foo" GOTO bb2;
+      lock-end "$anon/.:$service.706.1.foo" GOTO bb2;
     }
     bb2 {
       return;
@@ -77,7 +77,7 @@ class $service$0 {
   resource get hello $resource$get$0(string) -> string{
     bb0 {
       _ = name;
-      lock-start "$anon/.:$service.590.1.foo" GOTO bb1;
+      lock-start "$anon/.:$service.706.1.foo" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 4
@@ -87,7 +87,7 @@ class $service$0 {
       %0 = + %1 %2;
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.590.1.foo" GOTO bb2;
+      lock-end "$anon/.:$service.706.1.foo" GOTO bb2;
     }
     bb2 {
       return;

--- a/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
@@ -113,7 +113,7 @@ class $service$0 {
 
   get() -> int{
     bb0 {
-      lock-start "$anon/.:$service.600.0.count" GOTO bb1;
+      lock-start "$anon/.:$service.716.0.count" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 2
@@ -121,7 +121,7 @@ class $service$0 {
       %0 = (1, self)[%1];
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.600.0.count" GOTO bb2;
+      lock-end "$anon/.:$service.716.0.count" GOTO bb2;
     }
     bb2 {
       return;
@@ -133,7 +133,7 @@ class $service$0 {
 
   inc() -> nil{
     bb0 {
-      lock-start "$anon/.:$service.600.0.count" GOTO bb1;
+      lock-start "$anon/.:$service.716.0.count" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 7
@@ -146,7 +146,7 @@ class $service$0 {
       %6 = ConstantLoad count
       (1, self)[%6] = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.600.0.count" GOTO bb2;
+      lock-end "$anon/.:$service.716.0.count" GOTO bb2;
     }
     bb2 {
       return;

--- a/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
@@ -113,7 +113,7 @@ class $service$0 {
 
   get() -> int{
     bb0 {
-      lock-start "$anon/.:$service.716.0.count" GOTO bb1;
+      lock-start "$anon/.:$service.777.0.count" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 2
@@ -121,7 +121,7 @@ class $service$0 {
       %0 = (1, self)[%1];
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.716.0.count" GOTO bb2;
+      lock-end "$anon/.:$service.777.0.count" GOTO bb2;
     }
     bb2 {
       return;
@@ -133,7 +133,7 @@ class $service$0 {
 
   inc() -> nil{
     bb0 {
-      lock-start "$anon/.:$service.716.0.count" GOTO bb1;
+      lock-start "$anon/.:$service.777.0.count" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 7
@@ -146,7 +146,7 @@ class $service$0 {
       %6 = ConstantLoad count
       (1, self)[%6] = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.716.0.count" GOTO bb2;
+      lock-end "$anon/.:$service.777.0.count" GOTO bb2;
     }
     bb2 {
       return;

--- a/corpus/extern/http_client_test.go
+++ b/corpus/extern/http_client_test.go
@@ -190,6 +190,44 @@ func TestHttpClientBinaryLocal(t *testing.T) {
 	runExtern(t, fileCase("http-client-binary-local-v"), newHTTPPal(rewriteClient(server.URL)), nil)
 }
 
+// TestHttpClientMultipartLocal exercises a mime:Entity[] request body (msgToBody's
+// Entity[] branch, mime's EncodeMultipart, auto-generated boundary). The server parses
+// the multipart body with Go's own mime/multipart.Reader and echoes a deterministic,
+// boundary-independent summary so the assertion doesn't depend on the random boundary.
+func TestHttpClientMultipartLocal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/echo-multipart" || r.Method != http.MethodPost {
+			w.WriteHeader(404)
+			return
+		}
+		mr, err := r.MultipartReader()
+		if err != nil {
+			w.WriteHeader(400)
+			return
+		}
+		var sb strings.Builder
+		count := 0
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				w.WriteHeader(400)
+				return
+			}
+			count++
+			data, _ := io.ReadAll(part)
+			fmt.Fprintf(&sb, "%d:%s ", count, data)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintf(w, "count=%d %s", count, strings.TrimSpace(sb.String()))
+	}))
+	defer server.Close()
+	runExtern(t, fileCase("http-client-multipart-local-v"), newHTTPPal(rewriteClient(server.URL)), nil)
+}
+
 // TestHttpClientCompressionLocal exercises transparent gzip/deflate response
 // decompression (decompressResponseBody + the gzip/deflate ReadClosers). The
 // client factory disables Go's automatic decompression so the compressed body

--- a/corpus/extern/http_service_test.go
+++ b/corpus/extern/http_service_test.go
@@ -112,6 +112,14 @@ func TestHttpServiceRequestAccessors(t *testing.T) {
 	runExtern(t, fileCase("http-service/http-svc-request-accessors-v"), newHTTPPal(palnative.NewHTTPClient), nil)
 }
 
+// TestHttpServiceMultipartRequest exercises Request.getBodyParts() on the
+// inbound Request injected into a service resource, decoding a multipart
+// body sent by the client.
+func TestHttpServiceMultipartRequest(t *testing.T) {
+	skipIfNoLoopback(t)
+	runExtern(t, fileCase("http-service/http-svc-multipart-request-v"), newHTTPPal(palnative.NewHTTPClient), nil)
+}
+
 // TestHttpServiceRequestMutators exercises every Request mutator method
 // (setHeader/addHeader/removeHeader/removeAllHeaders/setContentType/
 // setTextPayload/setJsonPayload/setBinaryPayload) on the inbound Request
@@ -120,6 +128,14 @@ func TestHttpServiceRequestMutators(t *testing.T) {
 	skipIfNoLoopback(t)
 	t.Parallel()
 	runExtern(t, fileCase("http-service/http-svc-request-mutators-v"), newHTTPPal(palnative.NewHTTPClient), nil)
+}
+
+// TestHttpServiceMultipartResponse exercises Response.getBodyParts() on an
+// inbound Response received from an http:Client call, decoding a multipart
+// body sent by the server.
+func TestHttpServiceMultipartResponse(t *testing.T) {
+	skipIfNoLoopback(t)
+	runExtern(t, fileCase("http-service/http-svc-multipart-response-v"), newHTTPPal(palnative.NewHTTPClient), nil)
 }
 
 // TestHttpServiceHTTP10Fallback verifies that a listener configured with

--- a/corpus/extern/testdata/expected/http-client-multipart-local-v.txtar
+++ b/corpus/extern/testdata/expected/http-client-multipart-local-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+count=2 1:hello world 2:{"x":1}
+-- stderr --

--- a/corpus/extern/testdata/expected/http-service/http-svc-multipart-request-v.txtar
+++ b/corpus/extern/testdata/expected/http-service/http-svc-multipart-request-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+200
+{"count":2,"disposition":"form-data; name=field1","text":"hello world","x":42}
+-- stderr --

--- a/corpus/extern/testdata/expected/http-service/http-svc-multipart-response-v.txtar
+++ b/corpus/extern/testdata/expected/http-service/http-svc-multipart-response-v.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+2
+server part
+true
+-- stderr --

--- a/corpus/extern/testdata/http-client-multipart-local-v.bal
+++ b/corpus/extern/testdata/http-client-multipart-local-v.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mime;
+import ballerina/io;
+
+public function main() returns error? {
+    http:Client c = check new http:Client("http://testserver", {});
+
+    mime:Entity textPart = new;
+    textPart.setText("hello world");
+
+    mime:Entity jsonPart = new;
+    jsonPart.setJson({x: 1});
+
+    // POST a multipart body (mime:Entity[] via the widened RequestMessage) — exercises
+    // msgToBody's Entity[] branch, which serializes via mime's EncodeMultipart and
+    // auto-generates a boundary. The server parses the multipart body itself and echoes
+    // a deterministic, boundary-independent summary back.
+    http:Response r = check c->post("/echo-multipart", [textPart, jsonPart]);
+    io:println(check r.getTextPayload()); // @output count=2 1:hello world 2:{"x":1}
+    return;
+}

--- a/corpus/extern/testdata/http-service/http-svc-multipart-request-v.bal
+++ b/corpus/extern/testdata/http-service/http-svc-multipart-request-v.bal
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mime;
+import ballerina/io;
+
+// An inbound Request (the one the runtime builds for a service resource, as
+// opposed to one created via `new http:Request()`) must support the exact
+// same method set. getBodyParts() previously wasn't wired into the inbound
+// object's dispatch table and panicked with "function not found: getBodyParts".
+service /multiparts on new http:Listener(19500) {
+    resource function post decode(http:Request req) returns http:Response|error {
+        mime:Entity[] parts = check req.getBodyParts();
+        string firstText = check parts[0].getText();
+        string disposition = check parts[0].getHeader("content-disposition");
+        map<json> secondJson = <map<json>>check parts[1].getJson();
+        json result = {count: parts.length(), text: firstText, disposition: disposition, x: secondJson["x"]};
+
+        http:Response resp = new;
+        resp.setJsonPayload(result);
+        return resp;
+    }
+}
+
+public function testMain() returns error? {
+    http:Client c = check new http:Client("http://localhost:19500", {});
+
+    mime:Entity textPart = new;
+    textPart.setText("hello world");
+    mime:ContentDisposition disposition = check mime:getContentDispositionObject("form-data; name=\"field1\"");
+    textPart.setContentDisposition(disposition);
+
+    mime:Entity jsonPart = new;
+    jsonPart.setJson({x: 42});
+
+    http:Response r = check c->post("/multiparts/decode", [textPart, jsonPart]);
+    io:println(r.statusCode); // @output 200
+    io:println(check r.getTextPayload()); // @output {"count":2,"disposition":"form-data; name=field1","text":"hello world","x":42}
+}

--- a/corpus/extern/testdata/http-service/http-svc-multipart-response-v.bal
+++ b/corpus/extern/testdata/http-service/http-svc-multipart-response-v.bal
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mime;
+import ballerina/io;
+
+// An inbound Response (the one the runtime builds for a value returned by
+// http:Client, as opposed to one created via `new http:Response()`) must
+// support the exact same method set. getBodyParts() previously wasn't wired
+// into the inbound object's dispatch table and panicked with "function not
+// found: getBodyParts".
+service /multiparts on new http:Listener(19502) {
+    resource function get encode() returns http:Response|error {
+        mime:Entity textPart = new;
+        textPart.setText("server part");
+
+        mime:Entity jsonPart = new;
+        jsonPart.setJson({ok: true});
+
+        http:Response resp = new;
+        resp.setBodyParts([textPart, jsonPart]);
+        return resp;
+    }
+}
+
+public function testMain() returns error? {
+    http:Client c = check new http:Client("http://localhost:19502", {});
+    http:Response r = check c->get("/multiparts/encode");
+
+    mime:Entity[] parts = check r.getBodyParts();
+    io:println(parts.length()); // @output 2
+    io:println(check parts[0].getText()); // @output server part
+    map<json> j = <map<json>>check parts[1].getJson();
+    io:println(j["ok"]); // @output true
+}

--- a/corpus/extern/testdata/http-service/http-svc-request-mutators-v.bal
+++ b/corpus/extern/testdata/http-service/http-svc-request-mutators-v.bal
@@ -22,14 +22,14 @@ import ballerina/io;
 // wasn't wired into the inbound Request object's dispatch table (only the
 // read-only accessors were), so calling any of them on a service resource's
 // injected http:Request panicked with a generic, undiagnosable 500.
-service /reqmut on new http:Listener(19214) {
+service /reqmut on new http:Listener(19501) {
     resource function post headers(http:Request req) returns http:Response|error {
         req.setHeader("x-one", "a");
         req.addHeader("x-one", "b");
         req.setHeader("x-remove-me", "gone");
         req.removeHeader("x-remove-me");
         check req.setContentType("text/plain");
-        req.setTextPayload("mutated");
+        check req.setTextPayload("mutated");
 
         string hasRemoveMe = "false";
         if req.hasHeader("x-remove-me") {
@@ -46,20 +46,23 @@ service /reqmut on new http:Listener(19214) {
 
     resource function post payloads(http:Request req) returns http:Response|error {
         req.removeAllHeaders();
-        int countAfterRemove = req.getHeaderNames().length();
-        req.setJsonPayload({y: 7});
+        anydata countAfterRemove = req.getHeaderNames().length();
+        check req.setJsonPayload({y: 7});
         map<json> j = <map<json>>check req.getJsonPayload();
-        req.setBinaryPayload("bytes".toBytes());
+        check req.setBinaryPayload("bytes".toBytes());
         byte[] b = check req.getBinaryPayload();
 
+        anydata jsonY = j["y"];
         http:Response resp = new;
-        resp.setJsonPayload({countAfterRemove: countAfterRemove, jsonY: j["y"], bytesText: check string:fromBytes(b)});
+        resp.setHeader("x-count-after-remove", countAfterRemove.toString());
+        resp.setHeader("x-json-y", jsonY.toString());
+        resp.setTextPayload(check string:fromBytes(b));
         return resp;
     }
 }
 
 public function testMain() returns error? {
-    http:Client c = check new http:Client("http://localhost:19214", {});
+    http:Client c = check new http:Client("http://localhost:19501", {});
 
     http:Response r1 = check c->post("/reqmut/headers", "original");
     io:println(r1.statusCode); // @output 200
@@ -69,8 +72,7 @@ public function testMain() returns error? {
     io:println(check r1.getTextPayload()); // @output mutated
 
     http:Response r2 = check c->post("/reqmut/payloads", "ignored");
-    map<json> j2 = <map<json>>check r2.getJsonPayload();
-    io:println(j2["countAfterRemove"]); // @output 0
-    io:println(j2["jsonY"]); // @output 7
-    io:println(j2["bytesText"]); // @output bytes
+    io:println(check r2.getHeader("x-count-after-remove")); // @output 0
+    io:println(check r2.getHeader("x-json-y")); // @output 7
+    io:println(check r2.getTextPayload()); // @output bytes
 }

--- a/corpus/integration/lib/subset3/http-form-params-error-v.txtar
+++ b/corpus/integration/lib/subset3/http-form-params-error-v.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+true
+true
+Datasource does not contain form data
+true
+-- stderr --

--- a/corpus/integration/lib/subset3/http-form-params-v.txtar
+++ b/corpus/integration/lib/subset3/http-form-params-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+1
+hello world
+x=y
+orphan
+
+false
+5
+0
+-- stderr --

--- a/corpus/integration/lib/subset3/http-multipart-error-v.txtar
+++ b/corpus/integration/lib/subset3/http-multipart-error-v.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+true
+Error occurred while retrieving body parts from the request: Entity body is not a type of composite media type. Received content-type : text/plain
+true
+Error occurred while retrieving body parts from the response: Entity body is not a type of composite media type. Received content-type : text/plain
+-- stderr --

--- a/corpus/integration/lib/subset3/http-multipart-v.txtar
+++ b/corpus/integration/lib/subset3/http-multipart-v.txtar
@@ -1,0 +1,14 @@
+-- stdout --
+true
+2
+hello world
+form-data; name=field1
+1
+2
+2
+2
+hello world
+2
+2
+true
+-- stderr --

--- a/corpus/integration/lib/subset3/http-set-payload-v.txtar
+++ b/corpus/integration/lib/subset3/http-set-payload-v.txtar
@@ -1,0 +1,9 @@
+-- stdout --
+plain text
+3
+Alice
+30
+resp text
+3
+[1,2,3]
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-base64-1-v.txtar
+++ b/corpus/integration/lib/subset3/mime-base64-1-v.txtar
@@ -1,0 +1,8 @@
+-- stdout --
+SGVsbG8=
+Hello
+3
+true
+100
+true
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-constants1-v.txtar
+++ b/corpus/integration/lib/subset3/mime-constants1-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+application/json
+text/plain
+application/octet-stream
+content-type
+content-length
+UTF-8
+multipart/form-data
+image/jpeg
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-content-disposition1-v.txtar
+++ b/corpus/integration/lib/subset3/mime-content-disposition1-v.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+form-data
+file
+test.txt
+attachment; filename=report.pdf
+attachment; filename="my report.pdf"
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-entity-body1-v.txtar
+++ b/corpus/integration/lib/subset3/mime-entity-body1-v.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+Hello World
+5
+dispatched text
+4
+parser error
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-entity-headers1-v.txtar
+++ b/corpus/integration/lib/subset3/mime-entity-headers1-v.txtar
@@ -1,0 +1,9 @@
+-- stdout --
+application/json
+true
+false
+2
+2
+false
+false
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-entity-metadata1-v.txtar
+++ b/corpus/integration/lib/subset3/mime-entity-metadata1-v.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+text/html
+cid-001
+512
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-media-type1-v.txtar
+++ b/corpus/integration/lib/subset3/mime-media-type1-v.txtar
@@ -1,0 +1,12 @@
+-- stdout --
+application
+json
+
+application/json
+UTF-8
+application
+svg
+xml
+application/svg
+invalid content type
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-multipart-error-v.txtar
+++ b/corpus/integration/lib/subset3/mime-multipart-error-v.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+true
+Entity body is not a type of composite media type. Received content-type : text/plain
+true
+Error occurred while extracting body parts from entity: no boundary parameter found in Content-Type
+true
+-- stderr --

--- a/corpus/integration/lib/subset3/mime-multipart-v.txtar
+++ b/corpus/integration/lib/subset3/mime-multipart-v.txtar
@@ -1,0 +1,16 @@
+-- stdout --
+multipart/form-data; boundary=XYZBOUNDARY
+2
+hello world
+1
+2
+2
+2
+form-data; name="a"
+value-a
+application/json
+{"k":"v"}
+text/plain
+plain value
+multipart/form-data
+-- stderr --

--- a/corpus/lib/subset3/http-form-params-error-v.bal
+++ b/corpus/lib/subset3/http-form-params-error-v.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+
+public function main() returns error? {
+    http:Request noHeader = new;
+    map<string>|error noHeaderResult = noHeader.getFormParams();
+    io:println(noHeaderResult is error); // @output true
+
+    http:Request wrongType = new;
+    wrongType.setTextPayload("a=1", contentType = "text/plain");
+    map<string>|error wrongTypeResult = wrongType.getFormParams();
+    io:println(wrongTypeResult is error); // @output true
+
+    http:Request noEquals = new;
+    noEquals.setTextPayload("justastring", contentType = "application/x-www-form-urlencoded");
+    map<string>|error noEqualsResult = noEquals.getFormParams();
+    if noEqualsResult is error {
+        io:println(noEqualsResult.message()); // @output Datasource does not contain form data
+    }
+
+    http:Request badEncoding = new;
+    badEncoding.setTextPayload("a=%zz", contentType = "application/x-www-form-urlencoded");
+    map<string>|error badEncodingResult = badEncoding.getFormParams();
+    io:println(badEncodingResult is error); // @output true
+    return;
+}

--- a/corpus/lib/subset3/http-form-params-v.bal
+++ b/corpus/lib/subset3/http-form-params-v.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+
+public function main() returns error? {
+    http:Request req = new;
+    req.setTextPayload("a=1&b=hello%20world&c=x%3Dy&noeq&=orphan&d=",
+            contentType = "application/x-www-form-urlencoded");
+    map<string> params = check req.getFormParams();
+    io:println(params["a"]);              // @output 1
+    io:println(params["b"]);              // @output hello world
+    io:println(params["c"]);              // @output x=y
+    io:println(params[""]);               // @output orphan
+    io:println(params["d"]);              // @output
+    io:println(params.hasKey("noeq"));    // @output false
+    io:println(params.length());         // @output 5
+
+    http:Request emptyBody = new;
+    emptyBody.setTextPayload("", contentType = "application/x-www-form-urlencoded");
+    map<string> emptyParams = check emptyBody.getFormParams();
+    io:println(emptyParams.length()); // @output 0
+}

--- a/corpus/lib/subset3/http-multipart-error-v.bal
+++ b/corpus/lib/subset3/http-multipart-error-v.bal
@@ -1,0 +1,38 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mime;
+import ballerina/io;
+
+public function main() returns error? {
+    http:Request plainReq = new;
+    plainReq.setTextPayload("just text");
+    mime:Entity[]|error plainReqResult = plainReq.getBodyParts();
+    io:println(plainReqResult is error); // @output true
+    if plainReqResult is error {
+        io:println(plainReqResult.message()); // @output Error occurred while retrieving body parts from the request: Entity body is not a type of composite media type. Received content-type : text/plain
+    }
+
+    http:Response plainRes = new;
+    plainRes.setTextPayload("just text");
+    mime:Entity[]|error plainResResult = plainRes.getBodyParts();
+    io:println(plainResResult is error); // @output true
+    if plainResResult is error {
+        io:println(plainResResult.message()); // @output Error occurred while retrieving body parts from the response: Entity body is not a type of composite media type. Received content-type : text/plain
+    }
+    return;
+}

--- a/corpus/lib/subset3/http-multipart-v.bal
+++ b/corpus/lib/subset3/http-multipart-v.bal
@@ -1,0 +1,76 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mime;
+import ballerina/io;
+
+isolated function hasPrefix(string value, string prefix) returns boolean {
+    if value.length() < prefix.length() {
+        return false;
+    }
+    return value.substring(0, prefix.length()) == prefix;
+}
+
+public function main() returns error? {
+    mime:Entity part1 = new;
+    part1.setText("hello world");
+    mime:ContentDisposition disposition = check mime:getContentDispositionObject("form-data; name=\"field1\"");
+    part1.setContentDisposition(disposition);
+
+    mime:Entity part2 = new;
+    part2.setJson({x: 1, y: 2});
+
+    // ---- Request.setBodyParts / getBodyParts round-trip ----
+    http:Request req = new;
+    req.setBodyParts([part1, part2]);
+    io:println(hasPrefix(req.getContentType(), "multipart/form-data")); // @output true
+
+    mime:Entity[] reqParts = check req.getBodyParts();
+    io:println(reqParts.length());                                        // @output 2
+    io:println(check reqParts[0].getText());                              // @output hello world
+    io:println(check reqParts[0].getHeader("content-disposition"));       // @output form-data; name=field1
+    map<json> reqPartJson = <map<json>>check reqParts[1].getJson();
+    io:println(reqPartJson["x"]); // @output 1
+    io:println(reqPartJson["y"]); // @output 2
+
+    // memoized second call
+    mime:Entity[] reqPartsAgain = check req.getBodyParts();
+    io:println(reqPartsAgain.length()); // @output 2
+
+    // ---- Response.setBodyParts / getBodyParts round-trip ----
+    http:Response res = new;
+    res.setBodyParts([part1, part2]);
+    mime:Entity[] resParts = check res.getBodyParts();
+    io:println(resParts.length());          // @output 2
+    io:println(check resParts[0].getText()); // @output hello world
+
+    // ---- setPayload(mime:Entity[]) dispatch ----
+    http:Request reqViaSetPayload = new;
+    reqViaSetPayload.setPayload([part1, part2]);
+    mime:Entity[] viaSetPayloadParts = check reqViaSetPayload.getBodyParts();
+    io:println(viaSetPayloadParts.length()); // @output 2
+
+    http:Response resViaSetPayload = new;
+    resViaSetPayload.setPayload([part1, part2]);
+    mime:Entity[] resViaSetPayloadParts = check resViaSetPayload.getBodyParts();
+    io:println(resViaSetPayloadParts.length()); // @output 2
+
+    // ---- explicit content-type override ----
+    http:Request req2 = new;
+    req2.setBodyParts([part1], "multipart/mixed");
+    io:println(hasPrefix(req2.getContentType(), "multipart/mixed")); // @output true
+}

--- a/corpus/lib/subset3/http-set-payload-v.bal
+++ b/corpus/lib/subset3/http-set-payload-v.bal
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+
+public function main() returns error? {
+    // ---- Request.setPayload ----
+    http:Request reqText = new;
+    reqText.setPayload("plain text");
+    io:println(check reqText.getTextPayload()); // @output plain text
+
+    http:Request reqBytes = new;
+    reqBytes.setPayload("bin".toBytes());
+    byte[] reqBytesResult = check reqBytes.getBinaryPayload();
+    io:println(reqBytesResult.length()); // @output 3
+
+    http:Request reqJson = new;
+    reqJson.setPayload({name: "Alice", age: 30});
+    json reqJsonResult = check reqJson.getJsonPayload();
+    map<json> reqJsonMap = <map<json>>reqJsonResult;
+    io:println(reqJsonMap["name"]); // @output Alice
+    io:println(reqJsonMap["age"]);  // @output 30
+
+    // ---- Response.setPayload ----
+    http:Response resText = new;
+    resText.setPayload("resp text");
+    io:println(check resText.getTextPayload()); // @output resp text
+
+    http:Response resBytes = new;
+    resBytes.setPayload("xyz".toBytes());
+    byte[] resBytesResult = check resBytes.getBinaryPayload();
+    io:println(resBytesResult.length()); // @output 3
+
+    http:Response resJson = new;
+    json resPayload = [1, 2, 3];
+    resJson.setPayload(resPayload);
+    json resJsonResult = check resJson.getJsonPayload();
+    io:println(resJsonResult); // @output [1,2,3]
+}

--- a/corpus/lib/subset3/mime-base64-1-v.bal
+++ b/corpus/lib/subset3/mime-base64-1-v.bal
@@ -1,0 +1,46 @@
+import ballerina/io;
+import ballerina/mime;
+
+public function main() returns error? {
+    string|byte[]|mime:EncodeError enc = mime:base64Encode("Hello");
+    if enc is string {
+        io:println(enc);
+    }
+
+    string|byte[]|mime:DecodeError dec = mime:base64Decode("SGVsbG8=");
+    if dec is string {
+        io:println(dec);
+    }
+
+    byte[]|mime:EncodeError bEnc = mime:base64EncodeBlob([1, 2, 3]);
+    if bEnc is byte[] {
+        byte[]|mime:DecodeError bDec = mime:base64DecodeBlob(bEnc);
+        if bDec is byte[] {
+            io:println(bDec.length());
+        }
+    }
+
+    byte[] longInput = [];
+    foreach int i in 0 ..< 100 {
+        longInput.push(<byte>i);
+    }
+    byte[]|mime:EncodeError longEnc = mime:base64EncodeBlob(longInput);
+    if longEnc is byte[] {
+        string encStr = check string:fromBytes(longEnc);
+        io:println(encStr.length() > 76);
+
+        byte[]|mime:DecodeError longDec = mime:base64DecodeBlob(longEnc);
+        if longDec is byte[] {
+            io:println(longDec.length());
+        }
+    }
+
+    string|byte[]|mime:DecodeError invalidDec = mime:base64Decode("not-valid-base64!!!");
+    io:println(invalidDec is mime:DecodeError);
+}
+// @output SGVsbG8=
+// @output Hello
+// @output 3
+// @output true
+// @output 100
+// @output true

--- a/corpus/lib/subset3/mime-constants1-v.bal
+++ b/corpus/lib/subset3/mime-constants1-v.bal
@@ -1,0 +1,21 @@
+import ballerina/io;
+import ballerina/mime;
+
+public function main() {
+    io:println(mime:APPLICATION_JSON);
+    io:println(mime:TEXT_PLAIN);
+    io:println(mime:APPLICATION_OCTET_STREAM);
+    io:println(mime:CONTENT_TYPE);
+    io:println(mime:CONTENT_LENGTH);
+    io:println(mime:DEFAULT_CHARSET);
+    io:println(mime:MULTIPART_FORM_DATA);
+    io:println(mime:IMAGE_JPEG);
+}
+// @output application/json
+// @output text/plain
+// @output application/octet-stream
+// @output content-type
+// @output content-length
+// @output UTF-8
+// @output multipart/form-data
+// @output image/jpeg

--- a/corpus/lib/subset3/mime-content-disposition1-v.bal
+++ b/corpus/lib/subset3/mime-content-disposition1-v.bal
@@ -1,0 +1,24 @@
+import ballerina/io;
+import ballerina/mime;
+
+public function main() {
+    mime:ContentDisposition cd = mime:getContentDispositionObject("form-data; name=\"file\"; filename=\"test.txt\"");
+    io:println(cd.disposition);
+    io:println(cd.name);
+    io:println(cd.fileName);
+
+    mime:ContentDisposition newCd = new ();
+    newCd.disposition = "attachment";
+    newCd.fileName = "report.pdf";
+    io:println(newCd.toString());
+
+    mime:ContentDisposition quotedCd = new ();
+    quotedCd.disposition = "attachment";
+    quotedCd.fileName = "my report.pdf";
+    io:println(quotedCd.toString());
+}
+// @output form-data
+// @output file
+// @output test.txt
+// @output attachment; filename=report.pdf
+// @output attachment; filename="my report.pdf"

--- a/corpus/lib/subset3/mime-entity-body1-v.bal
+++ b/corpus/lib/subset3/mime-entity-body1-v.bal
@@ -1,0 +1,64 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/mime;
+
+public function main() {
+    mime:Entity textEntity = new ();
+    textEntity.setText("Hello World");
+    string|mime:ParserError textResult = textEntity.getText();
+    if textResult is string {
+        io:println(textResult);
+    }
+
+    mime:Entity bytesEntity = new ();
+    bytesEntity.setByteArray([72, 101, 108, 108, 111]);
+    byte[]|mime:ParserError bytesResult = bytesEntity.getByteArray();
+    if bytesResult is byte[] {
+        io:println(bytesResult.length());
+    }
+
+    mime:Entity bodyEntity = new ();
+    bodyEntity.setBody("dispatched text");
+    string|mime:ParserError dispatchResult = bodyEntity.getText();
+    if dispatchResult is string {
+        io:println(dispatchResult);
+    }
+
+    // Every accessor lazily converts from whatever the body was actually set as
+    // (matching jBallerina's data-source model), so getByteArray() on a text-body
+    // entity succeeds rather than erroring.
+    mime:Entity crossKindEntity = new ();
+    crossKindEntity.setText("text");
+    byte[]|mime:ParserError crossKindResult = crossKindEntity.getByteArray();
+    if crossKindResult is byte[] {
+        io:println(crossKindResult.length());
+    }
+
+    // A freshly-constructed entity with no body set at all is the one case that
+    // still produces a ParserError.
+    mime:Entity emptyEntity = new ();
+    byte[]|mime:ParserError emptyResult = emptyEntity.getByteArray();
+    if emptyResult is mime:ParserError {
+        io:println("parser error");
+    }
+}
+// @output Hello World
+// @output 5
+// @output dispatched text
+// @output 4
+// @output parser error

--- a/corpus/lib/subset3/mime-entity-headers1-v.bal
+++ b/corpus/lib/subset3/mime-entity-headers1-v.bal
@@ -1,0 +1,38 @@
+import ballerina/io;
+import ballerina/mime;
+
+public function main() {
+    mime:Entity entity = new ();
+    entity.setHeader("Content-Type", "application/json");
+
+    string|mime:HeaderNotFoundError ct = entity.getHeader("content-type");
+    if ct is string {
+        io:println(ct);
+    }
+
+    io:println(entity.hasHeader("content-type"));
+    io:println(entity.hasHeader("accept"));
+
+    entity.addHeader("Accept", "text/html");
+    entity.addHeader("Accept", "application/json");
+    string[]|mime:HeaderNotFoundError accepts = entity.getHeaders("accept");
+    if accepts is string[] {
+        io:println(accepts.length());
+    }
+
+    string[] names = entity.getHeaderNames();
+    io:println(names.length());
+
+    entity.removeHeader("Accept");
+    io:println(entity.hasHeader("accept"));
+
+    entity.removeAllHeaders();
+    io:println(entity.hasHeader("content-type"));
+}
+// @output application/json
+// @output true
+// @output false
+// @output 2
+// @output 2
+// @output false
+// @output false

--- a/corpus/lib/subset3/mime-entity-metadata1-v.bal
+++ b/corpus/lib/subset3/mime-entity-metadata1-v.bal
@@ -1,0 +1,22 @@
+import ballerina/io;
+import ballerina/mime;
+
+public function main() returns error? {
+    mime:Entity e = new ();
+    mime:InvalidContentTypeError? err = e.setContentType("text/html");
+    if !(err is mime:InvalidContentTypeError) {
+        io:println(e.getContentType());
+    }
+
+    e.setContentId("cid-001");
+    io:println(e.getContentId());
+
+    e.setContentLength(512);
+    int|error clen = e.getContentLength();
+    if clen is int {
+        io:println(clen);
+    }
+}
+// @output text/html
+// @output cid-001
+// @output 512

--- a/corpus/lib/subset3/mime-media-type1-v.bal
+++ b/corpus/lib/subset3/mime-media-type1-v.bal
@@ -1,0 +1,34 @@
+import ballerina/io;
+import ballerina/mime;
+
+public function main() returns error? {
+    mime:MediaType result = check mime:getMediaType("application/json; charset=UTF-8");
+    io:println(result.primaryType);
+    io:println(result.subType);
+    io:println(result.suffix);
+    io:println(result.getBaseType());
+    io:println(result.parameters["charset"]);
+
+    mime:MediaType result2 = check mime:getMediaType("application/svg+xml");
+    io:println(result2.primaryType);
+    io:println(result2.subType);
+    io:println(result2.suffix);
+    io:println(result2.getBaseType());
+
+    mime:MediaType|error result3 = mime:getMediaType("invalid!!");
+    if result3 is mime:MediaType {
+        io:println("got media type: ", result3);
+    }
+    io:println("invalid content type");
+}
+
+// @output application
+// @output json
+// @output
+// @output application/json
+// @output UTF-8
+// @output application
+// @output svg
+// @output xml
+// @output application/svg
+// @output invalid content type

--- a/corpus/lib/subset3/mime-multipart-error-v.bal
+++ b/corpus/lib/subset3/mime-multipart-error-v.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mime;
+import ballerina/io;
+
+public function main() returns error? {
+    // non-multipart entity
+    mime:Entity plain = new;
+    plain.setText("just text");
+    mime:Entity[]|mime:ParserError plainResult = plain.getBodyParts();
+    io:println(plainResult is mime:ParserError); // @output true
+    if plainResult is mime:ParserError {
+        io:println(plainResult.message()); // @output Entity body is not a type of composite media type. Received content-type : text/plain
+    }
+
+    // multipart content-type with no boundary parameter
+    mime:Entity noBoundary = new;
+    noBoundary.setByteArray("--x\r\n--x--".toBytes(), "multipart/form-data");
+    mime:Entity[]|mime:ParserError noBoundaryResult = noBoundary.getBodyParts();
+    io:println(noBoundaryResult is mime:ParserError); // @output true
+    if noBoundaryResult is mime:ParserError {
+        io:println(noBoundaryResult.message()); // @output Error occurred while extracting body parts from entity: no boundary parameter found in Content-Type
+    }
+
+    // entity with no content-type header at all
+    mime:Entity noHeader = new;
+    mime:Entity[]|mime:ParserError noHeaderResult = noHeader.getBodyParts();
+    io:println(noHeaderResult is mime:ParserError); // @output true
+    return;
+}

--- a/corpus/lib/subset3/mime-multipart-v.bal
+++ b/corpus/lib/subset3/mime-multipart-v.bal
@@ -1,0 +1,69 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mime;
+import ballerina/io;
+
+public function main() returns error? {
+    // ---- setBodyParts / getBodyParts round-trip ----
+    mime:Entity part1 = new;
+    part1.setText("hello world");
+    mime:ContentDisposition disposition = check mime:getContentDispositionObject("form-data; name=\"field1\"");
+    part1.setContentDisposition(disposition);
+
+    mime:Entity part2 = new;
+    part2.setJson({x: 1, y: 2});
+
+    mime:Entity whole = new;
+    whole.setBodyParts([part1, part2], "multipart/form-data; boundary=XYZBOUNDARY");
+    io:println(whole.getContentType()); // @output multipart/form-data; boundary=XYZBOUNDARY
+
+    mime:Entity[] parts = check whole.getBodyParts();
+    io:println(parts.length());          // @output 2
+    io:println(check parts[0].getText()); // @output hello world
+    map<json> partJson = <map<json>>check parts[1].getJson();
+    io:println(partJson["x"]); // @output 1
+    io:println(partJson["y"]); // @output 2
+
+    // memoized second call returns the same parts without re-decoding
+    mime:Entity[] partsAgain = check whole.getBodyParts();
+    io:println(partsAgain.length()); // @output 2
+
+    // ---- decode raw multipart bytes ----
+    string raw = "--XYZBOUNDARY\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nvalue-a\r\n" +
+        "--XYZBOUNDARY\r\nContent-Type: application/json\r\n\r\n{\"k\":\"v\"}\r\n--XYZBOUNDARY--\r\n";
+    mime:Entity decoded = new;
+    decoded.setByteArray(raw.toBytes(), "multipart/form-data; boundary=XYZBOUNDARY");
+    mime:Entity[] decodedParts = check decoded.getBodyParts();
+    io:println(decodedParts.length());                               // @output 2
+    io:println(check decodedParts[0].getHeader("content-disposition")); // @output form-data; name="a"
+    io:println(check decodedParts[0].getText());                      // @output value-a
+    io:println(decodedParts[1].getContentType());                     // @output application/json
+    io:println(check decodedParts[1].getJson());                      // @output {"k":"v"}
+
+    // ---- part with no Content-Type header defaults to text/plain ----
+    string rawNoContentType = "--B1\r\nContent-Disposition: form-data; name=\"noct\"\r\n\r\nplain value\r\n--B1--\r\n";
+    mime:Entity noCtEntity = new;
+    noCtEntity.setByteArray(rawNoContentType.toBytes(), "multipart/form-data; boundary=B1");
+    mime:Entity[] noCtParts = check noCtEntity.getBodyParts();
+    io:println(noCtParts[0].getContentType()); // @output text/plain
+    io:println(check noCtParts[0].getText());  // @output plain value
+
+    // ---- setBody's Entity[] arm delegates to setBodyParts ----
+    mime:Entity viaSetBody = new;
+    viaSetBody.setBody([part1, part2]);
+    io:println(viaSetBody.getContentType()); // @output multipart/form-data
+}

--- a/lib/rt/libs.go
+++ b/lib/rt/libs.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/http/0.0.1/go1.26/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/io/0.0.1/go1.26/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/log/0.0.1/go1.26/native"
+	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/mime/0.0.1/go1.26/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/os/0.0.1/go1.26/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/protobuf/0.0.1/go1.26/modules/types.any/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/random/0.0.1/go1.26/native"

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/Dependencies.toml
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/Dependencies.toml
@@ -3,5 +3,19 @@ dependencies-toml-version = "2"
 
 [[package]]
 org     = "ballerina"
+name    = "mime"
+version = "0.0.1"
+
+[[package]]
+org     = "ballerina"
+name    = "url"
+version = "0.0.1"
+
+[[package]]
+org     = "ballerina"
 name    = "http"
 version = "0.0.1"
+dependencies = [
+    {org = "ballerina", name = "mime"},
+    {org = "ballerina", name = "url"}
+]

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/README.md
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/README.md
@@ -22,6 +22,9 @@ The Go Native Interpreter supports the **HTTP client subset**: the nine core rem
 - Inspect response headers by name or enumerate all header names.
 - Construct `Response` objects in resource functions and populate them with `setTextPayload`, `setJsonPayload`, `setBinaryPayload`, `setHeader`, and direct field assignment (`response.statusCode = 404`).
 - Construct outbound `Request` objects and populate them for forwarding.
+- Set a request or response body generically via `setPayload`, dispatched by the runtime type of the value.
+- Decode an `application/x-www-form-urlencoded` request body into a parameter map via `getFormParams`.
+- Set and extract multipart request/response bodies as `mime:Entity[]` via `setBodyParts`/`getBodyParts`.
 - Parse structured header values (value + parameter map) with the header parsing utility.
 
 ## Examples
@@ -118,11 +121,13 @@ Support Levels:
 | Request object construction | Supported | `new http:Request()` creates an outbound request with `rawPath`, `method`, and `httpVersion` fields. |
 | Request write methods | Supported | `setTextPayload`, `setJsonPayload`, `setXmlPayload`, `setBinaryPayload` (each with optional `contentType`), `setHeader`, `addHeader`, `removeHeader`, `removeAllHeaders`, and `setContentType` populate the request. All four payload setters follow jBallerina's rule of keeping an existing `Content-Type` when no override is passed, falling back to their type-specific default only when none is set. |
 | Request read methods | Supported | `getTextPayload`, `getJsonPayload`, `getXmlPayload`, `getBinaryPayload`, `getHeader`, `getHeaders`, `hasHeader`, `getHeaderNames`, `getContentType`, `getQueryParams`, `getQueryParamValue`, and `getQueryParamValues` read from client-constructed or inbound requests. |
+| Generic payload setter | Partially Supported | `setPayload(json\|byte[]\|mime:Entity[] payload, string? contentType = ())` dispatches by runtime type to `setTextPayload`/`setBinaryPayload`/`setJsonPayload`/`setBodyParts`. jBallerina's signature also accepts `stream<byte[], io:Error?>`/`stream<SseEvent, error?>`, not accepted here since `http` doesn't support those payload kinds yet; `anydata` values outside `json` (e.g. `xml`, `table`) are also not accepted — use `setXmlPayload` directly for `xml`. |
+| Form-urlencoded payload parsing | Supported | `getFormParams()` decodes an `application/x-www-form-urlencoded` body into a `map<string>`. Returns an `error` if the `Content-Type` header is missing, invalid, or not `application/x-www-form-urlencoded`, or if the body cannot be decoded. |
+| Multipart and form-data payload | Partially Supported | `setBodyParts(mime:Entity[] bodyParts, string? contentType = ())` / `getBodyParts() returns mime:Entity[]\|error`, built on `ballerina/mime`'s multipart support. Flat (single-level) multipart only, matching `mime`'s own limitation — a part whose own body is itself multipart is not recursively decoded. `RequestMessage` (accepted by the client's `post`/`put`/`patch`/`execute` methods) is widened to include `mime:Entity[]`. |
 | Path parameter binding | Not Yet Supported | Automatic extraction of URL path segments into resource function parameters is not implemented. |
 | Query parameter binding | Not Yet Supported | Automatic binding of URL query parameters to resource function parameters is not implemented. |
 | Inbound header binding | Not Yet Supported | Automatic binding of request headers to resource function parameters via `@http:Header` is not implemented. |
 | Inbound payload binding | Not Yet Supported | Automatic deserialization of the request body into typed resource function parameters via `@http:Payload` is not implemented. |
-| Multipart and form-data payload | Not Yet Supported | `mime:Entity[]` as a request body type and the associated `getBodyParts()` response method are not implemented. |
 | Streaming request body | Not Yet Supported | `stream<byte[], io:Error?>` as a request payload type is not implemented. |
 
 ### Response
@@ -137,6 +142,8 @@ Support Levels:
 | Response header inspection | Supported | `hasHeader`, `getHeader`, `getHeaders`, and `getHeaderNames` operate on transport (leading) headers. Trailing header position is accepted at compile time but has no runtime effect. |
 | Response object construction | Supported | `new http:Response()` creates a response with status code 200; initialised via `init()`. |
 | Response write methods | Supported | `setTextPayload`, `setJsonPayload`, `setXmlPayload`, `setBinaryPayload` (each with optional `contentType`), `setHeader`, `addHeader`, `removeHeader`, `removeAllHeaders`, and `setContentType` populate a constructed `Response`. All four payload setters follow jBallerina's rule of keeping an existing `Content-Type` when no override is passed, falling back to their type-specific default only when none is set. Status code is set by direct field assignment (`resp.statusCode = 404`). |
+| Generic payload setter | Partially Supported | `setPayload(json\|byte[]\|mime:Entity[] payload, string? contentType = ())` dispatches by runtime type to `setTextPayload`/`setBinaryPayload`/`setJsonPayload`/`setBodyParts`. jBallerina's signature also accepts `stream<byte[], io:Error?>`/`stream<SseEvent, error?>`, not accepted here since `http` doesn't support those payload kinds yet; `anydata` values outside `json` (e.g. `xml`, `table`) are also not accepted — use `setXmlPayload` directly for `xml`. |
+| Multipart and form-data payload | Partially Supported | `setBodyParts(mime:Entity[] bodyParts, string? contentType = ())` / `getBodyParts() returns mime:Entity[]\|error`, built on `ballerina/mime`'s multipart support. Flat (single-level) multipart only, matching `mime`'s own limitation. |
 | Streaming response body | Not Yet Supported | `getByteStream()` is not implemented. |
 | Server-Sent Events | Not Yet Supported | `getSseEventStream()` and consuming a `stream<SseEvent, error?>` response are not implemented. |
 
@@ -176,7 +183,7 @@ Support Levels:
 | HTTP version enum | Supported | `HttpVersion` with `HTTP_1_0`, `HTTP_1_1`, and `HTTP_2_0` enum constants. `HTTP_1_0` prints a runtime warning and falls back to HTTP/1.1. |
 | Distinct HTTP error types | Not Yet Supported | All errors surface as the generic `error` type; `http:ClientError`, `http:HeaderNotFoundError`, and similar subtypes are not declared — `is http:ClientError` type checks will not work. |
 | Observability and metrics | Not Yet Supported | Metrics and tracing integration via `ballerina/observe` is not implemented. |
-| XML payloads | Supported | `setXmlPayload()` and `getXmlPayload()` are declared on both `Request` and `Response`, `RequestMessage` admits `xml` (an `xml` message is sent as `application/xml`), `application/xml` and `text/xml` responses bind to `xml` targets, and a resource may return `xml`. There is no `mime:Entity` layer, so multipart XML parts are still out of scope. |
+| XML payloads | Supported | `setXmlPayload()` and `getXmlPayload()` are declared on both `Request` and `Response`, `RequestMessage` admits `xml` (an `xml` message is sent as `application/xml`), `application/xml` and `text/xml` responses bind to `xml` targets, and a resource may return `xml`. `mime:Entity` has no `setXml`/`getXml` of its own, so multipart XML parts are still out of scope. |
 
 ### Notable Behavioural Changes
 

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/http.bal
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/http.bal
@@ -14,6 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/mime;
+import ballerina/url;
+
 // Supported subset of ballerina/http for the Go runtime.
 // See lib/http/client-support.md for the full feature support matrix.
 
@@ -382,6 +385,35 @@ public class Response {
     #              but all lookups operate on transport headers
     # + return - An array of all header names present in the response
     public isolated function getHeaderNames(HeaderPosition position = LEADING) returns string[] = external;
+
+    # Sets the response body as a set of multipart body parts.
+    #
+    # + bodyParts - The body parts to be set
+    # + contentType - Optional MIME type; if absent, the response's existing `Content-Type` is kept
+    #                 if already set, otherwise `multipart/form-data` is used
+    public isolated function setBodyParts(mime:Entity[] bodyParts, string? contentType = ()) = external;
+
+    # Extracts the response body as multipart body parts.
+    #
+    # + return - The body parts, or an `error` if the response body is not a composite
+    #            (`multipart/*` or `message/*`) media type, or the body cannot be decoded
+    public isolated function getBodyParts() returns mime:Entity[]|error = external;
+
+    # Sets the response body, dispatching to the specific setter based on the runtime type of `payload`.
+    #
+    # + payload - A `string`, `byte[]`, `mime:Entity[]`, or other JSON-compatible value to set as the response body
+    # + contentType - Optional MIME type overriding the type-inferred default
+    public isolated function setPayload(json|byte[]|mime:Entity[] payload, string? contentType = ()) {
+        if payload is string {
+            self.setTextPayload(payload, contentType);
+        } else if payload is byte[] {
+            self.setBinaryPayload(payload, contentType);
+        } else if payload is mime:Entity[] {
+            self.setBodyParts(payload, contentType);
+        } else {
+            self.setJsonPayload(payload, contentType);
+        }
+    }
 }
 
 // ── Request ───────────────────────────────────────────────────────────────────
@@ -530,12 +562,132 @@ public class Request {
     # + key - The query parameter name
     # + return - A `string[]` of all values, or `()` if the parameter is not present
     public isolated function getQueryParamValues(string key) returns string[]? = external;
+
+    # Sets the request body as a set of multipart body parts.
+    #
+    # + bodyParts - The body parts to be set
+    # + contentType - Optional MIME type; if absent, the request's existing `Content-Type` is kept
+    #                 if already set, otherwise `multipart/form-data` is used
+    public isolated function setBodyParts(mime:Entity[] bodyParts, string? contentType = ()) = external;
+
+    # Extracts the request body as multipart body parts.
+    #
+    # + return - The body parts, or an `error` if the request body is not a composite
+    #            (`multipart/*` or `message/*`) media type, or the body cannot be decoded
+    public isolated function getBodyParts() returns mime:Entity[]|error = external;
+
+    # Sets the request body, dispatching to the specific setter based on the runtime type of `payload`.
+    #
+    # + payload - A `string`, `byte[]`, `mime:Entity[]`, or other JSON-compatible value to set as the request body
+    # + contentType - Optional MIME type overriding the type-inferred default
+    public isolated function setPayload(json|byte[]|mime:Entity[] payload, string? contentType = ()) {
+        if payload is string {
+            self.setTextPayload(payload, contentType);
+        } else if payload is byte[] {
+            self.setBinaryPayload(payload, contentType);
+        } else if payload is mime:Entity[] {
+            self.setBodyParts(payload, contentType);
+        } else {
+            self.setJsonPayload(payload, contentType);
+        }
+    }
+
+    # Extracts and decodes the form parameters from a request body of
+    # `Content-Type: application/x-www-form-urlencoded`.
+    #
+    # + return - A `map<string>` of decoded form parameter names to values, or an `error` if the
+    #            `Content-Type` header is missing, invalid, not `application/x-www-form-urlencoded`,
+    #            or the body cannot be decoded
+    public isolated function getFormParams() returns map<string>|error {
+        string message = "Error occurred while retrieving form parameters from the request";
+        string|error contentTypeValue = self.getHeader(mime:CONTENT_TYPE);
+        if contentTypeValue is error {
+            return error(message, error("Content-Type header is not available"));
+        }
+        mime:MediaType|mime:InvalidContentTypeError mediaType = mime:getMediaType(contentTypeValue);
+        if mediaType is mime:InvalidContentTypeError {
+            return error(message, mediaType);
+        }
+        string baseType = mediaType.primaryType + "/" + mediaType.subType;
+        if !baseType.equalsIgnoreCaseAscii(mime:APPLICATION_FORM_URLENCODED) {
+            return error(message, error("Invalid content type: expected 'application/x-www-form-urlencoded'"));
+        }
+        string|error formData = self.getTextPayload();
+        if formData is error {
+            return error(message, formData);
+        }
+        return parseFormData(formData);
+    }
 }
 
-// Represents an HTTP outbound request entity. Accepts any `anydata` value (including `xml`)
-// or an existing `Request` object. The `mime:Entity[]` and `stream` subtypes of jBallerina's
-// `RequestMessage` are not supported in this implementation.
-public type RequestMessage anydata|Request;
+// Splits `formData` (already percent-decoded) on `&` into name/value pairs delimited by the
+// first `=` in each pair, mirroring jBallerina's `getFormDataMap`. Byte-level scanning is used
+// because this port's `lang.string` has no `indexOf`/`split`; splitting only on the single-byte
+// ASCII delimiters `&` (38) and `=` (61) is safe over decoded UTF-8 text since those byte values
+// never occur inside a multi-byte codepoint. Byte offsets are converted to codepoint offsets
+// before calling `substring` so multi-byte UTF-8 content decodes correctly.
+isolated function parseFormData(string formData) returns map<string>|error {
+    map<string> parameters = {};
+    if formData.length() == 0 {
+        return parameters;
+    }
+    string decodedValue = check url:decode(formData, "UTF-8");
+    byte[] allBytes = decodedValue.toBytes();
+    int totalLength = allBytes.length();
+    if indexOfByte(allBytes, 61, 0) == -1 {
+        return error("Datasource does not contain form data");
+    }
+    int entryStart = 0;
+    while entryStart <= totalLength {
+        int ampIndex = indexOfByte(allBytes, 38, entryStart);
+        int entryEnd = totalLength;
+        if ampIndex != -1 {
+            entryEnd = ampIndex;
+        }
+        int equalsIndex = indexOfByte(allBytes, 61, entryStart);
+        if equalsIndex != -1 && equalsIndex < entryEnd {
+            string name = decodedValue.substring(byteOffsetToCharOffset(allBytes, entryStart),
+                    byteOffsetToCharOffset(allBytes, equalsIndex));
+            string value = decodedValue.substring(byteOffsetToCharOffset(allBytes, equalsIndex + 1),
+                    byteOffsetToCharOffset(allBytes, entryEnd));
+            parameters[name.trim()] = value.trim();
+        }
+        entryStart = entryEnd + 1;
+    }
+    return parameters;
+}
+
+isolated function indexOfByte(byte[] data, int target, int startIndex) returns int {
+    int i = startIndex;
+    int len = data.length();
+    while i < len {
+        if data[i] == target {
+            return i;
+        }
+        i += 1;
+    }
+    return -1;
+}
+
+// Counts UTF-8 lead bytes (values outside the 0x80-0xBF continuation-byte range) up to
+// `byteOffset`, converting a byte-array index into the codepoint index `substring` expects.
+isolated function byteOffsetToCharOffset(byte[] data, int byteOffset) returns int {
+    int charOffset = 0;
+    int i = 0;
+    while i < byteOffset {
+        byte b = data[i];
+        if b < 128 || b >= 192 {
+            charOffset += 1;
+        }
+        i += 1;
+    }
+    return charOffset;
+}
+
+// Represents an HTTP outbound request entity. Accepts any `anydata` value (including `xml`),
+// an existing `Request` object, or a multipart body (`mime:Entity[]`). The `stream` subtype
+// of jBallerina's `RequestMessage` is not supported in this implementation.
+public type RequestMessage anydata|Request|mime:Entity[];
 
 # Represents the types of the `targetType` parameter of the client remote methods.
 # The `stream<SseEvent, error?>` member of jBallerina's `TargetType` is not supported

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/native/http_native.go
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/native/http_native.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/ballerina-nutcracker/ballerina/bir"
 	"github.com/ballerina-nutcracker/ballerina/decimal"
+	mimenative "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/mime/0.0.1/go1.26/native"
 	"github.com/ballerina-nutcracker/ballerina/model"
 	"github.com/ballerina-nutcracker/ballerina/platform/pal"
 	"github.com/ballerina-nutcracker/ballerina/runtime"
@@ -359,7 +360,7 @@ func goCtxOrBackground(_ *extern.Context) context.Context {
 // only reads methodKeys (never mutates it), so sharing one map is safe and
 // avoids re-allocating it on every request.
 var requestMethodKeyCache = makeMethodKeys("ballerina/http:Request.", []string{
-	"setTextPayload", "setJsonPayload", "setXmlPayload", "setBinaryPayload",
+	"setTextPayload", "setJsonPayload", "setXmlPayload", "setBinaryPayload", "setBodyParts", "getBodyParts",
 	"setHeader", "addHeader", "removeHeader", "removeAllHeaders", "getHeaderNames",
 	"setContentType", "getContentType", "getTextPayload", "getJsonPayload", "getXmlPayload",
 	"getBinaryPayload",
@@ -391,17 +392,15 @@ func compressionModeOf(self *values.Object) string {
 
 func initHttpModule(rt *runtime.Runtime) {
 	env := rt.GetTypeEnv()
-	jsonTy := semtypes.CreateJSON(semtypes.ContextFrom(env))
+	jsonListTy, jsonMapTy := mimenative.JSONListAndMapTypes(semtypes.ContextFrom(env))
 	byteArrLd := semtypes.NewListDefinition()
 	strArrLd := semtypes.NewListDefinition()
-	jsonMapMd := semtypes.NewMappingDefinition()
-	jsonListLd := semtypes.NewListDefinition()
 	strMapMd := semtypes.NewMappingDefinition()
 	types := httpTypes{
 		byteArrTy:   byteArrLd.Define(env, nil, semtypes.ListRest(semtypes.Byte)),
 		strArrTy:    strArrLd.Define(env, nil, semtypes.ListRest(semtypes.String)),
-		jsonMapTy:   jsonMapMd.Define(env, nil, jsonTy),
-		jsonListTy:  jsonListLd.Define(env, nil, semtypes.ListRest(jsonTy)),
+		jsonMapTy:   jsonMapTy,
+		jsonListTy:  jsonListTy,
 		mapStringTy: strMapMd.Define(env, nil, semtypes.String),
 	}
 
@@ -1052,6 +1051,57 @@ func initHttpModule(rt *runtime.Runtime) {
 			return nil, nil
 		})
 
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "Response.setBodyParts",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			self := args[0].(*values.Object)
+			parts, ok := entityListToParts(args[1])
+			if !ok {
+				return values.NewErrorWithMessage("setBodyParts: expected Entity[]"), nil
+			}
+			var newContentType string
+			if len(args) > 2 {
+				newContentType, _ = args[2].(string)
+			}
+			existingContentType := ""
+			if v, ok := responseHeaders(self).Get("content-type"); ok {
+				if list, ok := v.(*values.List); ok && list.Len() > 0 {
+					existingContentType, _ = list.Get(0).(string)
+				}
+			}
+			data, finalContentType, err := encodeMultipartBody(parts, resolveMultipartContentType(existingContentType, newContentType))
+			if err != nil {
+				return values.NewErrorWithMessage("setBodyParts: " + err.Error()), nil
+			}
+			self.Put("body", &responseBodyHolder{buf: data})
+			responseHeaders(self).Put(ctx.TypeCtx(), "content-type", newListValue([]values.BalValue{finalContentType}))
+			return nil, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "Response.getBodyParts",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			self := args[0].(*values.Object)
+			bodyVal, _ := self.Get("body")
+			var raw []byte
+			if holder, ok := bodyVal.(*responseBodyHolder); ok {
+				var err error
+				raw, err = holder.materialize()
+				if err != nil {
+					return values.NewErrorWithMessage(err.Error()), nil
+				}
+			}
+			contentType := ""
+			if v, ok := responseHeaders(self).Get("content-type"); ok {
+				if list, ok := v.(*values.List); ok && list.Len() > 0 {
+					contentType, _ = list.Get(0).(string)
+				}
+			}
+			parts, err := getMultipartBodyParts(ctx, raw, contentType, "response")
+			if err != nil {
+				return values.NewErrorWithMessage(err.Error()), nil
+			}
+			return parts, nil
+		})
+
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "Response.setHeader",
 		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
 			self := args[0].(*values.Object)
@@ -1319,6 +1369,58 @@ func initHttpModule(rt *runtime.Runtime) {
 			ct := payloadContentType(requestContentType(tc, self), optionalArg(args, 2), "application/octet-stream")
 			setRequestHeader(self, "content-type", ct, tc)
 			return nil, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "Request.setBodyParts",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			self := args[0].(*values.Object)
+			parts, ok := entityListToParts(args[1])
+			if !ok {
+				return values.NewErrorWithMessage("setBodyParts: expected Entity[]"), nil
+			}
+			var newContentType string
+			if len(args) > 2 {
+				newContentType, _ = args[2].(string)
+			}
+			existingContentType := ""
+			if hdrs, ok := requestHeadersMap(ctx.TypeCtx(), self); ok {
+				if v, ok := hdrs.Get("content-type"); ok {
+					if list, ok := v.(*values.List); ok && list.Len() > 0 {
+						existingContentType, _ = list.Get(0).(string)
+					}
+				}
+			}
+			data, finalContentType, err := encodeMultipartBody(parts, resolveMultipartContentType(existingContentType, newContentType))
+			if err != nil {
+				return values.NewErrorWithMessage("setBodyParts: " + err.Error()), nil
+			}
+			self.Put("$body", &requestBodyHolder{buf: data})
+			setRequestHeader(self, "content-type", finalContentType, ctx.TypeCtx())
+			return nil, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "Request.getBodyParts",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			self := args[0].(*values.Object)
+			bodyVal, _ := self.Get("$body")
+			holder, _ := bodyVal.(*requestBodyHolder)
+			var raw []byte
+			if holder != nil {
+				raw = holder.materialize()
+			}
+			contentType := ""
+			if hdrs, ok := requestHeadersMap(ctx.TypeCtx(), self); ok {
+				if v, ok := hdrs.Get("content-type"); ok {
+					if list, ok := v.(*values.List); ok && list.Len() > 0 {
+						contentType, _ = list.Get(0).(string)
+					}
+				}
+			}
+			parts, err := getMultipartBodyParts(ctx, raw, contentType, "request")
+			if err != nil {
+				return values.NewErrorWithMessage(err.Error()), nil
+			}
+			return parts, nil
 		})
 
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "Request.setHeader",
@@ -1775,7 +1877,7 @@ func extractHeaders(arg values.BalValue) map[string][]string {
 // responseMethodKeyCache mirrors requestMethodKeyCache for Response objects:
 // a constant map built once and shared read-only across all Response objects.
 var responseMethodKeyCache = makeMethodKeys("ballerina/http:Response.", []string{
-	"setTextPayload", "setJsonPayload", "setXmlPayload", "setBinaryPayload",
+	"setTextPayload", "setJsonPayload", "setXmlPayload", "setBinaryPayload", "setBodyParts", "getBodyParts",
 	"setHeader", "addHeader", "removeHeader", "removeAllHeaders",
 	"setContentType", "getContentType", "getTextPayload", "getJsonPayload", "getXmlPayload",
 	"getBinaryPayload",
@@ -1839,4 +1941,66 @@ func headerListValues(hdrs *values.Map, name string) []string {
 // toJSONBytes serializes a Ballerina value to JSON bytes.
 func toJSONBytes(v values.BalValue) ([]byte, error) {
 	return values.ToJSONByteArray(v)
+}
+
+// entityListToParts converts a Ballerina mime:Entity[] argument to native part objects.
+func entityListToParts(arg values.BalValue) ([]*values.Object, bool) {
+	list, ok := arg.(*values.List)
+	if !ok {
+		return nil, false
+	}
+	parts := make([]*values.Object, list.Len())
+	for i := range list.Len() {
+		part, ok := list.Get(i).(*values.Object)
+		if !ok {
+			return nil, false
+		}
+		parts[i] = part
+	}
+	return parts, true
+}
+
+// resolveMultipartContentType mirrors jBallerina's http_commons.bal `setBodyParts` helper:
+// an explicit override wins, otherwise the request/response's own existing Content-Type is
+// kept (if set), otherwise it falls back to mime:Entity's own multipart/form-data default.
+func resolveMultipartContentType(existingContentType, newContentType string) string {
+	if newContentType != "" {
+		return newContentType
+	}
+	if existingContentType != "" {
+		return existingContentType
+	}
+	return "multipart/form-data"
+}
+
+// encodeMultipartBody serializes body parts for wire transmission, generating a boundary if
+// contentType doesn't already carry one, and returns the finalized Content-Type header value.
+func encodeMultipartBody(parts []*values.Object, contentType string) (data []byte, finalContentType string, err error) {
+	_, boundary, _ := mimenative.MultipartBoundary(contentType)
+	data, usedBoundary, err := mimenative.EncodeMultipart(parts, boundary)
+	if err != nil {
+		return nil, "", err
+	}
+	if boundary != "" {
+		return data, contentType, nil
+	}
+	return data, contentType + "; boundary=" + usedBoundary, nil
+}
+
+// getMultipartBodyParts decodes a raw request/response body into mime:Entity[] body parts.
+// kind is "request" or "response", used only to word the error message.
+func getMultipartBodyParts(ctx *extern.Context, raw []byte, contentType, kind string) (*values.List, error) {
+	baseType, boundary, isComposite := mimenative.MultipartBoundary(contentType)
+	if !isComposite {
+		//nolint:staticcheck // error text mirrors jBallerina's runtime message verbatim
+		return nil, fmt.Errorf("Error occurred while retrieving body parts from the %s: "+
+			"Entity body is not a type of composite media type. Received content-type : %s", kind, baseType)
+	}
+	parts, err := mimenative.DecodeMultipart(ctx, raw, boundary)
+	if err != nil {
+		//nolint:staticcheck // error text mirrors jBallerina's runtime message verbatim
+		return nil, fmt.Errorf("Error occurred while retrieving body parts from the %s: "+
+			"Error occurred while extracting body parts from entity: %s", kind, err.Error())
+	}
+	return mimenative.EntityListFromParts(ctx, parts), nil
 }

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/native/payload_binding.go
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/native/payload_binding.go
@@ -37,6 +37,14 @@ func outboundPayload(tc semtypes.Context, types *httpTypes, v values.BalValue) (
 		if !semtypes.IsZero(p.Type) && semtypes.IsSubtype(tc, p.Type, types.byteArrTy) {
 			return p.ToByteSlice(), "application/octet-stream", nil
 		}
+		if p.Len() > 0 {
+			if parts, ok := entityListToParts(p); ok {
+				data, contentType, err := encodeMultipartBody(parts, "multipart/form-data")
+				if err == nil {
+					return data, contentType, nil
+				}
+			}
+		}
 	}
 	b, err := toJSONBytes(v)
 	if err != nil {

--- a/lib/stdlibs/ballerina/mime/0.0.1/go1.26/Bala.toml
+++ b/lib/stdlibs/ballerina/mime/0.0.1/go1.26/Bala.toml
@@ -1,0 +1,12 @@
+[bala]
+schema_version = "4"
+
+[build]
+ballerina_version      = ""
+implementation_vendor  = "WSO2"
+language_spec_version  = "2024R1"
+platform               = "go1.26"
+
+[[modules]]
+name   = "mime"
+export = true

--- a/lib/stdlibs/ballerina/mime/0.0.1/go1.26/Ballerina.toml
+++ b/lib/stdlibs/ballerina/mime/0.0.1/go1.26/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org     = "ballerina"
+name    = "mime"
+version = "0.0.1"

--- a/lib/stdlibs/ballerina/mime/0.0.1/go1.26/Dependencies.toml
+++ b/lib/stdlibs/ballerina/mime/0.0.1/go1.26/Dependencies.toml
@@ -1,0 +1,7 @@
+[ballerina]
+dependencies-toml-version = "2"
+
+[[package]]
+org     = "ballerina"
+name    = "mime"
+version = "0.0.1"

--- a/lib/stdlibs/ballerina/mime/0.0.1/go1.26/README.md
+++ b/lib/stdlibs/ballerina/mime/0.0.1/go1.26/README.md
@@ -1,0 +1,78 @@
+# Ballerina MIME Library
+
+## Overview
+
+The `ballerina/mime` library provides utilities for working with MIME (Multipurpose Internet Mail Extensions) types and entities as defined by RFC 2045/2046. It covers media type parsing and construction, content disposition handling, entity header and body management (text, JSON, binary, and multipart), and Base64 encoding/decoding.
+
+## Key Functionalities
+
+- Parse and construct MIME media types (`MediaType`) including primary type, sub-type, suffix, and parameters.
+- Parse and construct content disposition headers (`ContentDisposition`) including filename, name, and parameters.
+- Manage MIME entity headers: set, get, add, remove, and check presence.
+- Manage entity content metadata: content type, content ID, content length, and content disposition.
+- Set and retrieve entity body payloads as text, JSON, or byte arrays, with every accessor able to convert from whatever the body was actually set as.
+- Set and extract multipart (`multipart/form-data`, etc.) body parts as an `Entity[]`.
+- Perform Base64 encoding and decoding of strings and byte arrays using MIME-compatible line folding.
+- Predefined constants for common media type strings and header names.
+
+## Examples
+
+```ballerina
+import ballerina/io;
+import ballerina/mime;
+
+public function main() returns error? {
+    mime:MediaType mt = check mime:getMediaType("application/json; charset=UTF-8");
+    io:println(mt.primaryType);          // application
+    io:println(mt.getBaseType());        // application/json
+    io:println(mt.parameters["charset"]); // UTF-8
+
+    mime:Entity entity = new ();
+    entity.setHeader("Content-Type", mime:APPLICATION_JSON);
+    io:println(entity.hasHeader("content-type")); // true
+    entity.setText("Hello");
+    string|mime:ParserError text = entity.getText();
+    if text is string {
+        io:println(text); // Hello
+    }
+
+    string|byte[]|mime:EncodeError encoded = mime:base64Encode("Hello");
+    if encoded is string {
+        io:println(encoded); // SGVsbG8=
+    }
+}
+```
+
+## Go Native Interpreter Support Status
+
+This library is currently being migrated to Go to support the Ballerina Native Interpreter. The table below outlines the current support level for various features of this library in the Go implementation.
+
+Support Levels:
+
+- **Supported**: Fully implemented and tested in the Go version.
+- **Partially Supported**: Implemented but lacking some edge cases, options, or sub-features. (See comments).
+- **Not Yet Supported**: Planned for migration, but not yet implemented.
+- **Cannot Support**: Cannot be implemented in the Go version due to technical limitations or architectural differences. (See comments).
+
+| Feature/API | Support Status | Comments / Limitations |
+|---|---|---|
+| Media type MIME string constants | Supported | `APPLICATION_JSON`, `TEXT_PLAIN`, `APPLICATION_OCTET_STREAM`, `MULTIPART_FORM_DATA`, `TEXT_HTML`, `IMAGE_JPEG`, and 14 others |
+| Header and charset constants | Supported | `CONTENT_TYPE`, `CONTENT_LENGTH`, `CONTENT_ID`, `CONTENT_DISPOSITION`, `DEFAULT_CHARSET`, `CHARSET`, `BOUNDARY`, `START`, `TYPE` |
+| MediaType class | Supported | Fields `primaryType`, `subType`, `suffix`, `parameters`; methods `getBaseType()` and `toString()` |
+| ContentDisposition class | Supported | Fields `fileName`, `disposition`, `name`, `parameters`; method `toString()` |
+| Media type parsing | Supported | `getMediaType(contentType)` — returns `MediaType\|InvalidContentTypeError` |
+| Content disposition parsing | Supported | `getContentDispositionObject(contentDisposition)` |
+| Entity header management | Supported | `setHeader`, `getHeader`, `getHeaders`, `getHeaderNames`, `addHeader`, `removeHeader`, `removeAllHeaders`, `hasHeader` |
+| Entity content metadata | Supported | `setContentType`, `getContentType`, `setContentId`, `getContentId`, `setContentLength`, `getContentLength`, `setContentDisposition`, `getContentDisposition` |
+| Entity text body | Supported | `setText`, `getText` — `getText()` also converts from a JSON or byte[] body, matching jBallerina's data-source model |
+| Entity JSON body | Supported | `setJson`, `getJson` — `getJson()` also parses a text or byte[] body as JSON |
+| Entity byte array body | Supported | `setByteArray`, `getByteArray` — `getByteArray()` also encodes a text or JSON body to bytes |
+| Entity generic body dispatch | Supported | `setBody(string\|json\|byte[]\|Entity[])` |
+| Entity multipart body | Partially Supported | `setBodyParts`, `getBodyParts` — flat (single-level) multipart only; a part whose own body is itself multipart is not recursively decoded. Per-part `Content-Type` defaults to `text/plain` when the wire omits it, matching jBallerina. `getBodyPartsAsChannel` is not implemented — it returns `io:ReadableByteChannel`, an unrelated, still-unimplemented io type |
+| Base64 encoding and decoding | Supported | `base64Encode`, `base64Decode`, `base64EncodeBlob`, `base64DecodeBlob` |
+| Entity XML body | Not Yet Supported | `setXml`, `getXml` require XML type support |
+| Module-level error type | Partially Supported | `mime:Error` and all subtypes (`InvalidContentTypeError`, `ParserError`, `HeaderNotFoundError`, `EncodeError`, `DecodeError`, etc.) are plain `error` aliases; `distinct` type descriptor not yet supported |
+
+### Notable Behavioural Changes
+
+There are **no** notable behavioural changes in the Go-native version compared to the original jBallerina implementation for the currently supported features.

--- a/lib/stdlibs/ballerina/mime/0.0.1/go1.26/mime.bal
+++ b/lib/stdlibs/ballerina/mime/0.0.1/go1.26/mime.bal
@@ -1,0 +1,579 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+// Note: distinct error types are not yet supported; all subtypes are plain error aliases.
+
+# The base error type for the `mime` module.
+public type Error error;
+
+# Represents an error that occurred while encoding data.
+public type EncodeError error;
+
+# Represents an error that occurred while decoding data.
+public type DecodeError error;
+
+# Represents a generic MIME-related error.
+public type GenericMimeError error;
+
+# Represents an error that occurred while setting a header.
+public type SetHeaderError error;
+
+# Represents an error due to an invalid header value.
+public type InvalidHeaderValueError error;
+
+# Represents an error due to an invalid header parameter.
+public type InvalidHeaderParamError error;
+
+# Represents an error due to an invalid content-length value.
+public type InvalidContentLengthError error;
+
+# Represents an error when a requested header cannot be found.
+public type HeaderNotFoundError error;
+
+# Represents an error due to an invalid header operation.
+public type InvalidHeaderOperationError error;
+
+# Represents an error that occurred during serialization.
+public type SerializationError error;
+
+# Represents an error that occurred while parsing an entity body.
+public type ParserError error;
+
+# Represents an error due to an invalid content-type value.
+public type InvalidContentTypeError error;
+
+# Represents an error when a header is unavailable.
+public type HeaderUnavailableError error;
+
+# Represents an error triggered when an idle timeout is reached.
+public type IdleTimeoutTriggeredError error;
+
+# Represents an error when no content is available.
+public type NoContentError error;
+
+// ── Media type constants ─────────────────────────────────────────────────────
+
+# Media type for octet-stream.
+public const APPLICATION_OCTET_STREAM = "application/octet-stream";
+
+# Media type for JSON.
+public const APPLICATION_JSON = "application/json";
+
+# Media type for XML.
+public const APPLICATION_XML = "application/xml";
+
+# Media type for SVG+XML.
+public const APPLICATION_SVG_XML = "application/svg+xml";
+
+# Media type for XHTML+XML.
+public const APPLICATION_XHTML_XML = "application/xhtml+xml";
+
+# Media type for SOAP+XML.
+public const APPLICATION_SOAP_XML = "application/soap+xml";
+
+# Media type for URL-encoded form data.
+public const APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded";
+
+# Media type for PDF.
+public const APPLICATION_PDF = "application/pdf";
+
+# Media type for JPEG images.
+public const IMAGE_JPEG = "image/jpeg";
+
+# Media type for GIF images.
+public const IMAGE_GIF = "image/gif";
+
+# Media type for PNG images.
+public const IMAGE_PNG = "image/png";
+
+# Media type for multipart form data.
+public const MULTIPART_FORM_DATA = "multipart/form-data";
+
+# Media type for multipart mixed content.
+public const MULTIPART_MIXED = "multipart/mixed";
+
+# Media type for multipart alternative content.
+public const MULTIPART_ALTERNATIVE = "multipart/alternative";
+
+# Media type for multipart related content.
+public const MULTIPART_RELATED = "multipart/related";
+
+# Media type for multipart parallel content.
+public const MULTIPART_PARALLEL = "multipart/parallel";
+
+# Media type for plain text.
+public const TEXT_PLAIN = "text/plain";
+
+# Media type for HTML.
+public const TEXT_HTML = "text/html";
+
+# Media type for XML text.
+public const TEXT_XML = "text/xml";
+
+# Media type for server-sent events.
+public const TEXT_EVENT_STREAM = "text/event-stream";
+
+// ── Header names and native bindings ──────────────────────────────────────────
+
+# The `boundary` parameter name for multipart content types.
+public const BOUNDARY = "boundary";
+
+# The `start` parameter name for multipart content types.
+public const START = "start";
+
+# The `type` parameter name for multipart content types.
+public const TYPE = "type";
+
+# The `charset` parameter name for content types.
+public const CHARSET = "charset";
+
+# The default charset used when none is specified.
+public const DEFAULT_CHARSET = "UTF-8";
+
+# The `Content-Id` header name.
+public const CONTENT_ID = "content-id";
+
+# The `Content-Length` header name.
+public const CONTENT_LENGTH = "content-length";
+
+# The `Content-Type` header name.
+public const CONTENT_TYPE = "content-type";
+
+# The `Content-Disposition` header name.
+public const CONTENT_DISPOSITION = "content-disposition";
+
+# Represents the `Content-Disposition` header of an entity.
+public class ContentDisposition {
+
+    # The filename parameter of the content disposition.
+    public string fileName = "";
+    # The disposition type, e.g. `attachment`, `form-data`.
+    public string disposition = "";
+    # The `name` parameter of the content disposition.
+    public string name = "";
+    # Additional parameters of the content disposition.
+    public map<string> parameters = {};
+
+    # Converts this `ContentDisposition` to its wire representation.
+    #
+    # + return - the string representation of this content disposition
+    public isolated function toString() returns string {
+        return convertContentDispositionToString(self);
+    }
+}
+
+isolated function convertContentDispositionToString(ContentDisposition contentDisposition) returns string = external;
+
+# Represents the primary type, sub-type, suffix, and parameters of a MIME media type.
+public class MediaType {
+
+    # The primary type, e.g. `application`, `text`.
+    public string primaryType = "";
+    # The sub-type, e.g. `json`, `plain`.
+    public string subType = "";
+    # The suffix, e.g. `xml` in `application/svg+xml`.
+    public string suffix = "";
+    # Additional parameters of the media type, e.g. `charset`.
+    public map<string> parameters = {};
+
+    # Returns the base type, i.e. `primaryType/subType`, without any parameters.
+    #
+    # + return - the base media type string
+    public isolated function getBaseType() returns string {
+        return string `${self.primaryType}/${self.subType}`;
+    }
+
+    // Note: jBallerina uses the elvis operator (?:) which is not yet supported.
+    // Rewritten using explicit if/else.
+    # Converts this `MediaType` to its wire representation, including parameters.
+    #
+    # + return - the string representation of this media type
+    public isolated function toString() returns string {
+        string contentType = self.getBaseType();
+        string[] keys = self.parameters.keys();
+        if keys.length() > 0 {
+            contentType = contentType + "; ";
+        }
+        foreach int i in 0 ..< keys.length() {
+            string key = keys[i];
+            string value = "";
+            string? mapVal = self.parameters[key];
+            if mapVal is string {
+                value = mapVal;
+            }
+            if i > 0 {
+                contentType = contentType + ";";
+            }
+            contentType = contentType + string `${key}=${value}`;
+        }
+        return contentType;
+    }
+}
+
+# Represents a MIME entity: headers, content metadata, and a body (text, JSON,
+# byte array, or multipart body parts).
+public class Entity {
+
+    private MediaType? cType;
+    private string cId;
+    private int cLength;
+    private ContentDisposition? cDisposition;
+    private map<string[]> headerMap;
+    private string[] headerNames;
+
+    public isolated function init() {
+        self.cType = ();
+        self.cId = "";
+        self.cLength = 0;
+        self.cDisposition = ();
+        self.headerMap = {};
+        self.headerNames = [];
+    }
+
+    # Sets the content type of this entity.
+    #
+    # + mediaType - the media type string to set
+    # + return - an `InvalidContentTypeError` if `mediaType` cannot be parsed
+    public isolated function setContentType(string mediaType) returns InvalidContentTypeError? {
+        self.cType = check getMediaType(mediaType);
+        self.setHeader(CONTENT_TYPE, mediaType);
+        return;
+    }
+
+    # Returns the content type of this entity, or `""` if not set.
+    #
+    # + return - the content type string
+    public isolated function getContentType() returns string {
+        string contentTypeHeaderValue = "";
+        string|HeaderNotFoundError value = self.getHeader(CONTENT_TYPE);
+        if value is string {
+            contentTypeHeaderValue = value;
+        }
+        return contentTypeHeaderValue;
+    }
+
+    # Sets the content ID of this entity.
+    #
+    # + contentId - the content ID to set
+    public isolated function setContentId(string contentId) {
+        self.cId = contentId;
+        self.setHeader(CONTENT_ID, contentId);
+    }
+
+    # Returns the content ID of this entity, or `""` if not set.
+    #
+    # + return - the content ID string
+    public isolated function getContentId() returns string {
+        string contentId = "";
+        string|HeaderNotFoundError value = self.getHeader(CONTENT_ID);
+        if value is string {
+            contentId = value;
+        }
+        return contentId;
+    }
+
+    # Sets the content length of this entity.
+    #
+    # + contentLength - the content length to set
+    public isolated function setContentLength(int contentLength) {
+        self.cLength = contentLength;
+        self.setHeader(CONTENT_LENGTH, externIntToString(contentLength));
+    }
+
+    # Returns the content length of this entity, or `-1` if not set.
+    #
+    # + return - the content length, or an `error` if the header value isn't a valid integer
+    public isolated function getContentLength() returns int|error {
+        string contentLength = "";
+        string|HeaderNotFoundError length = self.getHeader(CONTENT_LENGTH);
+        if length is string {
+            contentLength = length;
+        }
+        if contentLength == "" {
+            return -1;
+        }
+        return externParseInt(contentLength);
+    }
+
+    # Sets the content disposition of this entity.
+    #
+    # + contentDisposition - the content disposition to set
+    public isolated function setContentDisposition(ContentDisposition contentDisposition) {
+        self.cDisposition = contentDisposition;
+        self.setHeader(CONTENT_DISPOSITION, contentDisposition.toString());
+    }
+
+    # Returns the content disposition of this entity, or a default (empty) one if not set.
+    #
+    # + return - the content disposition
+    public isolated function getContentDisposition() returns ContentDisposition {
+        string contentDispositionVal = "";
+        string|HeaderNotFoundError value = self.getHeader(CONTENT_DISPOSITION);
+        if value is string {
+            contentDispositionVal = value;
+        }
+        return getContentDispositionObject(contentDispositionVal);
+    }
+
+    # Sets the body of this entity, dispatching by the runtime type of `entityBody`.
+    #
+    # + entityBody - the body to set: text, JSON, byte array, or multipart body parts
+    public isolated function setBody(string|json|byte[]|Entity[] entityBody) {
+        if entityBody is string {
+            self.setText(entityBody);
+        } else if entityBody is byte[] {
+            self.setByteArray(entityBody);
+        } else if entityBody is Entity[] {
+            self.setBodyParts(entityBody);
+        } else if entityBody is json {
+            self.setJson(entityBody);
+        }
+    }
+
+    # Sets the body of this entity as JSON.
+    #
+    # + jsonContent - the JSON content to set
+    # + contentType - the content type to set; defaults to `application/json`
+    public isolated function setJson(json jsonContent, string contentType = "application/json") {
+        externSetJson(self, jsonContent, contentType);
+        self.setHeader(CONTENT_TYPE, contentType);
+    }
+
+    # Extracts the entity body as JSON, converting from a text or byte[] body if necessary.
+    #
+    # + return - the JSON body, or a `ParserError` if it cannot be parsed as JSON
+    public isolated function getJson() returns json|ParserError {
+        return externGetJson(self);
+    }
+
+    # Sets the body of this entity as text.
+    #
+    # + textContent - the text content to set
+    # + contentType - the content type to set; defaults to `text/plain`
+    public isolated function setText(string textContent, string contentType = "text/plain") {
+        externSetText(self, textContent, contentType);
+        self.setHeader(CONTENT_TYPE, contentType);
+    }
+
+    # Extracts the entity body as text, converting from a JSON or byte[] body if necessary.
+    #
+    # + return - the text body, or a `ParserError` if it cannot be read as text
+    public isolated function getText() returns string|ParserError {
+        return externGetText(self);
+    }
+
+    # Sets the body of this entity as a byte array.
+    #
+    # + blobContent - the byte array content to set
+    # + contentType - the content type to set; defaults to `application/octet-stream`
+    public isolated function setByteArray(byte[] blobContent, string contentType = "application/octet-stream") {
+        externSetByteArray(self, blobContent, contentType);
+        self.setHeader(CONTENT_TYPE, contentType);
+    }
+
+    # Extracts the entity body as a byte array, converting from a text or JSON body if necessary.
+    #
+    # + return - the byte array body, or a `ParserError` if it cannot be encoded to bytes
+    public isolated function getByteArray() returns byte[]|ParserError {
+        return externGetByteArray(self);
+    }
+
+    # Sets the body parts of the entity, marking it as a multipart entity.
+    #
+    # + bodyParts - The body parts to be set
+    # + contentType - Optional MIME type; defaults to `multipart/form-data`
+    public isolated function setBodyParts(Entity[] bodyParts, string contentType = MULTIPART_FORM_DATA) {
+        externSetBodyParts(self, bodyParts, contentType);
+        self.setHeader(CONTENT_TYPE, contentType);
+    }
+
+    # Extracts body parts from a multipart entity.
+    #
+    # + return - An array of body parts, or a `ParserError` if the entity is not a composite
+    # (`multipart/*` or `message/*`) media type, or the body cannot be decoded
+    public isolated function getBodyParts() returns Entity[]|ParserError {
+        return externGetBodyParts(self);
+    }
+
+    # Returns the first value of the given header.
+    #
+    # + headerName - the header name, case-insensitive
+    # + return - the header value, or a `HeaderNotFoundError` if it isn't set
+    public isolated function getHeader(string headerName) returns string|HeaderNotFoundError {
+        string[] value = check self.getHeaders(headerName.toLowerAscii());
+        return value[0];
+    }
+
+    # Returns all values of the given header.
+    #
+    # + headerName - the header name, case-insensitive
+    # + return - the header values, or a `HeaderNotFoundError` if it isn't set
+    public isolated function getHeaders(string headerName) returns string[]|HeaderNotFoundError {
+        string lowerCaseHeaderName = headerName.toLowerAscii();
+        string[]? value = self.headerMap[lowerCaseHeaderName];
+        if value is () {
+            return error HeaderNotFoundError("Http header does not exist");
+        }
+        return [...value];
+    }
+
+    # Returns the names of all headers set on this entity, in their original casing.
+    #
+    # + return - the header names
+    public isolated function getHeaderNames() returns string[] {
+        return [...self.headerNames];
+    }
+
+    # Adds a value to the given header, appending to any existing values.
+    #
+    # + headerName - the header name, case-insensitive
+    # + headerValue - the value to add
+    public isolated function addHeader(string headerName, string headerValue) {
+        string lowerCaseHeaderName = headerName.toLowerAscii();
+        string[]|HeaderNotFoundError headerList = self.getHeaders(lowerCaseHeaderName);
+        if headerList is string[] {
+            headerList.push(headerValue);
+            self.headerMap[lowerCaseHeaderName] = headerList;
+        } else {
+            self.setHeader(headerName, headerValue);
+        }
+    }
+
+    # Sets the given header, replacing any existing value(s).
+    #
+    # + headerName - the header name, case-insensitive
+    # + headerValue - the value to set
+    public isolated function setHeader(string headerName, string headerValue) {
+        string[] value = [headerValue];
+        self.headerMap[headerName.toLowerAscii()] = value;
+        string? caseSensitiveValue = getCaseSensitiveHeaderName(self.headerNames, headerName);
+        if caseSensitiveValue is () {
+            self.headerNames.push(headerName);
+        }
+    }
+
+    # Removes the given header, if present.
+    #
+    # + headerName - the header name, case-insensitive
+    public isolated function removeHeader(string headerName) {
+        string lowerName = headerName.toLowerAscii();
+        if !self.headerMap.hasKey(lowerName) {
+            return;
+        }
+        _ = self.headerMap.remove(lowerName);
+        self.headerNames = from string name in self.headerNames
+            where name.toLowerAscii() != lowerName
+            select name;
+    }
+
+    # Removes all headers set on this entity.
+    public isolated function removeAllHeaders() {
+        self.headerMap = {};
+        self.headerNames = [];
+    }
+
+    # Checks whether the given header is set on this entity.
+    #
+    # + headerName - the header name, case-insensitive
+    # + return - `true` if the header is set
+    public isolated function hasHeader(string headerName) returns boolean {
+        return self.headerMap.hasKey(headerName.toLowerAscii());
+    }
+}
+
+isolated function externSetJson(Entity entity, json jsonContent, string contentType) = external;
+
+isolated function externGetJson(Entity entity) returns json|ParserError = external;
+
+isolated function externSetText(Entity entity, string textContent, string contentType) = external;
+
+isolated function externGetText(Entity entity) returns string|ParserError = external;
+
+isolated function externSetByteArray(Entity entity, byte[] byteArray, string contentType) = external;
+
+isolated function externGetByteArray(Entity entity) returns byte[]|ParserError = external;
+
+isolated function externSetBodyParts(Entity entity, Entity[] bodyParts, string contentType) = external;
+
+isolated function externGetBodyParts(Entity entity) returns Entity[]|ParserError = external;
+
+isolated function externParseInt(string s) returns int|error = external;
+
+isolated function externIntToString(int n) returns string = external;
+
+isolated function getCaseSensitiveHeaderName(string[] headerNames, string headerName) returns string? {
+    foreach string name in headerNames {
+        if name.toLowerAscii() == headerName.toLowerAscii() {
+            return name;
+        }
+    }
+    return;
+}
+
+# Parses a `Content-Type` header value into a `MediaType`.
+#
+# + contentType - the content type string to parse
+# + return - the parsed media type, or an `InvalidContentTypeError` if it cannot be parsed
+public isolated function getMediaType(string contentType) returns MediaType|InvalidContentTypeError = external;
+
+# Parses a `Content-Disposition` header value into a `ContentDisposition`.
+#
+# + contentDisposition - the content disposition string to parse
+# + return - the parsed content disposition
+public isolated function getContentDispositionObject(string contentDisposition) returns ContentDisposition = external;
+
+# Encodes a string or byte array using MIME-compatible Base64 encoding.
+#
+# + contentToBeEncoded - the string or byte array to encode
+# + charset - the charset to use when the input is a string; defaults to `utf-8`
+# + return - the encoded value, in the same shape as the input, or an `EncodeError`
+public isolated function base64Encode((string|byte[]) contentToBeEncoded, string charset = "utf-8")
+        returns (string|byte[]|EncodeError) = external;
+
+# Decodes a Base64-encoded string or byte array.
+#
+# + contentToBeDecoded - the string or byte array to decode
+# + charset - the charset to use when the input is a string; defaults to `utf-8`
+# + return - the decoded value, in the same shape as the input, or a `DecodeError`
+public isolated function base64Decode((string|byte[]) contentToBeDecoded, string charset = "utf-8")
+        returns (string|byte[]|DecodeError) = external;
+
+# Encodes a byte array using MIME-compatible Base64 encoding.
+#
+# + valueToBeEncoded - the byte array to encode
+# + return - the encoded byte array, or an `EncodeError`
+public isolated function base64EncodeBlob(byte[] valueToBeEncoded) returns byte[]|EncodeError {
+    string|byte[]|EncodeError result = base64Encode(valueToBeEncoded);
+    if result is byte[]|EncodeError {
+        return result;
+    }
+    return error EncodeError("Error occurred while encoding byte[]");
+}
+
+# Decodes a Base64-encoded byte array.
+#
+# + valueToBeDecoded - the byte array to decode
+# + return - the decoded byte array, or a `DecodeError`
+public isolated function base64DecodeBlob(byte[] valueToBeDecoded) returns byte[]|DecodeError {
+    string|byte[]|DecodeError result = base64Decode(valueToBeDecoded);
+    if result is byte[]|DecodeError {
+        return result;
+    }
+    return error DecodeError("Error occurred while decoding byte[]");
+}

--- a/lib/stdlibs/ballerina/mime/0.0.1/go1.26/native/json_types.go
+++ b/lib/stdlibs/ballerina/mime/0.0.1/go1.26/native/json_types.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package native
+
+import (
+	stdruntime "runtime"
+	"sync"
+	"weak"
+
+	"github.com/ballerina-nutcracker/ballerina/semtypes"
+)
+
+type jsonTypePair struct {
+	listTy semtypes.SemType
+	mapTy  semtypes.SemType
+}
+
+// jsonTypesByEnv associates a weak pointer to a semtypes.Env with the canonical
+// json[]/map<json> semtypes built for it, self-cleaning once the Env is unreachable.
+var jsonTypesByEnv sync.Map // weak.Pointer[env-pointee] -> jsonTypePair
+
+// JSONListAndMapTypes returns the canonical json[]/map<json> semtypes for a context's
+// environment, memoized per environment. semtypes.ContextFrom builds a fresh Context
+// (with empty memo maps) on every call, so semtypes.CreateJSON's own per-Context memo
+// does not stop two independent callers (e.g. two stdlibs) building separate
+// ListDefinition/MappingDefinition instances for "the same" json list/map type — each
+// registers its own atom into the shared environment, which is otherwise-harmless but
+// shifts how unrelated recursive types print in that environment (extra atoms shift
+// atom-table numbering). Every caller that needs these types for GoToBalValue must go
+// through this shared accessor instead of building its own.
+func JSONListAndMapTypes(ctx semtypes.Context) (semtypes.SemType, semtypes.SemType) {
+	env := ctx.Env()
+	// Boxed as `any` immediately: env's pointee type is unexported in semtypes, so this
+	// package can only name weak.Pointer[...] for it via type inference, not explicitly —
+	// boxing lets the AddCleanup callback below stay a plain func(any).
+	key := any(weak.Make(env))
+	if v, ok := jsonTypesByEnv.Load(key); ok {
+		p := v.(jsonTypePair)
+		return p.listTy, p.mapTy
+	}
+	jsonTy := semtypes.CreateJSON(ctx)
+	listLd := semtypes.NewListDefinition()
+	mapMd := semtypes.NewMappingDefinition()
+	listTy := listLd.Define(env, nil, semtypes.ListRest(jsonTy))
+	mapTy := mapMd.Define(env, nil, jsonTy)
+	p := jsonTypePair{listTy, mapTy}
+	jsonTypesByEnv.Store(key, p)
+	stdruntime.AddCleanup(env, cleanupJSONTypes, key)
+	return listTy, mapTy
+}
+
+func cleanupJSONTypes(key any) {
+	jsonTypesByEnv.Delete(key)
+}

--- a/lib/stdlibs/ballerina/mime/0.0.1/go1.26/native/mime.go
+++ b/lib/stdlibs/ballerina/mime/0.0.1/go1.26/native/mime.go
@@ -1,0 +1,484 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package native
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"mime"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/ballerina-nutcracker/ballerina/runtime"
+	"github.com/ballerina-nutcracker/ballerina/runtime/extern"
+	"github.com/ballerina-nutcracker/ballerina/semtypes"
+	"github.com/ballerina-nutcracker/ballerina/values"
+)
+
+const (
+	orgName    = "ballerina"
+	moduleName = "mime"
+)
+
+// EntityBodyKind identifies the type of body content stored on an Entity.
+// Exported so sibling stdlibs (e.g. http) that construct or read mime:Entity
+// values natively can do so without duplicating this representation.
+type EntityBodyKind int
+
+const (
+	BodyNone EntityBodyKind = iota
+	BodyText
+	BodyJSON
+	BodyBytes
+	BodyParts
+)
+
+// EntityBody holds the body payload attached to a Ballerina Entity object.
+type EntityBody struct {
+	Kind  EntityBodyKind
+	Text  string
+	JSON  values.BalValue
+	Bytes []byte
+	Parts []*values.Object
+}
+
+const entityBodyField = "$mimeBody"
+
+// GetEntityBody returns the native body state attached to a mime:Entity object, or nil if unset.
+func GetEntityBody(obj *values.Object) *EntityBody {
+	v, ok := obj.Get(entityBodyField)
+	if !ok {
+		return nil
+	}
+	b, _ := v.(*EntityBody)
+	return b
+}
+
+// SetEntityBody attaches native body state to a mime:Entity object.
+func SetEntityBody(obj *values.Object, body *EntityBody) {
+	obj.Put(entityBodyField, body)
+}
+
+func mimeError(typeName, msg string) values.BalValue {
+	return values.NewError(semtypes.Error, msg, nil, typeName, nil)
+}
+
+// BytesForBody returns the byte representation of an Entity's body regardless of which
+// setter populated it, matching jBallerina's model where every accessor lazily converts
+// from the entity's underlying data source rather than requiring an exact kind match.
+// Exported so sibling stdlibs (e.g. http, serializing multipart parts) can reuse it.
+func BytesForBody(body *EntityBody) ([]byte, error) {
+	if body == nil {
+		//nolint:staticcheck // error text mirrors jBallerina's runtime message verbatim
+		return nil, fmt.Errorf("Entity body is not a byte[] value")
+	}
+	switch body.Kind {
+	case BodyBytes:
+		return body.Bytes, nil
+	case BodyText:
+		return []byte(body.Text), nil
+	case BodyJSON:
+		return values.ToJSONByteArray(body.JSON)
+	default:
+		//nolint:staticcheck // error text mirrors jBallerina's runtime message verbatim
+		return nil, fmt.Errorf("Entity body is not a byte[] value")
+	}
+}
+
+// stringForBody returns the string representation of an Entity's body regardless of
+// which setter populated it, mirroring BytesForBody for the text accessor.
+func stringForBody(body *EntityBody) (string, error) {
+	if body == nil {
+		//nolint:staticcheck // error text mirrors jBallerina's runtime message verbatim
+		return "", fmt.Errorf("Entity body is not a text value")
+	}
+	switch body.Kind {
+	case BodyText:
+		return body.Text, nil
+	case BodyBytes:
+		return string(body.Bytes), nil
+	case BodyJSON:
+		b, err := values.ToJSONByteArray(body.JSON)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	default:
+		//nolint:staticcheck // error text mirrors jBallerina's runtime message verbatim
+		return "", fmt.Errorf("Entity body is not a text value")
+	}
+}
+
+// mimeEncode produces MIME-compatible base64 (76-char line length, \r\n separators),
+// matching Java's Base64.getMimeEncoder() default behaviour.
+func mimeEncode(data []byte) string {
+	const lineLen = 76
+	encoded := base64.StdEncoding.EncodeToString(data)
+	if len(encoded) <= lineLen {
+		return encoded
+	}
+	var sb strings.Builder
+	for i := 0; i < len(encoded); i++ {
+		if i > 0 && i%lineLen == 0 {
+			sb.WriteString("\r\n")
+		}
+		sb.WriteByte(encoded[i])
+	}
+	return sb.String()
+}
+
+// mimeDecode strips MIME whitespace (\r, \n, space, tab) before decoding,
+// matching Java's Base64.getMimeDecoder() leniency.
+func mimeDecode(s string) ([]byte, error) {
+	cleaned := strings.Map(func(r rune) rune {
+		if r == '\r' || r == '\n' || r == ' ' || r == '\t' {
+			return -1
+		}
+		return r
+	}, s)
+	return base64.StdEncoding.DecodeString(cleaned)
+}
+
+// listToBytes converts a Ballerina byte[] to a Go []byte.
+func listToBytes(list *values.List) []byte {
+	b := make([]byte, list.Len())
+	for i := range list.Len() {
+		b[i] = byte(list.Get(i).(int64))
+	}
+	return b
+}
+
+// bytesToList converts a []byte to a Ballerina byte[] list value.
+func bytesToList(ctx *extern.Context, data []byte) *values.List {
+	items := make([]values.BalValue, len(data))
+	for i, b := range data {
+		items[i] = int64(b)
+	}
+	bld := semtypes.NewListDefinition()
+	ty := bld.Define(ctx.Env.TypeEnv, nil, semtypes.ListRest(semtypes.Byte))
+	return values.NewList(ty, semtypes.ToListAtomicType(ctx.TypeEnv(), ty), false, nil, 0, items)
+}
+
+// buildParamsMap creates a Ballerina map<string> from a Go string map.
+func buildParamsMap(tc semtypes.Context, env semtypes.Env, params map[string]string) *values.Map {
+	mmd := semtypes.NewMappingDefinition()
+	ty := mmd.Define(env, nil, semtypes.String)
+	entries := make([]values.MapEntry, 0, len(params))
+	for k, v := range params {
+		entries = append(entries, values.MapEntry{Key: k, Value: v})
+	}
+	return values.NewMap(ty, semtypes.ToMappingAtomicType(tc, ty), false, entries)
+}
+
+// formatParam quotes a parameter value if it contains chars that require quoting.
+func formatParam(val string) string {
+	for _, c := range val {
+		if c == ' ' || c == ',' || c == ';' || c == '"' || c == '\\' || c == '(' || c == ')' || c == '<' || c == '>' || c == '@' || c == ':' || c == '/' || c == '[' || c == ']' || c == '?' || c == '=' {
+			escaped := strings.ReplaceAll(val, `\`, `\\`)
+			escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+			return `"` + escaped + `"`
+		}
+	}
+	return val
+}
+
+func initMimeModule(rt *runtime.Runtime) {
+	env := rt.GetTypeEnv()
+	jsonListType, jsonMapType := JSONListAndMapTypes(semtypes.ContextFrom(env))
+
+	var (
+		once          sync.Once
+		byteArrayType semtypes.SemType
+	)
+	ensureTypes := func(ctx *extern.Context) {
+		once.Do(func() {
+			bld := semtypes.NewListDefinition()
+			byteArrayType = bld.Define(ctx.Env.TypeEnv, nil, semtypes.ListRest(semtypes.Byte))
+		})
+	}
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externSetJson",
+		func(_ *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("first argument must be an Entity object")
+			}
+			SetEntityBody(obj, &EntityBody{Kind: BodyJSON, JSON: args[1]})
+			return nil, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externGetJson",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("first argument must be an Entity object")
+			}
+			body := GetEntityBody(obj)
+			if body != nil && body.Kind == BodyJSON {
+				return body.JSON, nil
+			}
+			text, err := stringForBody(body)
+			if err != nil {
+				return mimeError("ParserError", "Entity body is not a JSON value"), nil
+			}
+			var v interface{}
+			dec := json.NewDecoder(strings.NewReader(text))
+			dec.UseNumber()
+			if err := dec.Decode(&v); err != nil {
+				return mimeError("ParserError", "Error occurred while retrieving the json payload from the entity: "+err.Error()), nil
+			}
+			return values.GoToBalValue(ctx.TypeCtx(), v, jsonListType, jsonMapType), nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externSetText",
+		func(_ *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("first argument must be an Entity object")
+			}
+			text, _ := args[1].(string)
+			SetEntityBody(obj, &EntityBody{Kind: BodyText, Text: text})
+			return nil, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externGetText",
+		func(_ *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("first argument must be an Entity object")
+			}
+			body := GetEntityBody(obj)
+			text, err := stringForBody(body)
+			if err != nil {
+				return mimeError("ParserError", "Entity body is not a text value"), nil
+			}
+			return text, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externSetByteArray",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("first argument must be an Entity object")
+			}
+			list, ok := args[1].(*values.List)
+			if !ok {
+				return nil, fmt.Errorf("second argument must be a byte array")
+			}
+			SetEntityBody(obj, &EntityBody{Kind: BodyBytes, Bytes: listToBytes(list)})
+			return nil, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externGetByteArray",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			ensureTypes(ctx)
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("first argument must be an Entity object")
+			}
+			body := GetEntityBody(obj)
+			data, err := BytesForBody(body)
+			if err != nil {
+				return mimeError("ParserError", err.Error()), nil
+			}
+			items := make([]values.BalValue, len(data))
+			for i, b := range data {
+				items[i] = int64(b)
+			}
+			return values.NewList(byteArrayType, semtypes.ToListAtomicType(ctx.TypeEnv(), byteArrayType), false, nil, 0, items), nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externIntToString",
+		func(_ *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			n, ok := args[0].(int64)
+			if !ok {
+				return nil, fmt.Errorf("argument must be an int")
+			}
+			return strconv.FormatInt(n, 10), nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externParseInt",
+		func(_ *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			s, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("argument must be a string")
+			}
+			n, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return values.NewErrorWithMessage("'int' from string: invalid number format: " + s), nil
+			}
+			return n, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "getMediaType",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			contentType, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("argument must be a string")
+			}
+			mediatype, params, err := mime.ParseMediaType(contentType)
+			if err != nil {
+				return mimeError("InvalidContentTypeError", "Invalid content-type: "+contentType), nil
+			}
+			primaryType := ""
+			subType := ""
+			suffix := ""
+			parts := strings.SplitN(mediatype, "/", 2)
+			if len(parts) >= 1 {
+				primaryType = parts[0]
+			}
+			if len(parts) == 2 {
+				subParts := strings.SplitN(parts[1], "+", 2)
+				subType = subParts[0]
+				if len(subParts) == 2 {
+					suffix = subParts[1]
+				}
+			}
+			paramsMap := buildParamsMap(ctx.TypeCtx(), ctx.Env.TypeEnv, params)
+			return values.NewObject(
+				semtypes.Object,
+				map[string]values.BalValue{
+					"primaryType": primaryType,
+					"subType":     subType,
+					"suffix":      suffix,
+					"parameters":  paramsMap,
+				},
+				map[string]string{
+					"getBaseType": "ballerina/mime:MediaType.getBaseType",
+					"toString":    "ballerina/mime:MediaType.toString",
+				},
+				nil,
+				nil,
+			), nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "getContentDispositionObject",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			contentDisposition, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("argument must be a string")
+			}
+			disposition, params, _ := mime.ParseMediaType(contentDisposition)
+			fileName := params["filename"]
+			name := params["name"]
+			delete(params, "filename")
+			delete(params, "name")
+			paramsMap := buildParamsMap(ctx.TypeCtx(), ctx.Env.TypeEnv, params)
+			return values.NewObject(
+				semtypes.Object,
+				map[string]values.BalValue{
+					"fileName":    fileName,
+					"disposition": disposition,
+					"name":        name,
+					"parameters":  paramsMap,
+				},
+				map[string]string{
+					"toString": "ballerina/mime:ContentDisposition.toString",
+				},
+				nil,
+				nil,
+			), nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "convertContentDispositionToString",
+		func(_ *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("argument must be a ContentDisposition object")
+			}
+			dispVal, _ := obj.Get("disposition")
+			disposition, _ := dispVal.(string)
+			if disposition == "" {
+				return "", nil
+			}
+			result := disposition
+			nameVal, _ := obj.Get("name")
+			if name, ok := nameVal.(string); ok && name != "" {
+				result += "; name=" + formatParam(name)
+			}
+			fileNameVal, _ := obj.Get("fileName")
+			if fileName, ok := fileNameVal.(string); ok && fileName != "" {
+				result += "; filename=" + formatParam(fileName)
+			}
+			paramsVal, _ := obj.Get("parameters")
+			if paramsMap, ok := paramsVal.(*values.Map); ok {
+				for _, k := range paramsMap.Keys() {
+					v, _ := paramsMap.Get(k)
+					vStr, _ := v.(string)
+					result += "; " + k + "=" + formatParam(vStr)
+				}
+			}
+			return result, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "base64Encode",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			charset := "utf-8"
+			if len(args) > 1 {
+				if cs, ok := args[1].(string); ok {
+					charset = cs
+				}
+			}
+			switch v := args[0].(type) {
+			case string:
+				_ = charset
+				encoded := mimeEncode([]byte(v))
+				return encoded, nil
+			case *values.List:
+				data := listToBytes(v)
+				encodedStr := mimeEncode(data)
+				return bytesToList(ctx, []byte(encodedStr)), nil
+			default:
+				return mimeError("EncodeError", "unsupported content type for base64 encoding"), nil
+			}
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "base64Decode",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			charset := "utf-8"
+			if len(args) > 1 {
+				if cs, ok := args[1].(string); ok {
+					charset = cs
+				}
+			}
+			switch v := args[0].(type) {
+			case string:
+				_ = charset
+				decoded, err := mimeDecode(v)
+				if err != nil {
+					return mimeError("DecodeError", "base64 decoding failed: "+err.Error()), nil
+				}
+				return string(decoded), nil
+			case *values.List:
+				data := listToBytes(v)
+				decoded, err := mimeDecode(string(data))
+				if err != nil {
+					return mimeError("DecodeError", "base64 decoding failed: "+err.Error()), nil
+				}
+				return bytesToList(ctx, decoded), nil
+			default:
+				return mimeError("DecodeError", "unsupported content type for base64 decoding"), nil
+			}
+		})
+}
+
+func init() {
+	runtime.RegisterModuleInitializer(initMimeModule)
+}

--- a/lib/stdlibs/ballerina/mime/0.0.1/go1.26/native/multipart.go
+++ b/lib/stdlibs/ballerina/mime/0.0.1/go1.26/native/multipart.go
@@ -1,0 +1,323 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package native
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"strings"
+
+	"github.com/ballerina-nutcracker/ballerina/runtime"
+	"github.com/ballerina-nutcracker/ballerina/runtime/extern"
+	"github.com/ballerina-nutcracker/ballerina/semtypes"
+	"github.com/ballerina-nutcracker/ballerina/values"
+)
+
+// entityMethodKeys lists every public Entity method, keyed by name, pointing at its
+// qualified BIR lookup key. Shared by every native path that constructs a fresh
+// Entity value (this file's multipart decoder, and sibling stdlibs via NewEntity)
+// so a natively-built Entity dispatches identically to one built via `new Entity()`.
+func entityMethodKeys() map[string]string {
+	names := []string{
+		"setContentType", "getContentType", "setContentId", "getContentId",
+		"setContentLength", "getContentLength", "setContentDisposition", "getContentDisposition",
+		"setBody", "setJson", "getJson", "setText", "getText", "setByteArray", "getByteArray",
+		"getHeader", "getHeaders", "getHeaderNames", "addHeader", "setHeader",
+		"removeHeader", "removeAllHeaders", "hasHeader", "setBodyParts", "getBodyParts",
+	}
+	keys := make(map[string]string, len(names))
+	for _, n := range names {
+		keys[n] = "ballerina/mime:Entity." + n
+	}
+	return keys
+}
+
+func stringListSemType(ctx *extern.Context) semtypes.SemType {
+	bld := semtypes.NewListDefinition()
+	return bld.Define(ctx.Env.TypeEnv, nil, semtypes.ListRest(semtypes.String))
+}
+
+func stringListMapSemType(ctx *extern.Context, elemType semtypes.SemType) semtypes.SemType {
+	mmd := semtypes.NewMappingDefinition()
+	return mmd.Define(ctx.Env.TypeEnv, nil, elemType)
+}
+
+// NewEntity constructs a fresh mime:Entity-shaped native object with the same
+// zero-state as `.bal`-level `new Entity()`. Exported so sibling stdlibs (e.g.
+// http) that need to construct Entity values natively — e.g. multipart body
+// parts decoded from a raw request/response body — can reuse this shape
+// instead of duplicating the method-key table.
+func NewEntity(ctx *extern.Context) *values.Object {
+	stringListType := stringListSemType(ctx)
+	headerMapType := stringListMapSemType(ctx, stringListType)
+	emptyHeaderMap := values.NewMap(headerMapType, semtypes.ToMappingAtomicType(ctx.TypeCtx(), headerMapType), false, nil)
+	emptyHeaderNames := values.NewList(stringListType, semtypes.ToListAtomicType(ctx.TypeEnv(), stringListType), false, nil, 0, nil)
+	return values.NewObject(
+		semtypes.Object,
+		map[string]values.BalValue{
+			"cType":        nil,
+			"cId":          "",
+			"cLength":      int64(0),
+			"cDisposition": nil,
+			"headerMap":    emptyHeaderMap,
+			"headerNames":  emptyHeaderNames,
+		},
+		entityMethodKeys(),
+		nil,
+		nil,
+	)
+}
+
+// entityHeaderValue reads the first value of a header from an Entity's own headerMap
+// field (the private `.bal`-declared state `Entity.setHeader`/`getHeader` operate on).
+func entityHeaderValue(obj *values.Object, headerName string) (string, bool) {
+	hmVal, ok := obj.Get("headerMap")
+	if !ok {
+		return "", false
+	}
+	hm, ok := hmVal.(*values.Map)
+	if !ok {
+		return "", false
+	}
+	v, ok := hm.Get(strings.ToLower(headerName))
+	if !ok {
+		return "", false
+	}
+	list, ok := v.(*values.List)
+	if !ok || list.Len() == 0 {
+		return "", false
+	}
+	s, ok := list.Get(0).(string)
+	return s, ok
+}
+
+// setEntityHeaders replaces an Entity's headerMap/headerNames fields from a parsed
+// MIME header set, preserving multi-value headers and original header-name casing.
+func setEntityHeaders(ctx *extern.Context, obj *values.Object, header textproto.MIMEHeader) {
+	stringListType := stringListSemType(ctx)
+	headerMapType := stringListMapSemType(ctx, stringListType)
+	entries := make([]values.MapEntry, 0, len(header))
+	names := make([]values.BalValue, 0, len(header))
+	for key, vals := range header {
+		items := make([]values.BalValue, len(vals))
+		for i, v := range vals {
+			items[i] = v
+		}
+		valueList := values.NewList(stringListType, semtypes.ToListAtomicType(ctx.TypeEnv(), stringListType), false, nil, 0, items)
+		entries = append(entries, values.MapEntry{Key: strings.ToLower(key), Value: valueList})
+		names = append(names, key)
+	}
+	obj.Put("headerMap", values.NewMap(headerMapType, semtypes.ToMappingAtomicType(ctx.TypeCtx(), headerMapType), false, entries))
+	obj.Put("headerNames", values.NewList(stringListType, semtypes.ToListAtomicType(ctx.TypeEnv(), stringListType), false, nil, 0, names))
+}
+
+// EntityListFromParts builds a Ballerina Entity[] list value from native part objects.
+func EntityListFromParts(ctx *extern.Context, parts []*values.Object) *values.List {
+	items := make([]values.BalValue, len(parts))
+	for i, p := range parts {
+		items[i] = p
+	}
+	bld := semtypes.NewListDefinition()
+	ty := bld.Define(ctx.Env.TypeEnv, nil, semtypes.ListRest(semtypes.Object))
+	return values.NewList(ty, semtypes.ToListAtomicType(ctx.TypeEnv(), ty), false, nil, 0, items)
+}
+
+// MultipartBoundary parses a Content-Type header value and reports whether it names a
+// composite (multipart/* or message/*) media type, along with its boundary parameter.
+func MultipartBoundary(contentType string) (baseType, boundary string, isComposite bool) {
+	if contentType == "" {
+		return "", "", false
+	}
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return contentType, "", false
+	}
+	primaryType := strings.ToLower(strings.SplitN(mediaType, "/", 2)[0])
+	if primaryType != "multipart" && primaryType != "message" {
+		return mediaType, "", false
+	}
+	return mediaType, params["boundary"], true
+}
+
+// DecodeMultipart splits a raw multipart body into per-part Entity values, defaulting
+// an absent per-part Content-Type to "text/plain" (matching jBallerina's underlying
+// MIME library default) and copying every part header verbatim.
+func DecodeMultipart(ctx *extern.Context, data []byte, boundary string) ([]*values.Object, error) {
+	if boundary == "" {
+		return nil, fmt.Errorf("no boundary parameter found in Content-Type")
+	}
+	reader := multipart.NewReader(bytes.NewReader(data), boundary)
+	var parts []*values.Object
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if part.Header.Get("Content-Type") == "" {
+			part.Header.Set("Content-Type", "text/plain")
+		}
+		bodyBytes, err := io.ReadAll(part)
+		if err != nil {
+			return nil, err
+		}
+		partObj := NewEntity(ctx)
+		setEntityHeaders(ctx, partObj, part.Header)
+		SetEntityBody(partObj, &EntityBody{Kind: BodyBytes, Bytes: bodyBytes})
+		parts = append(parts, partObj)
+	}
+	return parts, nil
+}
+
+// entityHeaderMap reads an Entity's headerMap/headerNames fields back into a Go header map,
+// preserving original header-name casing (the reverse of setEntityHeaders).
+func entityHeaderMap(obj *values.Object) map[string][]string {
+	result := make(map[string][]string)
+	namesVal, ok := obj.Get("headerNames")
+	if !ok {
+		return result
+	}
+	names, ok := namesVal.(*values.List)
+	if !ok {
+		return result
+	}
+	hmVal, ok := obj.Get("headerMap")
+	if !ok {
+		return result
+	}
+	hm, ok := hmVal.(*values.Map)
+	if !ok {
+		return result
+	}
+	for i := range names.Len() {
+		name, _ := names.Get(i).(string)
+		v, ok := hm.Get(strings.ToLower(name))
+		if !ok {
+			continue
+		}
+		list, ok := v.(*values.List)
+		if !ok {
+			continue
+		}
+		vals := make([]string, list.Len())
+		for j := range list.Len() {
+			s, _ := list.Get(j).(string)
+			vals[j] = s
+		}
+		result[name] = vals
+	}
+	return result
+}
+
+// EncodeMultipart serializes body parts into multipart-encoded wire bytes. If boundary is
+// empty, one is generated; the boundary actually used is always returned so the caller can
+// record the final Content-Type. Exported for sibling stdlibs (http) that need to serialize a
+// multipart body for wire transmission — mime's own Entity.getByteArray() intentionally does
+// not do this, matching jBallerina, where serializing a multipart entity to bytes is not
+// exposed through mime's public API either (jBallerina's HTTP transport layer does it
+// internally instead).
+func EncodeMultipart(parts []*values.Object, boundary string) (data []byte, usedBoundary string, err error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	if boundary != "" {
+		if err := w.SetBoundary(boundary); err != nil {
+			return nil, "", err
+		}
+	}
+	for _, part := range parts {
+		header := textproto.MIMEHeader(entityHeaderMap(part))
+		pw, err := w.CreatePart(header)
+		if err != nil {
+			return nil, "", err
+		}
+		partData, err := BytesForBody(GetEntityBody(part))
+		if err != nil {
+			return nil, "", err
+		}
+		if _, err := pw.Write(partData); err != nil {
+			return nil, "", err
+		}
+	}
+	usedBoundary = w.Boundary()
+	if err := w.Close(); err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), usedBoundary, nil
+}
+
+func initMultipartModule(rt *runtime.Runtime) {
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externSetBodyParts",
+		func(_ *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("first argument must be an Entity object")
+			}
+			list, ok := args[1].(*values.List)
+			if !ok {
+				return nil, fmt.Errorf("second argument must be an Entity array")
+			}
+			parts := make([]*values.Object, list.Len())
+			for i := range list.Len() {
+				part, ok := list.Get(i).(*values.Object)
+				if !ok {
+					return nil, fmt.Errorf("body part at index %d is not an Entity object", i)
+				}
+				parts[i] = part
+			}
+			SetEntityBody(obj, &EntityBody{Kind: BodyParts, Parts: parts})
+			return nil, nil
+		})
+
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externGetBodyParts",
+		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			obj, ok := args[0].(*values.Object)
+			if !ok {
+				return nil, fmt.Errorf("first argument must be an Entity object")
+			}
+			body := GetEntityBody(obj)
+			if body != nil && body.Kind == BodyParts {
+				return EntityListFromParts(ctx, body.Parts), nil
+			}
+			contentType, _ := entityHeaderValue(obj, "content-type")
+			baseType, boundary, isComposite := MultipartBoundary(contentType)
+			if !isComposite {
+				return mimeError("ParserError", "Entity body is not a type of composite media type. "+
+					"Received content-type : "+baseType), nil
+			}
+			if body == nil || body.Kind != BodyBytes {
+				return mimeError("ParserError", "Entity body is not a type of composite media type. "+
+					"Received content-type : "+baseType), nil
+			}
+			parts, err := DecodeMultipart(ctx, body.Bytes, boundary)
+			if err != nil {
+				return mimeError("ParserError", "Error occurred while extracting body parts from entity: "+err.Error()), nil
+			}
+			SetEntityBody(obj, &EntityBody{Kind: BodyParts, Parts: parts})
+			return EntityListFromParts(ctx, parts), nil
+		})
+}
+
+func init() {
+	runtime.RegisterModuleInitializer(initMultipartModule)
+}

--- a/semtypes/bdd_test.go
+++ b/semtypes/bdd_test.go
@@ -24,8 +24,8 @@ import (
 // Ported from SemTypeBddTest.java:bddTest()
 func TestBddDiff(t *testing.T) {
 	// Create two BDD atoms from different rec atoms
-	b1 := bddAtom(new(createRecAtom(1)))
-	b2 := bddAtom(new(createRecAtom(2)))
+	b1 := bddAtom(new(createRecAtom(1, recAtomKindList)))
+	b2 := bddAtom(new(createRecAtom(2, recAtomKindList)))
 
 	// Intersect them
 	b1and2 := bddIntersect(b1, b2)

--- a/semtypes/bdd_types.go
+++ b/semtypes/bdd_types.go
@@ -392,7 +392,7 @@ func (dc *bddDeserializationContext) deserializeBddFromDnf(
 
 func (dc *bddDeserializationContext) deserializeListAtom(atomIndex int32) atom {
 	if atomIndex == 0 {
-		ro := createRecAtom(bddRecAtomReadonly)
+		ro := createRecAtom(bddRecAtomReadonly, recAtomKindList)
 		return &ro
 	}
 	if dc.listAtoms[atomIndex] != nil {
@@ -428,7 +428,7 @@ func (dc *bddDeserializationContext) deserializeMappingAtom(atomIndex int32) ato
 		return &atom
 	}
 	if atomIndex == 0 {
-		ro := createRecAtom(bddRecAtomReadonly)
+		ro := createRecAtom(bddRecAtomReadonly, recAtomKindMapping)
 		return &ro
 	}
 	if dc.mappingAtoms[atomIndex] != nil {

--- a/semtypes/canonical_key.go
+++ b/semtypes/canonical_key.go
@@ -18,10 +18,25 @@ package semtypes
 
 import "sync"
 
+// recAtomKind discriminates which independent, 0-based index space a
+// recursive atom's index was drawn from (list/mapping/function/xml/distinct
+// each keep their own counter on env, so the same numeric index can be
+// assigned to atoms of different kinds).
+type recAtomKind uint8
+
+const (
+	recAtomKindList recAtomKind = iota
+	recAtomKindMapping
+	recAtomKindFunction
+	recAtomKindXML
+	recAtomKindDistinct
+)
+
 type atomKey struct {
 	index int
 	gen   uint64
 	rec   bool
+	kind  recAtomKind
 }
 
 type bddKey int
@@ -56,8 +71,8 @@ func typeAtomKey(index int, gen uint64) atomKey {
 	return atomKey{index: index, gen: gen}
 }
 
-func recAtomKey(index int) atomKey {
-	return atomKey{index: index, rec: true}
+func recAtomKey(index int, kind recAtomKind) atomKey {
+	return atomKey{index: index, rec: true, kind: kind}
 }
 
 func internBddNodeKey(key bddNodeKey) bddKey {

--- a/semtypes/env.go
+++ b/semtypes/env.go
@@ -140,7 +140,7 @@ func (e *env) recFunctionAtom() recAtom {
 	defer e.recFunctionAtomsMutex.Unlock()
 	result := len(e.recFunctionAtoms)
 	e.recFunctionAtoms = append(e.recFunctionAtoms, nil)
-	return createRecAtom(result)
+	return createRecAtom(result, recAtomKindFunction)
 }
 
 func (e *env) setRecFunctionAtomType(rec recAtom, atomicType *functionAtomicType) {
@@ -256,7 +256,7 @@ func (e *env) recListAtom() recAtom {
 	defer e.recListAtomsMutex.Unlock()
 	result := len(e.recListAtoms)
 	e.recListAtoms = append(e.recListAtoms, nil)
-	return createRecAtom(result)
+	return createRecAtom(result, recAtomKindList)
 }
 
 func (e *env) recMappingAtom() recAtom {
@@ -265,7 +265,7 @@ func (e *env) recMappingAtom() recAtom {
 	defer e.recMappingAtomsMutex.Unlock()
 	result := len(e.recMappingAtoms)
 	e.recMappingAtoms = append(e.recMappingAtoms, nil)
-	return createRecAtom(result)
+	return createRecAtom(result, recAtomKindMapping)
 }
 
 func (e *env) setRecListAtomType(rec recAtom, atomicType *ListAtomicType) {

--- a/semtypes/predefined_type.go
+++ b/semtypes/predefined_type.go
@@ -86,7 +86,7 @@ var (
 	ReadonlyXMLProcessingInstruction  = XMLSingleton(xmlPrimitiveProcessingInstructionReadonly)
 	XMLProcessingInstruction          = XMLSingleton((xmlPrimitiveProcessingInstructionReadonly | xmlPrimitivePiRw))
 	bddRecAtomReadonly                = 0
-	bddSubtypeRo                      = bddAtom(new(createRecAtom(bddRecAtomReadonly)))
+	bddSubtypeRo                      = bddAtom(new(createRecAtom(bddRecAtomReadonly, recAtomKindList)))
 	mappingRo                         = getBasicSubtype(btMapping, bddSubtypeRo)
 	cellAtomicVal                     = predefTypeEnv.cellAtomicVal()
 	atomCellVal                       = predefTypeEnv.atomCellVal()
@@ -125,7 +125,7 @@ var (
 	atomMappingObject                 = predefTypeEnv.atomMappingObject()
 	mappingSubtypeObject              = bddAtom(atomMappingObject)
 	bddRecAtomObjectReadonly          = 1
-	objectRoRecAtom                   = new(createRecAtom(bddRecAtomObjectReadonly))
+	objectRoRecAtom                   = new(createRecAtom(bddRecAtomObjectReadonly, recAtomKindMapping))
 	mappingSubtypeObjectRo            = bddAtom(objectRoRecAtom)
 	mappingArrayRo                    = getBasicSubtype(btList, listSubtypeMappingRo)
 	atomCellMappingArrayRo            = predefTypeEnv.atomCellMappingArrayRO()

--- a/semtypes/predefined_type_env.go
+++ b/semtypes/predefined_type_env.go
@@ -667,9 +667,9 @@ func (p *predefinedTypeEnv) ReservedRecAtomCount() int {
 }
 
 // GetPredefinedRecAtom returns a predefined recAtom for the given index
-func (p *predefinedTypeEnv) GetPredefinedRecAtom(index int) common.Optional[*recAtom] {
+func (p *predefinedTypeEnv) GetPredefinedRecAtom(index int, kind recAtomKind) common.Optional[*recAtom] {
 	if p.IsPredefinedRecAtom(index) {
-		recAtom := createRecAtom(index)
+		recAtom := createRecAtom(index, kind)
 		return common.OptionalOf(&recAtom)
 	}
 	return common.OptionalEmpty[*recAtom]()

--- a/semtypes/rec_atom.go
+++ b/semtypes/rec_atom.go
@@ -19,32 +19,39 @@ package semtypes
 import "fmt"
 
 type recAtom struct {
-	idx int
+	idx  int
+	kind recAtomKind
 }
 
-var zeroRecAtom = newRecAtomFromInt(bddRecAtomReadonly)
+// zeroRecAtom is the shared "fully readonly" sentinel recursive atom. It is
+// used interchangeably as the readonly placeholder for both list and mapping
+// BDDs (see bddSubtypeRo), so its kind is not meaningful; the to-string cycle
+// detector always special-cases index 0 before consulting kind or the
+// visited set.
+var zeroRecAtom = newRecAtomFromInt(bddRecAtomReadonly, recAtomKindList)
 var _ atom = &recAtom{}
 
-func newRecAtomFromInt(index int) recAtom {
+func newRecAtomFromInt(index int, kind recAtomKind) recAtom {
 	this := recAtom{}
 
 	this.idx = index
+	this.kind = kind
 	return this
 }
 
-func createRecAtom(index int) recAtom {
+func createRecAtom(index int, kind recAtomKind) recAtom {
 	if index == bddRecAtomReadonly {
 		return zeroRecAtom
 	}
-	return newRecAtomFromInt(index)
+	return newRecAtomFromInt(index, kind)
 }
 
 func createXMLRecAtom(index int) recAtom {
-	return newRecAtomFromInt(index)
+	return newRecAtomFromInt(index, recAtomKindXML)
 }
 
 func createDistinctRecAtom(index int) recAtom {
-	return newRecAtomFromInt(index)
+	return newRecAtomFromInt(index, recAtomKindDistinct)
 }
 
 func isDistinctRecAtom(atom atom) bool {
@@ -57,7 +64,7 @@ func (r *recAtom) index() int {
 }
 
 func (r *recAtom) canonicalKey() atomKey {
-	return recAtomKey(r.idx)
+	return recAtomKey(r.idx, r.kind)
 }
 
 func (r *recAtom) String() string {

--- a/test_util/testphases/phases.go
+++ b/test_util/testphases/phases.go
@@ -111,6 +111,7 @@ var builtinStdlibs = []stdlibEntry{
 	flatEntry("http", "0.0.1", "go1.26"),
 	flatEntry("log", "0.0.1", "go1.26"),
 	flatEntry("math.vector", "0.0.1", "go1.26"),
+	flatEntry("mime", "0.0.1", "go1.26"),
 	flatEntry("os", "0.0.1", "go1.26"),
 	flatEntry("random", "0.0.1", "go1.26"),
 	flatEntry("time", "0.0.1", "go1.26"),


### PR DESCRIPTION
Depends on: https://github.com/ballerina-nutcracker/ballerina/pull/712

## Summary

Extends `ballerina/http` with a generic `setPayload`, form-urlencoded parameter decoding, and flat multipart request/response bodies built on `ballerina/mime`'s `Entity[]` support.

- `Request`/`Response.setPayload(json|byte[]|mime:Entity[] payload, string? contentType = ())` dispatches by the runtime type of `payload` to `setTextPayload`/`setBinaryPayload`/`setJsonPayload`/`setBodyParts`
- `Request.getFormParams() returns map<string>|error` decodes an `application/x-www-form-urlencoded` body into a parameter map
- `Request`/`Response.setBodyParts(mime:Entity[] bodyParts, string? contentType = ())` and `getBodyParts() returns mime:Entity[]|error` set/extract multipart body parts, flat (single-level) only, matching `mime`'s own limitation
- `RequestMessage` widens from `json|Request` to `json|Request|mime:Entity[]`, so the client's `post`/`put`/`patch`/`delete`/`execute` accept a multipart body directly
- Inbound `Request`/`Response` objects (built by the server/client transport) get `setBodyParts`/`getBodyParts` wired into their method-key tables, so a natively-built object supports the same method set as one constructed via `new`

## Example

```ballerina
import ballerina/http;
import ballerina/mime;
import ballerina/io;

service /multiparts on new http:Listener(9090) {
    resource function post decode(http:Request req) returns http:Response|error {
        mime:Entity[] parts = check req.getBodyParts();
        string text = check parts[0].getText();

        http:Response resp = new;
        resp.setPayload({partCount: parts.length(), first: text});
        return resp;
    }
}

public function main() returns error? {
    http:Client c = check new ("http://localhost:9090");

    mime:Entity textPart = new;
    textPart.setText("hello world");

    http:Response r = check c->post("/multiparts/decode", [textPart]);
    io:println(check r.getJsonPayload()); // {"partCount":1,"first":"hello world"}
}
```

`getFormParams` on a form-encoded request body:

```ballerina
resource function post submit(http:Request req) returns error? {
    map<string> params = check req.getFormParams();
    io:println(params["name"]);
}
```

## Notes

- Adds a `Dependencies.toml` dependency on `ballerina/mime` (for `Entity`) and `ballerina/url` (for percent-decoding form data); this PR does not stand alone and must land on top of the `stdlib-mime` port.
- `getFormParams` is implemented in `.bal`, byte-scanning the decoded form body rather than using `lang.string`'s `indexOf`/`split`, since this port's `lang.string` doesn't have them; ASCII `&`/`=` delimiters are safe to scan at the byte level over decoded UTF-8 because those byte values never occur inside a multi-byte codepoint.
- `setPayload`'s accepted union is narrower than jBallerina's: no `stream<byte[], io:Error?>` or `stream<SseEvent, error?>`, and no other `anydata` (`xml`, `table`) since there's no `toJson()`-style conversion available — promotes both `Request`/`Response`'s "Generic payload setter" and "Multipart and form-data payload" rows from **Not Yet Supported** to **Partially Supported** in the module README.
- Multipart support is flat/single-level only — a part whose own body is itself multipart is not recursively decoded, the same limitation as `ballerina/mime`.
- Public contract validated against jBallerina's `module-ballerina-http`: `setPayload`, `getFormParams`, `setBodyParts`, and `getBodyParts` all match the declared jBallerina signatures.
- See `lib/stdlibs/ballerina/http/0.0.1/go1.26/README.md` for the full support matrix.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] New `corpus/bal/library/subset3/` compiler-pipeline tests (`http-form-params-v.bal`, `http-form-params-error-v.bal`, `http-set-payload-v.bal`) and `subset4/` (`http-multipart-v.bal`, `http-multipart-error-v.bal`) with goldens across AST, CFG, desugar, and BIR stages
- [x] New `corpus/extern` integration tests: client-side multipart post against a local server, and inbound service `getBodyParts()`/`setBodyParts()` on both `Request` and `Response`
