### PR TITLE
fix: remove restrictions on xmlns declarations

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -181,6 +181,7 @@ type (
 	}
 	BLangXMLNS struct {
 		bLangNodeBase
+		symbol       model.SymbolRef
 		namespaceURI BLangExpression
 		prefix       *BLangIdentifier
 	}
@@ -360,6 +361,14 @@ func (b *bLangNodeBase) SetPosition(pos diagnostics.Location) {
 	b.pos = pos
 }
 
+func (n *BLangXMLNS) Symbol() model.SymbolRef {
+	return n.symbol
+}
+
+func (n *BLangXMLNS) SetSymbol(symbolRef model.SymbolRef) {
+	n.symbol = symbolRef
+}
+
 func (n *BLangClassDefinition) Symbol() model.SymbolRef {
 	return n.symbol
 }
@@ -442,6 +451,7 @@ func (n *BLangAnnotationAttachment) SetSymbol(symbolRef model.SymbolRef) {
 var (
 	_ BNodeWithSymbol   = &BLangAnnotation{}
 	_ BNodeWithSymbol   = &BLangAnnotationAttachment{}
+	_ BNodeWithSymbol   = &BLangXMLNS{}
 	_ NodeWithScope     = &BLangClassDefinition{}
 	_ FunctionBodyNode  = &BLangExternFunctionBody{}
 	_ FunctionSignature = &BLangFunction{}

--- a/birgen/corpus_bir_test.go
+++ b/birgen/corpus_bir_test.go
@@ -51,13 +51,6 @@ func getBIRDiff(expectedText, actualText string) string {
 	return dmp.DiffPrettyText(diffs)
 }
 
-// birGenerationSkipList is the BIR-stage *additional* skip list, on top of
-// the shared test_util.UnsupportedTests baseline.
-var birGenerationSkipList = []string{
-	// https://github.com/ballerina-nutcracker/ballerina/issues/417
-	"subset8/08-xml/namespace12-v.bal",
-}
-
 func TestBIRGeneration(t *testing.T) {
 	flag.Parse()
 
@@ -73,7 +66,7 @@ func TestBIRGeneration(t *testing.T) {
 
 // testBIRGeneration tests BIR generation for a single .bal file.
 func testBIRGeneration(t *testing.T, testPair test_util.TestCase) {
-	if test_util.IsUnsupported(testPair.InputPath) || test_util.MatchesSkip(testPair.InputPath, birGenerationSkipList) {
+	if test_util.IsUnsupported(testPair.InputPath) {
 		t.Skipf("Skipping BIR generation test for %s", testPair.InputPath)
 		return
 	}

--- a/context/context.go
+++ b/context/context.go
@@ -169,6 +169,10 @@ func (c *CompilerContext) SetSymbolType(symbol model.SymbolRef, ty semtypes.SemT
 	c.GetSymbol(symbol).SetType(ty)
 }
 
+func (c *CompilerContext) SetXMLNamespaceURI(symbol model.SymbolRef, uri string) error {
+	return model.SetXMLNamespaceURI(c.GetSymbol(symbol), uri)
+}
+
 func (c *CompilerContext) SetSymbolAnnotationValue(symbol model.SymbolRef, key string, value values.AnnotationValue) {
 	c.env.SetSymbolAnnotationValue(symbol, key, value)
 }

--- a/corpus/ast/subset8/08-xml/namespace12-v.txt
+++ b/corpus/ast/subset8/08-xml/namespace12-v.txt
@@ -1,19 +1,34 @@
 (compilation-unit
 (package-id $anon . 0.0.0)
   (import-package ballerina io (as io))
+  (const SCHEME (
+    (value-type string)) (
+    (literal https:)))
   (const URI (
     (value-type string)) (
-    (literal https:foo/bar)))
+    (binary-expr +
+      (binary-expr +
+        (simple-var-ref SCHEME)
+        (literal foo/))
+      (literal bar))))
   (xmlns
     (simple-var-ref URI) as bar)
+  (variable elem (type
+    (value-type xml)) (expr
+    (xml-element-literal bar:f
+      (xml-element-literal bar:x))))
   (function main () (
     (value-type null))
     (block-function-body
-      (var-def
-        (variable elem (type
-          (value-type xml)) (expr
-          (xml-element-literal bar:f
-            (xml-element-literal bar:x)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref elem)))))))
+          (simple-var-ref elem))))
+      (xmlns
+        (simple-var-ref URI) as local)
+      (var-def
+        (variable localElem (type
+          (value-type xml)) (expr
+          (xml-element-literal local:f))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref localElem)))))))

--- a/corpus/bal/subset8/08-xml/namespace16-e.bal
+++ b/corpus/bal/subset8/08-xml/namespace16-e.bal
@@ -14,19 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
+const string FIRST = SECOND; // @error
+const string SECOND = FIRST;
 
-const string SCHEME = "https:";
-const string URI = SCHEME + "foo/" + "bar";
-
-xmlns URI as bar;
-
-xml elem = xml `<bar:f><bar:x></bar:x></bar:f>`;
-
-public function main() {
-    io:println(elem); // @output <bar:f xmlns:bar="https:foo/bar"><bar:x/></bar:f>
-
-    xmlns URI as local;
-    xml localElem = xml `<local:f/>`;
-    io:println(localElem); // @output <local:f xmlns:local="https:foo/bar"/>
-}
+xmlns FIRST as cyclic;

--- a/corpus/bal/subset8/08-xml/namespace17-e.bal
+++ b/corpus/bal/subset8/08-xml/namespace17-e.bal
@@ -14,19 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
+const int URI = 1;
 
-const string SCHEME = "https:";
-const string URI = SCHEME + "foo/" + "bar";
-
-xmlns URI as bar;
-
-xml elem = xml `<bar:f><bar:x></bar:x></bar:f>`;
-
-public function main() {
-    io:println(elem); // @output <bar:f xmlns:bar="https:foo/bar"><bar:x/></bar:f>
-
-    xmlns URI as local;
-    xml localElem = xml `<local:f/>`;
-    io:println(localElem); // @output <local:f xmlns:local="https:foo/bar"/>
-}
+xmlns URI as invalid; // @error

--- a/corpus/bal/subset8/08-xml/namespace18-e.bal
+++ b/corpus/bal/subset8/08-xml/namespace18-e.bal
@@ -14,19 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
+string URI = "https:foo/bar";
 
-const string SCHEME = "https:";
-const string URI = SCHEME + "foo/" + "bar";
-
-xmlns URI as bar;
-
-xml elem = xml `<bar:f><bar:x></bar:x></bar:f>`;
-
-public function main() {
-    io:println(elem); // @output <bar:f xmlns:bar="https:foo/bar"><bar:x/></bar:f>
-
-    xmlns URI as local;
-    xml localElem = xml `<local:f/>`;
-    io:println(localElem); // @output <local:f xmlns:local="https:foo/bar"/>
-}
+xmlns URI as invalid; // @error

--- a/corpus/bir/subset8/08-xml/namespace12-v.txt
+++ b/corpus/bir/subset8/08-xml/namespace12-v.txt
@@ -1,0 +1,19 @@
+module $anon.. v 0.0.0;
+elem  xml;
+main() -> nil{
+  bb0 {
+    %1 = println(elem) -> bb1;
+  }
+  bb1 {
+    %2 = ConstantLoad local:f
+    %3 = ConstantLoad xmlns:local
+    %4 = ConstantLoad https:foo/bar
+    %5 = newMap {| string... |}{%3=%4}
+    %6 = newXMLElement(%2, (), (), %5)
+    localElem = %6;
+    %8 = println(localElem) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/cfg/subset8/08-xml/namespace12-v.txt
+++ b/corpus/cfg/subset8/08-xml/namespace12-v.txt
@@ -1,0 +1,16 @@
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref elem))))
+    (xmlns
+      (simple-var-ref URI) as local)
+    (var-def
+      (variable localElem (type
+        (value-type xml)) (expr
+        (xml-element-literal local:f))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref localElem))))
+  )
+)

--- a/corpus/desugared/subset8/08-xml/namespace12-v.txt
+++ b/corpus/desugared/subset8/08-xml/namespace12-v.txt
@@ -2,17 +2,26 @@
   (import-package ballerina io (as io))
   (xmlns
     (simple-var-ref URI) as bar)
-  (const URI (
-    (value-type string)) (
-    (literal https:foo/bar)))
+  (variable elem (type
+    (value-type xml)))
+  (function init () ()
+    (block-function-body
+      (assignment
+        (simple-var-ref elem)
+        (xml-element-literal bar:f
+          (xml-element-literal bar:x)))))
   (function main () (
     (value-type null))
     (block-function-body
-      (var-def
-        (variable elem (type
-          (value-type xml)) (expr
-          (xml-element-literal bar:f
-            (xml-element-literal bar:x)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref elem)))))))
+          (simple-var-ref elem))))
+      (xmlns
+        (simple-var-ref URI) as local)
+      (var-def
+        (variable localElem (type
+          (value-type xml)) (expr
+          (xml-element-literal local:f))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref localElem)))))))

--- a/corpus/integration/subset8/08-xml/namespace12-v.txtar
+++ b/corpus/integration/subset8/08-xml/namespace12-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+<bar:f xmlns:bar="https:foo/bar"><bar:x/></bar:f>
+<local:f xmlns:local="https:foo/bar"/>
+-- stderr --

--- a/corpus/integration/subset8/08-xml/namespace16-e.txtar
+++ b/corpus/integration/subset8/08-xml/namespace16-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: invalid cycle detected for FIRST
+  --> namespace16-e.bal:17:14
+   |
+17 | const string FIRST = SECOND; // @error
+   |              ^^^^^

--- a/corpus/integration/subset8/08-xml/namespace17-e.txtar
+++ b/corpus/integration/subset8/08-xml/namespace17-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: xmlns URI must be a string
+  --> namespace17-e.bal:19:7
+   |
+19 | xmlns URI as invalid; // @error
+   |       ^^^

--- a/corpus/integration/subset8/08-xml/namespace18-e.txtar
+++ b/corpus/integration/subset8/08-xml/namespace18-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: expression is not a constant expression
+  --> namespace18-e.bal:19:7
+   |
+19 | xmlns URI as invalid; // @error
+   |       ^^^

--- a/corpus/integration_test.go
+++ b/corpus/integration_test.go
@@ -85,8 +85,6 @@ var (
 		// panic or a compile-time `fatal[...]` bailout, so it does not satisfy
 		// the future-test contract yet. Tracked separately.
 		"subset8/08-future/fieldlvalue1-fp.bal",
-		// https://github.com/ballerina-nutcracker/ballerina/issues/417
-		"subset8/08-xml/namespace12-v.bal",
 		// https://github.com/ballerina-nutcracker/ballerina/issues/533
 		"subset9/09-template-expr/template-query-xml-sequence-fv.bal",
 		// https://github.com/ballerina-nutcracker/ballerina/issues/538

--- a/corpus/project/xmlns-module-v/main.bal
+++ b/corpus/project/xmlns-module-v/main.bal
@@ -15,8 +15,9 @@
 // under the License.
 
 import ballerina/io;
+import testorg/xmlnsmodule.constants;
 
-xmlns "https:foo/bar" as bar;
+xmlns constants:URI as bar;
 
 public function main() {
     xml elem = xml `<bar:f><bar:x></bar:x></bar:f>`;

--- a/corpus/project/xmlns-module-v/modules/constants/constants.bal
+++ b/corpus/project/xmlns-module-v/modules/constants/constants.bal
@@ -10,23 +10,8 @@
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
+// KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
-
-const string SCHEME = "https:";
-const string URI = SCHEME + "foo/" + "bar";
-
-xmlns URI as bar;
-
-xml elem = xml `<bar:f><bar:x></bar:x></bar:f>`;
-
-public function main() {
-    io:println(elem); // @output <bar:f xmlns:bar="https:foo/bar"><bar:x/></bar:f>
-
-    xmlns URI as local;
-    xml localElem = xml `<local:f/>`;
-    io:println(localElem); // @output <local:f xmlns:local="https:foo/bar"/>
-}
+public const string URI = "https:foo/" + "bar";

--- a/model/symbol.go
+++ b/model/symbol.go
@@ -1260,6 +1260,15 @@ func XMLNamespaceURI(symbol Symbol) (string, error) {
 	return xmlns.URI(), nil
 }
 
+func SetXMLNamespaceURI(symbol Symbol, uri string) error {
+	xmlns, ok := symbol.(*XMLNSSymbol)
+	if !ok {
+		return errors.New("expected XML namespace symbol")
+	}
+	xmlns.uri = uri
+	return nil
+}
+
 func XMLNamespaceDeclKey(symbol Symbol) (string, error) {
 	xmlns, ok := symbol.(*XMLNSSymbol)
 	if !ok {

--- a/semantics/internal/analysis/corpus_semantic_analysis_test.go
+++ b/semantics/internal/analysis/corpus_semantic_analysis_test.go
@@ -27,13 +27,6 @@ import (
 	"github.com/ballerina-nutcracker/ballerina/test_util/testphases"
 )
 
-// semanticAnalysisSkipList is the semantic-analysis *additional* skip list,
-// on top of the shared test_util.UnsupportedTests baseline.
-var semanticAnalysisSkipList = []string{
-	// https://github.com/ballerina-nutcracker/ballerina/issues/417
-	"subset8/08-xml/namespace12-v.bal",
-}
-
 func TestSemanticAnalysis(t *testing.T) {
 	flag.Parse()
 
@@ -48,7 +41,7 @@ func TestSemanticAnalysis(t *testing.T) {
 }
 
 func testSemanticAnalysis(t *testing.T, testCase test_util.TestCase) {
-	if test_util.IsUnsupported(testCase.InputPath) || test_util.MatchesSkip(testCase.InputPath, semanticAnalysisSkipList) {
+	if test_util.IsUnsupported(testCase.InputPath) {
 		t.Skipf("Skipping semantic analysis test for %s", testCase.InputPath)
 		return
 	}

--- a/semantics/internal/analysis/semantic_analyzer.go
+++ b/semantics/internal/analysis/semantic_analyzer.go
@@ -830,7 +830,7 @@ func (ca *constantAnalyzer) Visit(node ast.BLangNode) ast.Visitor {
 	case ast.BLangExpression:
 		bLangExpr := n
 		hasErrors := false
-		validateConstantExpr(ca.ctx(), bLangExpr, func(e ast.BLangExpression) {
+		common.ValidateConstantExpr(ca.ctx(), bLangExpr, func(e ast.BLangExpression) {
 			ca.semanticErr("expression is not a constant expression", e.GetPosition())
 			hasErrors = true
 		})
@@ -841,50 +841,6 @@ func (ca *constantAnalyzer) Visit(node ast.BLangNode) ast.Visitor {
 		return nil
 	}
 	return ca
-}
-
-func validateConstantExpr(ctx *context.CompilerContext, expr ast.BLangExpression, onNonConst func(ast.BLangExpression)) {
-	switch e := expr.(type) {
-	case *ast.BLangLiteral, *ast.BLangNumericLiteral, *ast.BLangConstRef:
-		// always valid
-	case *ast.BLangVarRef:
-		sym := ctx.GetSymbol(e.Symbol())
-		if vs, ok := sym.(model.ValueSymbol); ok && vs.IsConst() {
-			return
-		}
-		onNonConst(expr)
-	case *ast.BLangUnaryExpr:
-		validateConstantExpr(ctx, e.Expr, onNonConst)
-	case *ast.BLangTypeConversionExpr:
-		validateConstantExpr(ctx, e.Expression, onNonConst)
-	case *ast.BLangGroupExpr:
-		validateConstantExpr(ctx, e.Expression, onNonConst)
-	case *ast.BLangBinaryExpr:
-		validateConstantExpr(ctx, e.LhsExpr, onNonConst)
-		validateConstantExpr(ctx, e.RhsExpr, onNonConst)
-	case *ast.BLangListConstructorExpr:
-		for _, member := range e.Exprs {
-			validateConstantExpr(ctx, member, onNonConst)
-		}
-	case *ast.BLangMappingConstructorExpr:
-		for _, field := range e.Fields {
-			if kv, ok := field.(*ast.BLangMappingKeyValueField); ok {
-				validateConstantExpr(ctx, kv.ValueExpr, onNonConst)
-			}
-		}
-	case *ast.BLangTemplateExpr:
-		for _, ins := range e.Insertions {
-			validateConstantExpr(ctx, ins, onNonConst)
-		}
-	case *ast.BLangAnnotAccessExpr:
-		validateConstantExpr(ctx, e.Expr, onNonConst)
-	case *ast.BLangXMLTemplateExpr:
-		for _, ins := range e.Insertions {
-			validateConstantExpr(ctx, ins, onNonConst)
-		}
-	default:
-		onNonConst(expr)
-	}
 }
 
 // validateResolvedType validates that a resolved expression type is compatible with the expected type
@@ -1797,11 +1753,6 @@ func visitInner[A analyzer](a A, node ast.BLangNode) ast.Visitor {
 	case *ast.BLangBreak, *ast.BLangContinue:
 		return nil
 	case *ast.BLangXMLNS:
-		expr := n.GetNamespaceURI()
-		validateResolvedType(a, expr, semtypes.String)
-		validateConstantExpr(a.ctx(), expr, func(e ast.BLangExpression) {
-			a.semanticErr("expression is not a constant expression", e.GetPosition())
-		})
 		return nil
 	case *ast.BLangMatchStatement:
 		return a

--- a/semantics/internal/cfg/corpus_cfg_test.go
+++ b/semantics/internal/cfg/corpus_cfg_test.go
@@ -31,13 +31,6 @@ import (
 
 var updateCFG = flag.Bool("update", false, "update expected CFG text files")
 
-// cfgGenerationSkipList is the CFG-stage *additional* skip list, on top of
-// the shared test_util.UnsupportedTests baseline.
-var cfgGenerationSkipList = []string{
-	// https://github.com/ballerina-nutcracker/ballerina/issues/417
-	"subset8/08-xml/namespace12-v.bal",
-}
-
 func TestCFGGeneration(t *testing.T) {
 	flag.Parse()
 
@@ -53,7 +46,7 @@ func TestCFGGeneration(t *testing.T) {
 
 // testCFGGeneration tests CFG generation for a single .bal file.
 func testCFGGeneration(t *testing.T, testPair test_util.TestCase) {
-	if test_util.IsUnsupported(testPair.InputPath) || test_util.MatchesSkip(testPair.InputPath, cfgGenerationSkipList) {
+	if test_util.IsUnsupported(testPair.InputPath) {
 		t.Skipf("Skipping CFG generation test for %s", testPair.InputPath)
 		return
 	}

--- a/semantics/internal/common/common.go
+++ b/semantics/internal/common/common.go
@@ -135,3 +135,46 @@ func XMLTemplateInsertionAllowedTypes(kind ast.XMLTemplateInsertionKind) semtype
 	}
 	return TemplateInsertionAllowedTypes
 }
+
+func ValidateConstantExpr(ctx *context.CompilerContext, expr ast.BLangExpression, onNonConst func(ast.BLangExpression)) {
+	switch e := expr.(type) {
+	case *ast.BLangLiteral, *ast.BLangNumericLiteral, *ast.BLangConstRef:
+	case *ast.BLangVarRef:
+		sym := ctx.GetSymbol(e.Symbol())
+		if vs, ok := sym.(model.ValueSymbol); ok && vs.IsConst() {
+			return
+		}
+		onNonConst(expr)
+	case *ast.BLangUnaryExpr:
+		ValidateConstantExpr(ctx, e.Expr, onNonConst)
+	case *ast.BLangTypeConversionExpr:
+		ValidateConstantExpr(ctx, e.Expression, onNonConst)
+	case *ast.BLangGroupExpr:
+		ValidateConstantExpr(ctx, e.Expression, onNonConst)
+	case *ast.BLangBinaryExpr:
+		ValidateConstantExpr(ctx, e.LhsExpr, onNonConst)
+		ValidateConstantExpr(ctx, e.RhsExpr, onNonConst)
+	case *ast.BLangListConstructorExpr:
+		for _, member := range e.Exprs {
+			ValidateConstantExpr(ctx, member, onNonConst)
+		}
+	case *ast.BLangMappingConstructorExpr:
+		for _, field := range e.Fields {
+			if kv, ok := field.(*ast.BLangMappingKeyValueField); ok {
+				ValidateConstantExpr(ctx, kv.ValueExpr, onNonConst)
+			}
+		}
+	case *ast.BLangTemplateExpr:
+		for _, ins := range e.Insertions {
+			ValidateConstantExpr(ctx, ins, onNonConst)
+		}
+	case *ast.BLangAnnotAccessExpr:
+		ValidateConstantExpr(ctx, e.Expr, onNonConst)
+	case *ast.BLangXMLTemplateExpr:
+		for _, ins := range e.Insertions {
+			ValidateConstantExpr(ctx, ins, onNonConst)
+		}
+	default:
+		onNonConst(expr)
+	}
+}

--- a/semantics/internal/symbols/corpus_symbol_resolver_test.go
+++ b/semantics/internal/symbols/corpus_symbol_resolver_test.go
@@ -28,13 +28,6 @@ import (
 	"github.com/ballerina-nutcracker/ballerina/test_util/testphases"
 )
 
-// symbolResolverSkipList is the symbol-resolver *additional* skip list, on
-// top of the shared test_util.UnsupportedTests baseline.
-var symbolResolverSkipList = []string{
-	// https://github.com/ballerina-nutcracker/ballerina/issues/417
-	"subset8/08-xml/namespace12-v.bal",
-}
-
 func TestSymbolResolver(t *testing.T) {
 	flag.Parse()
 	testPairs := test_util.GetValidAndPanicTests(t, test_util.AST)
@@ -48,7 +41,7 @@ func TestSymbolResolver(t *testing.T) {
 }
 
 func testSymbolResolution(t *testing.T, testCase test_util.TestCase) {
-	if test_util.IsUnsupported(testCase.InputPath) || test_util.MatchesSkip(testCase.InputPath, symbolResolverSkipList) {
+	if test_util.IsUnsupported(testCase.InputPath) {
 		t.Skipf("Skipping symbol resolver test for %s", testCase.InputPath)
 		return
 	}

--- a/semantics/internal/symbols/symbol_resolver.go
+++ b/semantics/internal/symbols/symbol_resolver.go
@@ -1193,6 +1193,9 @@ func (bs *blockSymbolResolver) Visit(node ast.BLangNode) ast.Visitor {
 		return nil
 	case *ast.BLangXMLNS:
 		processBlockXMLNS(bs, n)
+		if uriExpr := n.GetNamespaceURI(); uriExpr != nil {
+			ast.Walk(bs, uriExpr)
+		}
 		return nil
 	case *ast.BLangFunction:
 		// This happens because we visit from the top in [resolveFunction]

--- a/semantics/internal/symbols/xmlns_resolver.go
+++ b/semantics/internal/symbols/xmlns_resolver.go
@@ -24,20 +24,6 @@ import (
 	"github.com/ballerina-nutcracker/ballerina/tools/diagnostics"
 )
 
-func extractXMLNSURI[T symbolResolver](resolver T, uriExpr ast.BLangExpression, pos diagnostics.Location) (string, bool) {
-	lit, ok := uriExpr.(*ast.BLangLiteral)
-	if !ok {
-		semanticError(resolver, "xmlns URI must be a string literal", pos)
-		return "", false
-	}
-	val, ok := lit.GetValue().(string)
-	if !ok {
-		semanticError(resolver, "xmlns URI must be a string", pos)
-		return "", false
-	}
-	return val, true
-}
-
 func xmlnsPrefixName(prefix string) string {
 	if prefix == "" {
 		return model.DefaultXMLNSSymbolName
@@ -46,11 +32,15 @@ func xmlnsPrefixName(prefix string) string {
 }
 
 func defineXMLNS[T symbolResolver](resolver T, scope model.Scope, prefix, uri string, pos diagnostics.Location) (model.SymbolRef, bool) {
-	ensurePrefixMap(resolver, scope)
 	if uri == "" {
 		semanticError(resolver, "XML namespace URI cannot be empty", pos)
 		return model.SymbolRef{}, false
 	}
+	return declareXMLNS(resolver, scope, prefix, uri, pos)
+}
+
+func declareXMLNS[T symbolResolver](resolver T, scope model.Scope, prefix, uri string, pos diagnostics.Location) (model.SymbolRef, bool) {
+	ensurePrefixMap(resolver, scope)
 	name := xmlnsPrefixName(prefix)
 	if localXMLNSPrefixExists(scope, name) {
 		switch prefix {
@@ -181,20 +171,18 @@ func processBlockXMLNS(resolver *blockSymbolResolver, decl *ast.BLangXMLNS) {
 }
 
 func processXMLNSDecl[T symbolResolver](resolver T, scope model.Scope, decl *ast.BLangXMLNS) {
-	uriExpr := decl.GetNamespaceURI()
-	if uriExpr == nil {
+	if decl.GetNamespaceURI() == nil {
 		semanticError(resolver, "xmlns declaration missing URI", decl.GetPosition())
-		return
-	}
-	uri, ok := extractXMLNSURI(resolver, uriExpr, decl.GetPosition())
-	if !ok {
 		return
 	}
 	prefix := ""
 	if p := decl.GetPrefix(); p != nil {
 		prefix = p.GetValue()
 	}
-	defineXMLNS(resolver, scope, prefix, uri, decl.GetPosition())
+	ref, ok := declareXMLNS(resolver, scope, prefix, "", decl.GetPosition())
+	if ok {
+		decl.SetSymbol(ref)
+	}
 }
 
 func splitXMLName(name string) (prefix, local string) {

--- a/semantics/internal/types/corpus_type_resolver_test.go
+++ b/semantics/internal/types/corpus_type_resolver_test.go
@@ -28,13 +28,6 @@ import (
 	"github.com/ballerina-nutcracker/ballerina/test_util/testphases"
 )
 
-// typeResolverSkipList is the type-resolver *additional* skip list, on top of
-// the shared test_util.UnsupportedTests baseline.
-var typeResolverSkipList = []string{
-	// https://github.com/ballerina-nutcracker/ballerina/issues/417
-	"subset8/08-xml/namespace12-v.bal",
-}
-
 func TestTypeResolver(t *testing.T) {
 	flag.Parse()
 
@@ -49,7 +42,7 @@ func TestTypeResolver(t *testing.T) {
 }
 
 func testTypeResolution(t *testing.T, testCase test_util.TestCase) {
-	if test_util.IsUnsupported(testCase.InputPath) || test_util.MatchesSkip(testCase.InputPath, typeResolverSkipList) {
+	if test_util.IsUnsupported(testCase.InputPath) {
 		t.Skipf("Skipping type resolver test for %s", testCase.InputPath)
 		return
 	}

--- a/semantics/internal/types/type_resolver.go
+++ b/semantics/internal/types/type_resolver.go
@@ -1075,6 +1075,11 @@ func (t *packageTypeResolver) resolveTopLevelTypes(pkg *ast.BLangPackage) {
 	for i := range pkg.GlobalVars {
 		resolveGlobalVarType(t, pkg.GlobalVars[i])
 	}
+	for i := range pkg.XmlnsList {
+		if !resolveXMLNS(t, nil, pkg.XmlnsList[i]) {
+			return
+		}
+	}
 	if !resolvePackageConstants(t, pkg) {
 		return
 	}
@@ -1114,10 +1119,6 @@ func (t *packageTypeResolver) resolveTopLevelTypes(pkg *ast.BLangPackage) {
 		}
 		svc.SetDeterminedType(semtypes.Never)
 	}
-	for i := range pkg.XmlnsList {
-		resolveXMLNS(t, nil, pkg.XmlnsList[i])
-	}
-
 	t.drainDeferredEmptinessChecks()
 }
 
@@ -1750,7 +1751,9 @@ func resolveStatementInner(t typeResolver, chain *binding, stmt ast.StatementNod
 		}
 		return statementEffect{binding: nil, nonCompletion: true}, true
 	case *ast.BLangXMLNS:
-		resolveXMLNS(t, chain, s)
+		if !resolveXMLNS(t, chain, s) {
+			return defaultStmtEffect(chain), false
+		}
 		return defaultStmtEffect(chain), true
 	default:
 		t.internalError(fmt.Sprintf("unhandled statement type: %T", stmt), stmt.GetPosition())
@@ -1758,14 +1761,55 @@ func resolveStatementInner(t typeResolver, chain *binding, stmt ast.StatementNod
 	}
 }
 
-func resolveXMLNS(t typeResolver, chain *binding, decl *ast.BLangXMLNS) {
+func resolveXMLNS(t typeResolver, chain *binding, decl *ast.BLangXMLNS) bool {
 	decl.SetDeterminedType(semtypes.Never)
-	if uriExpr := decl.GetNamespaceURI(); uriExpr != nil {
-		resolveActionOrExpression(t, chain, uriExpr, semtypes.String)
+	uriExpr := decl.GetNamespaceURI()
+	if uriExpr == nil {
+		t.internalError("xmlns declaration missing URI", decl.GetPosition())
+		return false
 	}
+	uriTy, _, ok := resolveActionOrExpression(t, chain, uriExpr, semtypes.String)
+	if !ok {
+		return false
+	}
+	if !semtypes.IsSubtype(t.typeContext(), uriTy, semtypes.String) {
+		t.semanticError("xmlns URI must be a string", uriExpr.GetPosition())
+		return false
+	}
+	isConstant := true
+	common.ValidateConstantExpr(t.compilerContext(), uriExpr, func(expr ast.BLangExpression) {
+		// Report only the first non-constant subexpression to avoid duplicate diagnostics.
+		if isConstant {
+			t.semanticError("expression is not a constant expression", expr.GetPosition())
+		}
+		isConstant = false
+	})
+	if !isConstant {
+		return false
+	}
+	value, err := evaluateConstantExpression(t, uriExpr)
+	if err != nil {
+		t.semanticError("expression is not a constant expression", uriExpr.GetPosition())
+		return false
+	}
+	uri, ok := value.(string)
+	if !ok {
+		t.semanticError("xmlns URI must be a string", uriExpr.GetPosition())
+		return false
+	}
+	if uri == "" {
+		t.semanticError("XML namespace URI cannot be empty", decl.GetPosition())
+		return false
+	}
+	if err := t.compilerContext().SetXMLNamespaceURI(decl.Symbol(), uri); err != nil {
+		t.internalError(err.Error(), decl.GetPosition())
+		return false
+	}
+	t.setSymbolType(decl.Symbol(), semtypes.String)
 	if prefix := decl.GetPrefix(); prefix != nil {
 		prefix.SetDeterminedType(semtypes.Never)
 	}
+	return true
 }
 
 func resolveOnFailClause(t typeResolver, chain *binding, clause *ast.BLangOnFailClause) {


### PR DESCRIPTION
$subject
resolves #417 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * XML namespace URIs can be defined using string constants, including constants imported from another module.
  * Namespace declarations support assembled constant values and namespaced XML elements.

* **Bug Fixes**
  * Added validation for missing, empty, non-string, non-constant, and invalid namespace URIs.
  * Improved compiler diagnostics for cyclic constant references used in namespace declarations.

* **Tests**
  * Added coverage for valid namespace constants and invalid namespace declaration scenarios.
  * Enabled integration coverage for namespaced XML element output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->