### PR TITLE
refactor: handle check expression in bir gen instead of desugar

### DIFF
--- a/birgen/bir_gen.go
+++ b/birgen/bir_gen.go
@@ -964,6 +964,10 @@ func handleActionOrExpression(ctx context, curBB *bir.BIRBasicBlock, expr ast.BL
 		return literal(ctx, curBB, &expr.BLangLiteral)
 	case *ast.BLangBinaryExpr:
 		return binaryExpression(ctx, curBB, expr)
+	case *ast.BLangCheckedExpr:
+		return checkedExpression(ctx, curBB, expr.Expr, expr.GetDeterminedType(), false, expr.GetPosition())
+	case *ast.BLangCheckPanickedExpr:
+		return checkedExpression(ctx, curBB, expr.Expr, expr.GetDeterminedType(), true, expr.GetPosition())
 	case *ast.BLangVarRef:
 		return simpleVariableReference(ctx, curBB, expr)
 	case *ast.BLangUnaryExpr:
@@ -1652,6 +1656,40 @@ func binaryExpression(ctx context, curBB *bir.BIRBasicBlock, expr *ast.BLangBina
 	default:
 		return binaryExpressionInner(ctx, curBB, expr.OpKind, expr.LhsExpr, expr.RhsExpr, expr.GetDeterminedType(), ctx.function().loc(expr.GetPosition()))
 	}
+}
+
+func checkedExpression(ctx context, curBB *bir.BIRBasicBlock, expr ast.BLangActionOrExpression, resultType semtypes.SemType, isPanic bool, exprPos diagnostics.Location) expressionEffect {
+	pos := ctx.function().loc(exprPos)
+	resultOperand := ctx.addTempVar(resultType)
+	innerEffect := handleActionOrExpression(ctx, curBB, expr)
+
+	isErrorOperand := ctx.addTempVar(semtypes.Boolean)
+	typeTest := bir.NewTypeTest(semtypes.Error, isErrorOperand, innerEffect.result, pos)
+	innerEffect.block.Instructions = append(innerEffect.block.Instructions, typeTest)
+
+	errorBB := ctx.function().addBB()
+	successBB := ctx.function().addBB()
+	doneBB := ctx.function().addBB()
+	innerEffect.block.Terminator = bir.NewBranch(isErrorOperand, errorBB, successBB, pos)
+
+	if isPanic {
+		panicOp := innerEffect.result
+		if _, depth := functionRoot(ctx); depth > 0 {
+			store, fromRoot := addFunctionTempVar(ctx, innerEffect.result.VariableDcl.GetType())
+			errorBB.Instructions = append(errorBB.Instructions, bir.NewMove(innerEffect.result, store, pos))
+			panicOp = fromRoot
+		}
+		errorBB = unwindFunction(ctx, errorBB, pos)
+		errorBB.Terminator = bir.NewPanic(panicOp, pos)
+	} else {
+		errorBB.Instructions = append(errorBB.Instructions, bir.NewMove(innerEffect.result, retVar(ctx), pos))
+		errorBB = unwindFunction(ctx, errorBB, pos)
+		errorBB.Terminator = bir.NewReturn(pos)
+	}
+
+	successBB.Instructions = append(successBB.Instructions, bir.NewMove(innerEffect.result, resultOperand, pos))
+	successBB.Terminator = bir.NewGoto(doneBB, pos)
+	return expressionEffect{result: resultOperand, block: doneBB}
 }
 
 func logicalAndExpression(ctx context, curBB *bir.BIRBasicBlock, expr *ast.BLangBinaryExpr) expressionEffect {

--- a/corpus/ast/subset8/08-error/check15-v.txt
+++ b/corpus/ast/subset8/08-error/check15-v.txt
@@ -1,0 +1,38 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable result (type
+          (union-type
+            (error-type)
+            (value-type null))) (expr
+          (trap-expr
+            (invocation nestedScopeCheckpanic ())))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref result))))))
+  (function nestedScopeCheckpanic () (
+    (value-type null))
+    (block-function-body
+      (if
+        (literal true)
+        (block-stmt
+          (if
+            (literal true)
+            (block-stmt
+              (expression-stmt
+                (check-panicked-expr
+                  (invocation alwaysErr ())))) ())
+          (block-stmt)) ())
+      (block-stmt)))
+  (function alwaysErr () (
+    (union-type
+      (error-type)
+      (value-type null)))
+    (block-function-body
+      (return
+        (error-constructor-expr (
+          (literal original error)))))))

--- a/corpus/bal/subset8/08-error/check15-v.bal
+++ b/corpus/bal/subset8/08-error/check15-v.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    error? result = trap nestedScopeCheckpanic();
+    io:println(result); // @output error("original error")
+}
+
+function nestedScopeCheckpanic() {
+    if true {
+        if true {
+            checkpanic alwaysErr();
+        }
+    }
+}
+
+function alwaysErr() returns error? {
+    return error("original error");
+}

--- a/corpus/bir/library/subset1/http-client-methods-v.txt
+++ b/corpus/bir/library/subset1/http-client-methods-v.txt
@@ -7,236 +7,243 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newObject ballerina/http:Client
-    %6 = init(%5,$desugar$0,$desugar$1) -> bb2;
+    %6 = newObject ballerina/http:Client
+    %7 = init(%6,$desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    %8 = %6 is nil
-    %8 ? bb3 : bb4;
+    %9 = %7 is nil
+    %9 ? bb3 : bb4;
   }
   bb3 {
-    %7 = %5;
+    %8 = %6;
     GOTO bb5;
   }
   bb4 {
-    %7 = %6;
+    %8 = %7;
     GOTO bb5;
   }
   bb5 {
-    $desugar$2 = %7;
-    %10 = $desugar$2 is error
+    %10 = %8 is error
     %10 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb7 {
-    c = $desugar$2;
-    %12 = ConstantLoad /put
-    $desugar$3 = %12;
-    %14 = ConstantLoad body
-    $desugar$4 = %14;
-    %16 = $default$28($desugar$3,$desugar$4) -> bb8;
+    %5 = %8;
+    GOTO bb8;
   }
   bb8 {
-    $desugar$5 = %16;
-    %18 = $default$29($desugar$3,$desugar$4,$desugar$5) -> bb9;
+    c = %5;
+    %12 = ConstantLoad /put
+    $desugar$2 = %12;
+    %14 = ConstantLoad body
+    $desugar$3 = %14;
+    %16 = $default$28($desugar$2,$desugar$3) -> bb9;
   }
   bb9 {
-    $desugar$6 = %18;
-    %20 = ConstantLoad typedesc
-    $desugar$7 = %20;
-    %22 = $remote$put(c,$desugar$3,$desugar$4,$desugar$5,$desugar$6,$desugar$7) -> bb10;
+    $desugar$4 = %16;
+    %18 = $default$29($desugar$2,$desugar$3,$desugar$4) -> bb10;
   }
   bb10 {
-    $desugar$8 = %22;
-    %24 = $desugar$8 is error
-    %24 ? bb11 : bb12;
+    $desugar$5 = %18;
+    %20 = ConstantLoad typedesc
+    $desugar$6 = %20;
+    %23 = $remote$put(c,$desugar$2,$desugar$3,$desugar$4,$desugar$5,$desugar$6) -> bb11;
   }
   bb11 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    %24 = %23 is error
+    %24 ? bb12 : bb13;
   }
   bb12 {
-    r1 = $desugar$8;
+    %0 = %23;
+    return;
+  }
+  bb13 {
+    %22 = %23;
+    GOTO bb14;
+  }
+  bb14 {
+    r1 = %22;
     %27 = ConstantLoad statusCode
     %26 = r1[%27];
     %28 = %26;
-    %29 = println(%28) -> bb13;
+    %29 = println(%28) -> bb15;
   }
-  bb13 {
+  bb15 {
     %30 = ConstantLoad /patch
-    $desugar$9 = %30;
+    $desugar$7 = %30;
     %32 = ConstantLoad key
     %33 = ConstantLoad val
     %34 = newMap {| json... |}{%32=%33}
-    $desugar$10 = %34;
-    %36 = $default$24($desugar$9,$desugar$10) -> bb14;
-  }
-  bb14 {
-    $desugar$11 = %36;
-    %38 = $default$25($desugar$9,$desugar$10,$desugar$11) -> bb15;
-  }
-  bb15 {
-    $desugar$12 = %38;
-    %40 = ConstantLoad typedesc
-    $desugar$13 = %40;
-    %42 = $remote$patch(c,$desugar$9,$desugar$10,$desugar$11,$desugar$12,$desugar$13) -> bb16;
+    $desugar$8 = %34;
+    %36 = $default$24($desugar$7,$desugar$8) -> bb16;
   }
   bb16 {
-    $desugar$14 = %42;
-    %44 = $desugar$14 is error
-    %44 ? bb17 : bb18;
+    $desugar$9 = %36;
+    %38 = $default$25($desugar$7,$desugar$8,$desugar$9) -> bb17;
   }
   bb17 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
-    return;
+    $desugar$10 = %38;
+    %40 = ConstantLoad typedesc
+    $desugar$11 = %40;
+    %43 = $remote$patch(c,$desugar$7,$desugar$8,$desugar$9,$desugar$10,$desugar$11) -> bb18;
   }
   bb18 {
-    r2 = $desugar$14;
+    %44 = %43 is error
+    %44 ? bb19 : bb20;
+  }
+  bb19 {
+    %0 = %43;
+    return;
+  }
+  bb20 {
+    %42 = %43;
+    GOTO bb21;
+  }
+  bb21 {
+    r2 = %42;
     %47 = ConstantLoad statusCode
     %46 = r2[%47];
     %48 = %46;
-    %49 = println(%48) -> bb19;
-  }
-  bb19 {
-    %50 = ConstantLoad /delete
-    $desugar$15 = %50;
-    %52 = $default$16($desugar$15) -> bb20;
-  }
-  bb20 {
-    $desugar$16 = %52;
-    %54 = $default$17($desugar$15,$desugar$16) -> bb21;
-  }
-  bb21 {
-    $desugar$17 = %54;
-    %56 = $default$18($desugar$15,$desugar$16,$desugar$17) -> bb22;
+    %49 = println(%48) -> bb22;
   }
   bb22 {
-    $desugar$18 = %56;
-    %58 = ConstantLoad typedesc
-    $desugar$19 = %58;
-    %60 = $remote$delete(c,$desugar$15,$desugar$16,$desugar$17,$desugar$18,$desugar$19) -> bb23;
+    %50 = ConstantLoad /delete
+    $desugar$12 = %50;
+    %52 = $default$16($desugar$12) -> bb23;
   }
   bb23 {
-    $desugar$20 = %60;
-    %62 = $desugar$20 is error
-    %62 ? bb24 : bb25;
+    $desugar$13 = %52;
+    %54 = $default$17($desugar$12,$desugar$13) -> bb24;
   }
   bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
+    $desugar$14 = %54;
+    %56 = $default$18($desugar$12,$desugar$13,$desugar$14) -> bb25;
   }
   bb25 {
-    r3 = $desugar$20;
+    $desugar$15 = %56;
+    %58 = ConstantLoad typedesc
+    $desugar$16 = %58;
+    %61 = $remote$delete(c,$desugar$12,$desugar$13,$desugar$14,$desugar$15,$desugar$16) -> bb26;
+  }
+  bb26 {
+    %62 = %61 is error
+    %62 ? bb27 : bb28;
+  }
+  bb27 {
+    %0 = %61;
+    return;
+  }
+  bb28 {
+    %60 = %61;
+    GOTO bb29;
+  }
+  bb29 {
+    r3 = %60;
     %65 = ConstantLoad statusCode
     %64 = r3[%65];
     %66 = %64;
-    %67 = println(%66) -> bb26;
-  }
-  bb26 {
-    %68 = ConstantLoad /head
-    $desugar$21 = %68;
-    %70 = $default$22($desugar$21) -> bb27;
-  }
-  bb27 {
-    $desugar$22 = %70;
-    %72 = $remote$head(c,$desugar$21,$desugar$22) -> bb28;
-  }
-  bb28 {
-    $desugar$23 = %72;
-    %74 = $desugar$23 is error
-    %74 ? bb29 : bb30;
-  }
-  bb29 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$23);
-    PopScopeFrame
-    return;
+    %67 = println(%66) -> bb30;
   }
   bb30 {
-    r4 = $desugar$23;
+    %68 = ConstantLoad /head
+    $desugar$17 = %68;
+    %70 = $default$22($desugar$17) -> bb31;
+  }
+  bb31 {
+    $desugar$18 = %70;
+    %73 = $remote$head(c,$desugar$17,$desugar$18) -> bb32;
+  }
+  bb32 {
+    %74 = %73 is error
+    %74 ? bb33 : bb34;
+  }
+  bb33 {
+    %0 = %73;
+    return;
+  }
+  bb34 {
+    %72 = %73;
+    GOTO bb35;
+  }
+  bb35 {
+    r4 = %72;
     %77 = ConstantLoad statusCode
     %76 = r4[%77];
     %78 = %76;
-    %79 = println(%78) -> bb31;
+    %79 = println(%78) -> bb36;
   }
-  bb31 {
+  bb36 {
     %80 = ConstantLoad /options
-    $desugar$24 = %80;
-    %82 = $default$23($desugar$24) -> bb32;
+    $desugar$19 = %80;
+    %82 = $default$23($desugar$19) -> bb37;
   }
-  bb32 {
-    $desugar$25 = %82;
+  bb37 {
+    $desugar$20 = %82;
     %84 = ConstantLoad typedesc
-    $desugar$26 = %84;
-    %86 = $remote$options(c,$desugar$24,$desugar$25,$desugar$26) -> bb33;
+    $desugar$21 = %84;
+    %87 = $remote$options(c,$desugar$19,$desugar$20,$desugar$21) -> bb38;
   }
-  bb33 {
-    $desugar$27 = %86;
-    %88 = $desugar$27 is error
-    %88 ? bb34 : bb35;
+  bb38 {
+    %88 = %87 is error
+    %88 ? bb39 : bb40;
   }
-  bb34 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$27);
-    PopScopeFrame
+  bb39 {
+    %0 = %87;
     return;
   }
-  bb35 {
-    r5 = $desugar$27;
+  bb40 {
+    %86 = %87;
+    GOTO bb41;
+  }
+  bb41 {
+    r5 = %86;
     %91 = ConstantLoad statusCode
     %90 = r5[%91];
     %92 = %90;
-    %93 = println(%92) -> bb36;
+    %93 = println(%92) -> bb42;
   }
-  bb36 {
+  bb42 {
     %94 = ConstantLoad PATCH
-    $desugar$28 = %94;
+    $desugar$22 = %94;
     %96 = ConstantLoad /execute
-    $desugar$29 = %96;
+    $desugar$23 = %96;
     %98 = ConstantLoad exec body
-    $desugar$30 = %98;
-    %100 = $default$19($desugar$28,$desugar$29,$desugar$30) -> bb37;
+    $desugar$24 = %98;
+    %100 = $default$19($desugar$22,$desugar$23,$desugar$24) -> bb43;
   }
-  bb37 {
-    $desugar$31 = %100;
-    %102 = $default$20($desugar$28,$desugar$29,$desugar$30,$desugar$31) -> bb38;
+  bb43 {
+    $desugar$25 = %100;
+    %102 = $default$20($desugar$22,$desugar$23,$desugar$24,$desugar$25) -> bb44;
   }
-  bb38 {
-    $desugar$32 = %102;
+  bb44 {
+    $desugar$26 = %102;
     %104 = ConstantLoad typedesc
-    $desugar$33 = %104;
-    %106 = $remote$execute(c,$desugar$28,$desugar$29,$desugar$30,$desugar$31,$desugar$32,$desugar$33) -> bb39;
+    $desugar$27 = %104;
+    %107 = $remote$execute(c,$desugar$22,$desugar$23,$desugar$24,$desugar$25,$desugar$26,$desugar$27) -> bb45;
   }
-  bb39 {
-    $desugar$34 = %106;
-    %108 = $desugar$34 is error
-    %108 ? bb40 : bb41;
+  bb45 {
+    %108 = %107 is error
+    %108 ? bb46 : bb47;
   }
-  bb40 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$34);
-    PopScopeFrame
+  bb46 {
+    %0 = %107;
     return;
   }
-  bb41 {
-    r6 = $desugar$34;
+  bb47 {
+    %106 = %107;
+    GOTO bb48;
+  }
+  bb48 {
+    r6 = %106;
     %111 = ConstantLoad statusCode
     %110 = r6[%111];
     %112 = %110;
-    %113 = println(%112) -> bb42;
+    %113 = println(%112) -> bb49;
   }
-  bb42 {
+  bb49 {
     %114 = ConstantLoad <nil>
     %0 = %114;
     return;

--- a/corpus/bir/library/subset1/http-client-post-v.txt
+++ b/corpus/bir/library/subset1/http-client-post-v.txt
@@ -7,135 +7,139 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newObject ballerina/http:Client
-    %6 = init(%5,$desugar$0,$desugar$1) -> bb2;
+    %6 = newObject ballerina/http:Client
+    %7 = init(%6,$desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    %8 = %6 is nil
-    %8 ? bb3 : bb4;
+    %9 = %7 is nil
+    %9 ? bb3 : bb4;
   }
   bb3 {
-    %7 = %5;
+    %8 = %6;
     GOTO bb5;
   }
   bb4 {
-    %7 = %6;
+    %8 = %7;
     GOTO bb5;
   }
   bb5 {
-    $desugar$2 = %7;
-    %10 = $desugar$2 is error
+    %10 = %8 is error
     %10 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb7 {
-    c = $desugar$2;
-    %12 = ConstantLoad /post
-    $desugar$3 = %12;
-    %14 = ConstantLoad hello world
-    $desugar$4 = %14;
-    %16 = $default$26($desugar$3,$desugar$4) -> bb8;
+    %5 = %8;
+    GOTO bb8;
   }
   bb8 {
-    $desugar$5 = %16;
-    %18 = $default$27($desugar$3,$desugar$4,$desugar$5) -> bb9;
+    c = %5;
+    %12 = ConstantLoad /post
+    $desugar$2 = %12;
+    %14 = ConstantLoad hello world
+    $desugar$3 = %14;
+    %16 = $default$26($desugar$2,$desugar$3) -> bb9;
   }
   bb9 {
-    $desugar$6 = %18;
-    %20 = ConstantLoad typedesc
-    $desugar$7 = %20;
-    %22 = $remote$post(c,$desugar$3,$desugar$4,$desugar$5,$desugar$6,$desugar$7) -> bb10;
+    $desugar$4 = %16;
+    %18 = $default$27($desugar$2,$desugar$3,$desugar$4) -> bb10;
   }
   bb10 {
-    $desugar$8 = %22;
-    %24 = $desugar$8 is error
-    %24 ? bb11 : bb12;
+    $desugar$5 = %18;
+    %20 = ConstantLoad typedesc
+    $desugar$6 = %20;
+    %23 = $remote$post(c,$desugar$2,$desugar$3,$desugar$4,$desugar$5,$desugar$6) -> bb11;
   }
   bb11 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    %24 = %23 is error
+    %24 ? bb12 : bb13;
   }
   bb12 {
-    r = $desugar$8;
+    %0 = %23;
+    return;
+  }
+  bb13 {
+    %22 = %23;
+    GOTO bb14;
+  }
+  bb14 {
+    r = %22;
     %27 = ConstantLoad statusCode
     %26 = r[%27];
     %28 = %26;
-    %29 = println(%28) -> bb13;
-  }
-  bb13 {
-    %30 = ConstantLoad /post
-    %31 = ConstantLoad {"key":"value"}
-    %32 = ConstantLoad <nil>
-    %33 = %32;
-    %34 = ConstantLoad application/json
-    %35 = ConstantLoad typedesc
-    %36 = $remote$post(c,%30,%31,%33,%34,%35) -> bb14;
-  }
-  bb14 {
-    $desugar$9 = %36;
-    %38 = $desugar$9 is error
-    %38 ? bb15 : bb16;
+    %29 = println(%28) -> bb15;
   }
   bb15 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
-    return;
+    %31 = ConstantLoad /post
+    %32 = ConstantLoad {"key":"value"}
+    %33 = ConstantLoad <nil>
+    %34 = %33;
+    %35 = ConstantLoad application/json
+    %36 = ConstantLoad typedesc
+    %37 = $remote$post(c,%31,%32,%34,%35,%36) -> bb16;
   }
   bb16 {
-    r2 = $desugar$9;
+    %38 = %37 is error
+    %38 ? bb17 : bb18;
+  }
+  bb17 {
+    %0 = %37;
+    return;
+  }
+  bb18 {
+    %30 = %37;
+    GOTO bb19;
+  }
+  bb19 {
+    r2 = %30;
     %41 = ConstantLoad statusCode
     %40 = r2[%41];
     %42 = %40;
-    %43 = println(%42) -> bb17;
+    %43 = println(%42) -> bb20;
   }
-  bb17 {
+  bb20 {
     %44 = ConstantLoad /post
-    $desugar$10 = %44;
+    $desugar$7 = %44;
     %46 = ConstantLoad name
     %47 = ConstantLoad test
     %48 = ConstantLoad count
     %49 = ConstantLoad 1
     %50 = newMap {| json... |}{%46=%47, %48=%49}
-    $desugar$11 = %50;
-    %52 = $default$26($desugar$10,$desugar$11) -> bb18;
-  }
-  bb18 {
-    $desugar$12 = %52;
-    %54 = $default$27($desugar$10,$desugar$11,$desugar$12) -> bb19;
-  }
-  bb19 {
-    $desugar$13 = %54;
-    %56 = ConstantLoad typedesc
-    $desugar$14 = %56;
-    %58 = $remote$post(c,$desugar$10,$desugar$11,$desugar$12,$desugar$13,$desugar$14) -> bb20;
-  }
-  bb20 {
-    $desugar$15 = %58;
-    %60 = $desugar$15 is error
-    %60 ? bb21 : bb22;
+    $desugar$8 = %50;
+    %52 = $default$26($desugar$7,$desugar$8) -> bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$15);
-    PopScopeFrame
-    return;
+    $desugar$9 = %52;
+    %54 = $default$27($desugar$7,$desugar$8,$desugar$9) -> bb22;
   }
   bb22 {
-    r3 = $desugar$15;
+    $desugar$10 = %54;
+    %56 = ConstantLoad typedesc
+    $desugar$11 = %56;
+    %59 = $remote$post(c,$desugar$7,$desugar$8,$desugar$9,$desugar$10,$desugar$11) -> bb23;
+  }
+  bb23 {
+    %60 = %59 is error
+    %60 ? bb24 : bb25;
+  }
+  bb24 {
+    %0 = %59;
+    return;
+  }
+  bb25 {
+    %58 = %59;
+    GOTO bb26;
+  }
+  bb26 {
+    r3 = %58;
     %63 = ConstantLoad statusCode
     %62 = r3[%63];
     %64 = %62;
-    %65 = println(%64) -> bb23;
+    %65 = println(%64) -> bb27;
   }
-  bb23 {
+  bb27 {
     %66 = ConstantLoad <nil>
     %0 = %66;
     return;

--- a/corpus/bir/library/subset1/http-client-response-headers-v.txt
+++ b/corpus/bir/library/subset1/http-client-response-headers-v.txt
@@ -7,93 +7,95 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newObject ballerina/http:Client
-    %6 = init(%5,$desugar$0,$desugar$1) -> bb2;
+    %6 = newObject ballerina/http:Client
+    %7 = init(%6,$desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    %8 = %6 is nil
-    %8 ? bb3 : bb4;
+    %9 = %7 is nil
+    %9 ? bb3 : bb4;
   }
   bb3 {
-    %7 = %5;
+    %8 = %6;
     GOTO bb5;
   }
   bb4 {
-    %7 = %6;
+    %8 = %7;
     GOTO bb5;
   }
   bb5 {
-    $desugar$2 = %7;
-    %10 = $desugar$2 is error
+    %10 = %8 is error
     %10 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb7 {
-    c = $desugar$2;
-    %12 = ConstantLoad /path
-    $desugar$3 = %12;
-    %14 = $default$21($desugar$3) -> bb8;
+    %5 = %8;
+    GOTO bb8;
   }
   bb8 {
-    $desugar$4 = %14;
-    %16 = ConstantLoad typedesc
-    $desugar$5 = %16;
-    %18 = $remote$get(c,$desugar$3,$desugar$4,$desugar$5) -> bb9;
+    c = %5;
+    %12 = ConstantLoad /path
+    $desugar$2 = %12;
+    %14 = $default$21($desugar$2) -> bb9;
   }
   bb9 {
-    $desugar$6 = %18;
-    %20 = $desugar$6 is error
-    %20 ? bb10 : bb11;
+    $desugar$3 = %14;
+    %16 = ConstantLoad typedesc
+    $desugar$4 = %16;
+    %19 = $remote$get(c,$desugar$2,$desugar$3,$desugar$4) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    %20 = %19 is error
+    %20 ? bb11 : bb12;
   }
   bb11 {
-    r = $desugar$6;
-    %22 = ConstantLoad x-absent
-    $desugar$7 = %22;
-    %24 = $default$4($desugar$7) -> bb12;
+    %0 = %19;
+    return;
   }
   bb12 {
-    $desugar$8 = %24;
-    %26 = hasHeader(r,$desugar$7,$desugar$8) -> bb13;
+    %18 = %19;
+    GOTO bb13;
   }
   bb13 {
-    %27 = %26;
-    %28 = println(%27) -> bb14;
+    r = %18;
+    %22 = ConstantLoad x-absent
+    $desugar$5 = %22;
+    %24 = $default$4($desugar$5) -> bb14;
   }
   bb14 {
-    %29 = $default$2() -> bb15;
+    $desugar$6 = %24;
+    %26 = hasHeader(r,$desugar$5,$desugar$6) -> bb15;
   }
   bb15 {
-    $desugar$9 = %29;
-    %31 = getHeaderNames(r,$desugar$9) -> bb16;
+    %27 = %26;
+    %28 = println(%27) -> bb16;
   }
   bb16 {
-    %32 = length(%31) -> bb17;
+    %29 = $default$2() -> bb17;
   }
   bb17 {
-    %33 = %32;
-    %34 = println(%33) -> bb18;
+    $desugar$7 = %29;
+    %31 = getHeaderNames(r,$desugar$7) -> bb18;
   }
   bb18 {
-    %35 = ConstantLoad x-absent
-    %36 = ConstantLoad LEADING
-    %37 = hasHeader(r,%35,%36) -> bb19;
+    %32 = length(%31) -> bb19;
   }
   bb19 {
-    %38 = %37;
-    %39 = println(%38) -> bb20;
+    %33 = %32;
+    %34 = println(%33) -> bb20;
   }
   bb20 {
+    %35 = ConstantLoad x-absent
+    %36 = ConstantLoad LEADING
+    %37 = hasHeader(r,%35,%36) -> bb21;
+  }
+  bb21 {
+    %38 = %37;
+    %39 = println(%38) -> bb22;
+  }
+  bb22 {
     %40 = ConstantLoad <nil>
     %0 = %40;
     return;

--- a/corpus/bir/library/subset1/http-client-response-payload-v.txt
+++ b/corpus/bir/library/subset1/http-client-response-payload-v.txt
@@ -7,88 +7,91 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newObject ballerina/http:Client
-    %6 = init(%5,$desugar$0,$desugar$1) -> bb2;
+    %6 = newObject ballerina/http:Client
+    %7 = init(%6,$desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    %8 = %6 is nil
-    %8 ? bb3 : bb4;
+    %9 = %7 is nil
+    %9 ? bb3 : bb4;
   }
   bb3 {
-    %7 = %5;
+    %8 = %6;
     GOTO bb5;
   }
   bb4 {
-    %7 = %6;
+    %8 = %7;
     GOTO bb5;
   }
   bb5 {
-    $desugar$2 = %7;
-    %10 = $desugar$2 is error
+    %10 = %8 is error
     %10 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb7 {
-    c = $desugar$2;
-    %12 = ConstantLoad /path
-    $desugar$3 = %12;
-    %14 = $default$21($desugar$3) -> bb8;
+    %5 = %8;
+    GOTO bb8;
   }
   bb8 {
-    $desugar$4 = %14;
-    %16 = ConstantLoad typedesc
-    $desugar$5 = %16;
-    %18 = $remote$get(c,$desugar$3,$desugar$4,$desugar$5) -> bb9;
+    c = %5;
+    %12 = ConstantLoad /path
+    $desugar$2 = %12;
+    %14 = $default$21($desugar$2) -> bb9;
   }
   bb9 {
-    $desugar$6 = %18;
-    %20 = $desugar$6 is error
-    %20 ? bb10 : bb11;
+    $desugar$3 = %14;
+    %16 = ConstantLoad typedesc
+    $desugar$4 = %16;
+    %19 = $remote$get(c,$desugar$2,$desugar$3,$desugar$4) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    %20 = %19 is error
+    %20 ? bb11 : bb12;
   }
   bb11 {
-    r = $desugar$6;
-    %22 = getBinaryPayload(r) -> bb12;
-  }
-  bb12 {
-    $desugar$7 = %22;
-    %24 = $desugar$7 is error
-    %24 ? bb13 : bb14;
-  }
-  bb13 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
+    %0 = %19;
     return;
   }
+  bb12 {
+    %18 = %19;
+    GOTO bb13;
+  }
+  bb13 {
+    r = %18;
+    %23 = getBinaryPayload(r) -> bb14;
+  }
   bb14 {
-    b = $desugar$7;
-    %26 = length(b) -> bb15;
+    %24 = %23 is error
+    %24 ? bb15 : bb16;
   }
   bb15 {
-    %27 = %26;
-    %28 = println(%27) -> bb16;
+    %0 = %23;
+    return;
   }
   bb16 {
-    %29 = getJsonPayload(r) -> bb17;
+    %22 = %23;
+    GOTO bb17;
   }
   bb17 {
+    b = %22;
+    %26 = length(b) -> bb18;
+  }
+  bb18 {
+    %27 = %26;
+    %28 = println(%27) -> bb19;
+  }
+  bb19 {
+    %29 = getJsonPayload(r) -> bb20;
+  }
+  bb20 {
     payload = %29;
     %31 = payload is error
     %32 = %31;
-    %33 = println(%32) -> bb18;
+    %33 = println(%32) -> bb21;
   }
-  bb18 {
+  bb21 {
     %34 = ConstantLoad <nil>
     %0 = %34;
     return;

--- a/corpus/bir/library/subset1/http-client-tls-v.txt
+++ b/corpus/bir/library/subset1/http-client-tls-v.txt
@@ -1,216 +1,222 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = newObject ballerina/http:Client
-    %2 = ConstantLoad https://example.com
-    %3 = ConstantLoad secureSocket
-    %4 = ConstantLoad enable
-    %5 = ConstantLoad false
-    %6 = newMap {| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}{%4=%5} defaults{enable=ballerina/http:$desugar$0, verifyHostName=ballerina/http:$desugar$1, shareSession=ballerina/http:$desugar$2}
-    %7 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%3=%6} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %8 = init(%1,%2,%7) -> bb1;
+    %2 = newObject ballerina/http:Client
+    %3 = ConstantLoad https://example.com
+    %4 = ConstantLoad secureSocket
+    %5 = ConstantLoad enable
+    %6 = ConstantLoad false
+    %7 = newMap {| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}{%5=%6} defaults{enable=ballerina/http:$desugar$0, verifyHostName=ballerina/http:$desugar$1, shareSession=ballerina/http:$desugar$2}
+    %8 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%4=%7} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %9 = init(%2,%3,%8) -> bb1;
   }
   bb1 {
-    %10 = %8 is nil
-    %10 ? bb2 : bb3;
+    %11 = %9 is nil
+    %11 ? bb2 : bb3;
   }
   bb2 {
-    %9 = %1;
+    %10 = %2;
     GOTO bb4;
   }
   bb3 {
-    %9 = %8;
+    %10 = %9;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %9;
-    %12 = $desugar$0 is error
+    %12 = %10 is error
     %12 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %10;
     return;
   }
   bb6 {
-    c1 = $desugar$0;
-    %14 = ConstantLoad /path
-    $desugar$1 = %14;
-    %16 = $default$21($desugar$1) -> bb7;
+    %1 = %10;
+    GOTO bb7;
   }
   bb7 {
-    $desugar$2 = %16;
-    %18 = ConstantLoad typedesc
-    $desugar$3 = %18;
-    %20 = $remote$get(c1,$desugar$1,$desugar$2,$desugar$3) -> bb8;
+    c1 = %1;
+    %14 = ConstantLoad /path
+    $desugar$0 = %14;
+    %16 = $default$21($desugar$0) -> bb8;
   }
   bb8 {
-    $desugar$4 = %20;
-    %22 = $desugar$4 is error
-    %22 ? bb9 : bb10;
+    $desugar$1 = %16;
+    %18 = ConstantLoad typedesc
+    $desugar$2 = %18;
+    %21 = $remote$get(c1,$desugar$0,$desugar$1,$desugar$2) -> bb9;
   }
   bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %22 = %21 is error
+    %22 ? bb10 : bb11;
   }
   bb10 {
-    r1 = $desugar$4;
+    %0 = %21;
+    return;
+  }
+  bb11 {
+    %20 = %21;
+    GOTO bb12;
+  }
+  bb12 {
+    r1 = %20;
     %25 = ConstantLoad statusCode
     %24 = r1[%25];
     %26 = %24;
-    %27 = println(%26) -> bb11;
-  }
-  bb11 {
-    %28 = newObject ballerina/http:Client
-    %29 = ConstantLoad https://example.com
-    %30 = ConstantLoad secureSocket
-    %31 = ConstantLoad enable
-    %32 = ConstantLoad false
-    %33 = ConstantLoad verifyHostName
-    %34 = ConstantLoad false
-    %35 = ConstantLoad shareSession
-    %36 = ConstantLoad false
-    %37 = ConstantLoad serverName
-    %38 = ConstantLoad example.com
-    %39 = ConstantLoad ciphers
-    %40 = ConstantLoad TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    %41 = ConstantLoad 1
-    %42 = newArray [string...][%41]{%40}
-    %43 = ConstantLoad handshakeTimeout
-    %44 = ConstantLoad 10
-    %45 = newMap {| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}{%31=%32, %33=%34, %35=%36, %37=%38, %39=%42, %43=%44} defaults{enable=ballerina/http:$desugar$0, verifyHostName=ballerina/http:$desugar$1, shareSession=ballerina/http:$desugar$2}
-    %46 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%30=%45} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %47 = init(%28,%29,%46) -> bb12;
-  }
-  bb12 {
-    %49 = %47 is nil
-    %49 ? bb13 : bb14;
+    %27 = println(%26) -> bb13;
   }
   bb13 {
-    %48 = %28;
-    GOTO bb15;
+    %29 = newObject ballerina/http:Client
+    %30 = ConstantLoad https://example.com
+    %31 = ConstantLoad secureSocket
+    %32 = ConstantLoad enable
+    %33 = ConstantLoad false
+    %34 = ConstantLoad verifyHostName
+    %35 = ConstantLoad false
+    %36 = ConstantLoad shareSession
+    %37 = ConstantLoad false
+    %38 = ConstantLoad serverName
+    %39 = ConstantLoad example.com
+    %40 = ConstantLoad ciphers
+    %41 = ConstantLoad TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    %42 = ConstantLoad 1
+    %43 = newArray [string...][%42]{%41}
+    %44 = ConstantLoad handshakeTimeout
+    %45 = ConstantLoad 10
+    %46 = newMap {| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}{%32=%33, %34=%35, %36=%37, %38=%39, %40=%43, %44=%45} defaults{enable=ballerina/http:$desugar$0, verifyHostName=ballerina/http:$desugar$1, shareSession=ballerina/http:$desugar$2}
+    %47 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%31=%46} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %48 = init(%29,%30,%47) -> bb14;
   }
   bb14 {
-    %48 = %47;
-    GOTO bb15;
+    %50 = %48 is nil
+    %50 ? bb15 : bb16;
   }
   bb15 {
-    $desugar$5 = %48;
-    %51 = $desugar$5 is error
-    %51 ? bb16 : bb17;
+    %49 = %29;
+    GOTO bb17;
   }
   bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %49 = %48;
+    GOTO bb17;
   }
   bb17 {
-    c2 = $desugar$5;
-    %53 = ConstantLoad /path
-    $desugar$6 = %53;
-    %55 = $default$21($desugar$6) -> bb18;
+    %51 = %49 is error
+    %51 ? bb18 : bb19;
   }
   bb18 {
-    $desugar$7 = %55;
-    %57 = ConstantLoad typedesc
-    $desugar$8 = %57;
-    %59 = $remote$get(c2,$desugar$6,$desugar$7,$desugar$8) -> bb19;
-  }
-  bb19 {
-    $desugar$9 = %59;
-    %61 = $desugar$9 is error
-    %61 ? bb20 : bb21;
-  }
-  bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %49;
     return;
   }
+  bb19 {
+    %28 = %49;
+    GOTO bb20;
+  }
+  bb20 {
+    c2 = %28;
+    %53 = ConstantLoad /path
+    $desugar$3 = %53;
+    %55 = $default$21($desugar$3) -> bb21;
+  }
   bb21 {
-    r2 = $desugar$9;
+    $desugar$4 = %55;
+    %57 = ConstantLoad typedesc
+    $desugar$5 = %57;
+    %60 = $remote$get(c2,$desugar$3,$desugar$4,$desugar$5) -> bb22;
+  }
+  bb22 {
+    %61 = %60 is error
+    %61 ? bb23 : bb24;
+  }
+  bb23 {
+    %0 = %60;
+    return;
+  }
+  bb24 {
+    %59 = %60;
+    GOTO bb25;
+  }
+  bb25 {
+    r2 = %59;
     %64 = ConstantLoad statusCode
     %63 = r2[%64];
     %65 = %63;
-    %66 = println(%65) -> bb22;
-  }
-  bb22 {
-    %67 = newObject ballerina/http:Client
-    %68 = ConstantLoad https://example.com
-    %69 = ConstantLoad secureSocket
-    %70 = ConstantLoad enable
-    %71 = ConstantLoad false
-    %72 = ConstantLoad protocol
-    %73 = ConstantLoad name
-    %74 = ConstantLoad TLS
-    %75 = ConstantLoad versions
-    %76 = ConstantLoad TLSv1.2
-    %77 = ConstantLoad TLSv1.3
-    %78 = ConstantLoad 2
-    %79 = newArray [string...][%78]{%76, %77}
-    %80 = newMap {| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}{%73=%74, %75=%79}
-    %81 = newMap {| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}{%70=%71, %72=%80} defaults{enable=ballerina/http:$desugar$0, verifyHostName=ballerina/http:$desugar$1, shareSession=ballerina/http:$desugar$2}
-    %82 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%69=%81} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %83 = init(%67,%68,%82) -> bb23;
-  }
-  bb23 {
-    %85 = %83 is nil
-    %85 ? bb24 : bb25;
-  }
-  bb24 {
-    %84 = %67;
-    GOTO bb26;
-  }
-  bb25 {
-    %84 = %83;
-    GOTO bb26;
+    %66 = println(%65) -> bb26;
   }
   bb26 {
-    $desugar$10 = %84;
-    %87 = $desugar$10 is error
-    %87 ? bb27 : bb28;
+    %68 = newObject ballerina/http:Client
+    %69 = ConstantLoad https://example.com
+    %70 = ConstantLoad secureSocket
+    %71 = ConstantLoad enable
+    %72 = ConstantLoad false
+    %73 = ConstantLoad protocol
+    %74 = ConstantLoad name
+    %75 = ConstantLoad TLS
+    %76 = ConstantLoad versions
+    %77 = ConstantLoad TLSv1.2
+    %78 = ConstantLoad TLSv1.3
+    %79 = ConstantLoad 2
+    %80 = newArray [string...][%79]{%77, %78}
+    %81 = newMap {| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}{%74=%75, %76=%80}
+    %82 = newMap {| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}{%71=%72, %73=%81} defaults{enable=ballerina/http:$desugar$0, verifyHostName=ballerina/http:$desugar$1, shareSession=ballerina/http:$desugar$2}
+    %83 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%70=%82} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %84 = init(%68,%69,%83) -> bb27;
   }
   bb27 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
-    return;
+    %86 = %84 is nil
+    %86 ? bb28 : bb29;
   }
   bb28 {
-    c3 = $desugar$10;
-    %89 = ConstantLoad /path
-    $desugar$11 = %89;
-    %91 = $default$21($desugar$11) -> bb29;
+    %85 = %68;
+    GOTO bb30;
   }
   bb29 {
-    $desugar$12 = %91;
-    %93 = ConstantLoad typedesc
-    $desugar$13 = %93;
-    %95 = $remote$get(c3,$desugar$11,$desugar$12,$desugar$13) -> bb30;
+    %85 = %84;
+    GOTO bb30;
   }
   bb30 {
-    $desugar$14 = %95;
-    %97 = $desugar$14 is error
-    %97 ? bb31 : bb32;
+    %87 = %85 is error
+    %87 ? bb31 : bb32;
   }
   bb31 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
+    %0 = %85;
     return;
   }
   bb32 {
-    r3 = $desugar$14;
+    %67 = %85;
+    GOTO bb33;
+  }
+  bb33 {
+    c3 = %67;
+    %89 = ConstantLoad /path
+    $desugar$6 = %89;
+    %91 = $default$21($desugar$6) -> bb34;
+  }
+  bb34 {
+    $desugar$7 = %91;
+    %93 = ConstantLoad typedesc
+    $desugar$8 = %93;
+    %96 = $remote$get(c3,$desugar$6,$desugar$7,$desugar$8) -> bb35;
+  }
+  bb35 {
+    %97 = %96 is error
+    %97 ? bb36 : bb37;
+  }
+  bb36 {
+    %0 = %96;
+    return;
+  }
+  bb37 {
+    %95 = %96;
+    GOTO bb38;
+  }
+  bb38 {
+    r3 = %95;
     %100 = ConstantLoad statusCode
     %99 = r3[%100];
     %101 = %99;
-    %102 = println(%101) -> bb33;
+    %102 = println(%101) -> bb39;
   }
-  bb33 {
+  bb39 {
     %103 = ConstantLoad <nil>
     %0 = %103;
     return;

--- a/corpus/bir/library/subset1/http-client-v.txt
+++ b/corpus/bir/library/subset1/http-client-v.txt
@@ -1,392 +1,405 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = newObject ballerina/http:Client
-    %2 = ConstantLoad https://example.com
-    %3 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %4 = init(%1,%2,%3) -> bb1;
+    %2 = newObject ballerina/http:Client
+    %3 = ConstantLoad https://example.com
+    %4 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %5 = init(%2,%3,%4) -> bb1;
   }
   bb1 {
-    %6 = %4 is nil
-    %6 ? bb2 : bb3;
+    %7 = %5 is nil
+    %7 ? bb2 : bb3;
   }
   bb2 {
-    %5 = %1;
+    %6 = %2;
     GOTO bb4;
   }
   bb3 {
-    %5 = %4;
+    %6 = %5;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %5;
-    %8 = $desugar$0 is error
+    %8 = %6 is error
     %8 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %6;
     return;
   }
   bb6 {
-    c1 = $desugar$0;
-    %10 = ConstantLoad /path
-    $desugar$1 = %10;
-    %12 = $default$21($desugar$1) -> bb7;
+    %1 = %6;
+    GOTO bb7;
   }
   bb7 {
-    $desugar$2 = %12;
-    %14 = ConstantLoad typedesc
-    $desugar$3 = %14;
-    %16 = $remote$get(c1,$desugar$1,$desugar$2,$desugar$3) -> bb8;
+    c1 = %1;
+    %10 = ConstantLoad /path
+    $desugar$0 = %10;
+    %12 = $default$21($desugar$0) -> bb8;
   }
   bb8 {
-    $desugar$4 = %16;
-    %18 = $desugar$4 is error
-    %18 ? bb9 : bb10;
+    $desugar$1 = %12;
+    %14 = ConstantLoad typedesc
+    $desugar$2 = %14;
+    %17 = $remote$get(c1,$desugar$0,$desugar$1,$desugar$2) -> bb9;
   }
   bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %18 = %17 is error
+    %18 ? bb10 : bb11;
   }
   bb10 {
-    r1 = $desugar$4;
+    %0 = %17;
+    return;
+  }
+  bb11 {
+    %16 = %17;
+    GOTO bb12;
+  }
+  bb12 {
+    r1 = %16;
     %21 = ConstantLoad statusCode
     %20 = r1[%21];
     %22 = %20;
-    %23 = println(%22) -> bb11;
-  }
-  bb11 {
-    %24 = newObject ballerina/http:Client
-    %25 = ConstantLoad https://example.com
-    %26 = ConstantLoad timeout
-    %27 = ConstantLoad 30
-    %28 = ConstantLoad followRedirects
-    %29 = ConstantLoad enabled
-    %30 = ConstantLoad false
-    %31 = newMap {| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}{%29=%30} defaults{enabled=ballerina/http:$desugar$10, maxCount=ballerina/http:$desugar$11, allowAuthHeaders=ballerina/http:$desugar$12}
-    %32 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%26=%27, %28=%31} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %33 = init(%24,%25,%32) -> bb12;
-  }
-  bb12 {
-    %35 = %33 is nil
-    %35 ? bb13 : bb14;
+    %23 = println(%22) -> bb13;
   }
   bb13 {
-    %34 = %24;
-    GOTO bb15;
+    %25 = newObject ballerina/http:Client
+    %26 = ConstantLoad https://example.com
+    %27 = ConstantLoad timeout
+    %28 = ConstantLoad 30
+    %29 = ConstantLoad followRedirects
+    %30 = ConstantLoad enabled
+    %31 = ConstantLoad false
+    %32 = newMap {| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}{%30=%31} defaults{enabled=ballerina/http:$desugar$10, maxCount=ballerina/http:$desugar$11, allowAuthHeaders=ballerina/http:$desugar$12}
+    %33 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%27=%28, %29=%32} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %34 = init(%25,%26,%33) -> bb14;
   }
   bb14 {
-    %34 = %33;
-    GOTO bb15;
+    %36 = %34 is nil
+    %36 ? bb15 : bb16;
   }
   bb15 {
-    $desugar$5 = %34;
-    %37 = $desugar$5 is error
-    %37 ? bb16 : bb17;
+    %35 = %25;
+    GOTO bb17;
   }
   bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %35 = %34;
+    GOTO bb17;
   }
   bb17 {
-    c2 = $desugar$5;
-    %39 = ConstantLoad /path
-    $desugar$6 = %39;
-    %41 = $default$21($desugar$6) -> bb18;
+    %37 = %35 is error
+    %37 ? bb18 : bb19;
   }
   bb18 {
-    $desugar$7 = %41;
-    %43 = ConstantLoad typedesc
-    $desugar$8 = %43;
-    %45 = $remote$get(c2,$desugar$6,$desugar$7,$desugar$8) -> bb19;
-  }
-  bb19 {
-    $desugar$9 = %45;
-    %47 = $desugar$9 is error
-    %47 ? bb20 : bb21;
-  }
-  bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %35;
     return;
   }
+  bb19 {
+    %24 = %35;
+    GOTO bb20;
+  }
+  bb20 {
+    c2 = %24;
+    %39 = ConstantLoad /path
+    $desugar$3 = %39;
+    %41 = $default$21($desugar$3) -> bb21;
+  }
   bb21 {
-    r2 = $desugar$9;
+    $desugar$4 = %41;
+    %43 = ConstantLoad typedesc
+    $desugar$5 = %43;
+    %46 = $remote$get(c2,$desugar$3,$desugar$4,$desugar$5) -> bb22;
+  }
+  bb22 {
+    %47 = %46 is error
+    %47 ? bb23 : bb24;
+  }
+  bb23 {
+    %0 = %46;
+    return;
+  }
+  bb24 {
+    %45 = %46;
+    GOTO bb25;
+  }
+  bb25 {
+    r2 = %45;
     %50 = ConstantLoad statusCode
     %49 = r2[%50];
     %51 = %49;
-    %52 = println(%51) -> bb22;
-  }
-  bb22 {
-    %53 = getTextPayload(r2) -> bb23;
-  }
-  bb23 {
-    $desugar$10 = %53;
-    %55 = $desugar$10 is error
-    %55 ? bb24 : bb25;
-  }
-  bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
-    return;
-  }
-  bb25 {
-    %56 = println($desugar$10) -> bb26;
+    %52 = println(%51) -> bb26;
   }
   bb26 {
-    %57 = ConstantLoad https://example.com
-    $desugar$11 = %57;
-    %59 = $default$15($desugar$11) -> bb27;
+    %54 = getTextPayload(r2) -> bb27;
   }
   bb27 {
-    $desugar$12 = %59;
-    %61 = newObject ballerina/http:Client
-    %62 = init(%61,$desugar$11,$desugar$12) -> bb28;
+    %55 = %54 is error
+    %55 ? bb28 : bb29;
   }
   bb28 {
-    %64 = %62 is nil
-    %64 ? bb29 : bb30;
+    %0 = %54;
+    return;
   }
   bb29 {
-    %63 = %61;
-    GOTO bb31;
+    %53 = %54;
+    GOTO bb30;
   }
   bb30 {
-    %63 = %62;
-    GOTO bb31;
+    %56 = println(%53) -> bb31;
   }
   bb31 {
-    $desugar$13 = %63;
-    %66 = $desugar$13 is error
-    %66 ? bb32 : bb33;
+    %57 = ConstantLoad https://example.com
+    $desugar$6 = %57;
+    %59 = $default$15($desugar$6) -> bb32;
   }
   bb32 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
-    return;
+    $desugar$7 = %59;
+    %62 = newObject ballerina/http:Client
+    %63 = init(%62,$desugar$6,$desugar$7) -> bb33;
   }
   bb33 {
-    c3 = $desugar$13;
-    %68 = ConstantLoad /path
-    $desugar$14 = %68;
-    %70 = $default$21($desugar$14) -> bb34;
+    %65 = %63 is nil
+    %65 ? bb34 : bb35;
   }
   bb34 {
-    $desugar$15 = %70;
-    %72 = ConstantLoad typedesc
-    $desugar$16 = %72;
-    %74 = $remote$get(c3,$desugar$14,$desugar$15,$desugar$16) -> bb35;
+    %64 = %62;
+    GOTO bb36;
   }
   bb35 {
-    $desugar$17 = %74;
-    %76 = $desugar$17 is error
-    %76 ? bb36 : bb37;
+    %64 = %63;
+    GOTO bb36;
   }
   bb36 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
-    return;
+    %66 = %64 is error
+    %66 ? bb37 : bb38;
   }
   bb37 {
-    r3 = $desugar$17;
+    %0 = %64;
+    return;
+  }
+  bb38 {
+    %61 = %64;
+    GOTO bb39;
+  }
+  bb39 {
+    c3 = %61;
+    %68 = ConstantLoad /path
+    $desugar$8 = %68;
+    %70 = $default$21($desugar$8) -> bb40;
+  }
+  bb40 {
+    $desugar$9 = %70;
+    %72 = ConstantLoad typedesc
+    $desugar$10 = %72;
+    %75 = $remote$get(c3,$desugar$8,$desugar$9,$desugar$10) -> bb41;
+  }
+  bb41 {
+    %76 = %75 is error
+    %76 ? bb42 : bb43;
+  }
+  bb42 {
+    %0 = %75;
+    return;
+  }
+  bb43 {
+    %74 = %75;
+    GOTO bb44;
+  }
+  bb44 {
+    r3 = %74;
     %79 = ConstantLoad statusCode
     %78 = r3[%79];
     %80 = %78;
-    %81 = println(%80) -> bb38;
-  }
-  bb38 {
-    %82 = ConstantLoad https://example.com
-    $desugar$18 = %82;
-    %84 = $default$15($desugar$18) -> bb39;
-  }
-  bb39 {
-    $desugar$19 = %84;
-    %86 = newObject ballerina/http:Client
-    %87 = init(%86,$desugar$18,$desugar$19) -> bb40;
-  }
-  bb40 {
-    %89 = %87 is nil
-    %89 ? bb41 : bb42;
-  }
-  bb41 {
-    %88 = %86;
-    GOTO bb43;
-  }
-  bb42 {
-    %88 = %87;
-    GOTO bb43;
-  }
-  bb43 {
-    $desugar$20 = %88;
-    %91 = $desugar$20 is error
-    %91 ? bb44 : bb45;
-  }
-  bb44 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
+    %81 = println(%80) -> bb45;
   }
   bb45 {
-    c4 = $desugar$20;
-    %93 = ConstantLoad /path
-    %94 = ConstantLoad X-Custom
-    %95 = ConstantLoad value
-    %96 = newMap {| string|[string...]... |}{%94=%95}
-    %97 = ConstantLoad typedesc
-    %98 = $remote$get(c4,%93,%96,%97) -> bb46;
+    %82 = ConstantLoad https://example.com
+    $desugar$11 = %82;
+    %84 = $default$15($desugar$11) -> bb46;
   }
   bb46 {
-    $desugar$21 = %98;
-    %100 = $desugar$21 is error
-    %100 ? bb47 : bb48;
+    $desugar$12 = %84;
+    %87 = newObject ballerina/http:Client
+    %88 = init(%87,$desugar$11,$desugar$12) -> bb47;
   }
   bb47 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$21);
-    PopScopeFrame
-    return;
+    %90 = %88 is nil
+    %90 ? bb48 : bb49;
   }
   bb48 {
-    r4 = $desugar$21;
-    %103 = ConstantLoad statusCode
-    %102 = r4[%103];
-    %104 = %102;
-    %105 = println(%104) -> bb49;
+    %89 = %87;
+    GOTO bb50;
   }
   bb49 {
-    %106 = newObject ballerina/http:Client
-    %107 = ConstantLoad https://example.com
-    %108 = ConstantLoad httpVersion
-    %109 = ConstantLoad 1.1
-    %110 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%108=%109} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %111 = init(%106,%107,%110) -> bb50;
+    %89 = %88;
+    GOTO bb50;
   }
   bb50 {
-    %113 = %111 is nil
-    %113 ? bb51 : bb52;
+    %91 = %89 is error
+    %91 ? bb51 : bb52;
   }
   bb51 {
-    %112 = %106;
-    GOTO bb53;
+    %0 = %89;
+    return;
   }
   bb52 {
-    %112 = %111;
+    %86 = %89;
     GOTO bb53;
   }
   bb53 {
-    $desugar$22 = %112;
-    %115 = $desugar$22 is error
-    %115 ? bb54 : bb55;
+    c4 = %86;
+    %94 = ConstantLoad /path
+    %95 = ConstantLoad X-Custom
+    %96 = ConstantLoad value
+    %97 = newMap {| string|[string...]... |}{%95=%96}
+    %98 = ConstantLoad typedesc
+    %99 = $remote$get(c4,%94,%97,%98) -> bb54;
   }
   bb54 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
-    return;
+    %100 = %99 is error
+    %100 ? bb55 : bb56;
   }
   bb55 {
-    c5 = $desugar$22;
-    %117 = ConstantLoad /path
-    $desugar$23 = %117;
-    %119 = $default$21($desugar$23) -> bb56;
-  }
-  bb56 {
-    $desugar$24 = %119;
-    %121 = ConstantLoad typedesc
-    $desugar$25 = %121;
-    %123 = $remote$get(c5,$desugar$23,$desugar$24,$desugar$25) -> bb57;
-  }
-  bb57 {
-    $desugar$26 = %123;
-    %125 = $desugar$26 is error
-    %125 ? bb58 : bb59;
-  }
-  bb58 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$26);
-    PopScopeFrame
+    %0 = %99;
     return;
   }
+  bb56 {
+    %93 = %99;
+    GOTO bb57;
+  }
+  bb57 {
+    r4 = %93;
+    %103 = ConstantLoad statusCode
+    %102 = r4[%103];
+    %104 = %102;
+    %105 = println(%104) -> bb58;
+  }
+  bb58 {
+    %107 = newObject ballerina/http:Client
+    %108 = ConstantLoad https://example.com
+    %109 = ConstantLoad httpVersion
+    %110 = ConstantLoad 1.1
+    %111 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%109=%110} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %112 = init(%107,%108,%111) -> bb59;
+  }
   bb59 {
-    r5 = $desugar$26;
+    %114 = %112 is nil
+    %114 ? bb60 : bb61;
+  }
+  bb60 {
+    %113 = %107;
+    GOTO bb62;
+  }
+  bb61 {
+    %113 = %112;
+    GOTO bb62;
+  }
+  bb62 {
+    %115 = %113 is error
+    %115 ? bb63 : bb64;
+  }
+  bb63 {
+    %0 = %113;
+    return;
+  }
+  bb64 {
+    %106 = %113;
+    GOTO bb65;
+  }
+  bb65 {
+    c5 = %106;
+    %117 = ConstantLoad /path
+    $desugar$13 = %117;
+    %119 = $default$21($desugar$13) -> bb66;
+  }
+  bb66 {
+    $desugar$14 = %119;
+    %121 = ConstantLoad typedesc
+    $desugar$15 = %121;
+    %124 = $remote$get(c5,$desugar$13,$desugar$14,$desugar$15) -> bb67;
+  }
+  bb67 {
+    %125 = %124 is error
+    %125 ? bb68 : bb69;
+  }
+  bb68 {
+    %0 = %124;
+    return;
+  }
+  bb69 {
+    %123 = %124;
+    GOTO bb70;
+  }
+  bb70 {
+    r5 = %123;
     %128 = ConstantLoad statusCode
     %127 = r5[%128];
     %129 = %127;
-    %130 = println(%129) -> bb60;
+    %130 = println(%129) -> bb71;
   }
-  bb60 {
-    %131 = newObject ballerina/http:Client
-    %132 = ConstantLoad https://example.com
-    %133 = ConstantLoad httpVersion
-    %134 = ConstantLoad 2.0
-    %135 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%133=%134} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %136 = init(%131,%132,%135) -> bb61;
+  bb71 {
+    %132 = newObject ballerina/http:Client
+    %133 = ConstantLoad https://example.com
+    %134 = ConstantLoad httpVersion
+    %135 = ConstantLoad 2.0
+    %136 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%134=%135} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %137 = init(%132,%133,%136) -> bb72;
   }
-  bb61 {
-    %138 = %136 is nil
-    %138 ? bb62 : bb63;
+  bb72 {
+    %139 = %137 is nil
+    %139 ? bb73 : bb74;
   }
-  bb62 {
-    %137 = %131;
-    GOTO bb64;
+  bb73 {
+    %138 = %132;
+    GOTO bb75;
   }
-  bb63 {
-    %137 = %136;
-    GOTO bb64;
+  bb74 {
+    %138 = %137;
+    GOTO bb75;
   }
-  bb64 {
-    $desugar$27 = %137;
-    %140 = $desugar$27 is error
-    %140 ? bb65 : bb66;
+  bb75 {
+    %140 = %138 is error
+    %140 ? bb76 : bb77;
   }
-  bb65 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$27);
-    PopScopeFrame
+  bb76 {
+    %0 = %138;
     return;
   }
-  bb66 {
-    c6 = $desugar$27;
+  bb77 {
+    %131 = %138;
+    GOTO bb78;
+  }
+  bb78 {
+    c6 = %131;
     %142 = ConstantLoad /path
-    $desugar$28 = %142;
-    %144 = $default$21($desugar$28) -> bb67;
+    $desugar$16 = %142;
+    %144 = $default$21($desugar$16) -> bb79;
   }
-  bb67 {
-    $desugar$29 = %144;
+  bb79 {
+    $desugar$17 = %144;
     %146 = ConstantLoad typedesc
-    $desugar$30 = %146;
-    %148 = $remote$get(c6,$desugar$28,$desugar$29,$desugar$30) -> bb68;
+    $desugar$18 = %146;
+    %149 = $remote$get(c6,$desugar$16,$desugar$17,$desugar$18) -> bb80;
   }
-  bb68 {
-    $desugar$31 = %148;
-    %150 = $desugar$31 is error
-    %150 ? bb69 : bb70;
+  bb80 {
+    %150 = %149 is error
+    %150 ? bb81 : bb82;
   }
-  bb69 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$31);
-    PopScopeFrame
+  bb81 {
+    %0 = %149;
     return;
   }
-  bb70 {
-    r6 = $desugar$31;
+  bb82 {
+    %148 = %149;
+    GOTO bb83;
+  }
+  bb83 {
+    r6 = %148;
     %153 = ConstantLoad statusCode
     %152 = r6[%153];
     %154 = %152;
-    %155 = println(%154) -> bb71;
+    %155 = println(%154) -> bb84;
   }
-  bb71 {
+  bb84 {
     %156 = ConstantLoad <nil>
     %0 = %156;
     return;

--- a/corpus/bir/library/subset2/civil-functions-v.txt
+++ b/corpus/bir/library/subset2/civil-functions-v.txt
@@ -18,40 +18,41 @@ main() -> nil|error{
     %11 = println(%10) -> bb3;
   }
   bb3 {
-    %12 = ConstantLoad 2024-06-15T10:30:45.00Z
-    %13 = utcFromString(%12) -> bb4;
+    %13 = ConstantLoad 2024-06-15T10:30:45.00Z
+    %14 = utcFromString(%13) -> bb4;
   }
   bb4 {
-    $desugar$0 = %13;
-    %15 = $desugar$0 is error
+    %15 = %14 is error
     %15 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %14;
     return;
   }
   bb6 {
-    base = $desugar$0;
-    %17 = ConstantLoad 3600.0
-    %18 = %17;
-    %19 = utcAddSeconds(base,%18) -> bb7;
+    %12 = %14;
+    GOTO bb7;
   }
   bb7 {
-    later = %19;
-    %21 = utcDiffSeconds(later,base) -> bb8;
+    base = %12;
+    %17 = ConstantLoad 3600.0
+    %18 = %17;
+    %19 = utcAddSeconds(base,%18) -> bb8;
   }
   bb8 {
+    later = %19;
+    %21 = utcDiffSeconds(later,base) -> bb9;
+  }
+  bb9 {
     diff = %21;
     %24 = diff;
     %25 = ConstantLoad 3600.0
     %26 = %25;
     %23 = == %24 %26;
     %27 = %23;
-    %28 = println(%27) -> bb9;
+    %28 = println(%27) -> bb10;
   }
-  bb9 {
+  bb10 {
     %29 = ConstantLoad year
     %30 = ConstantLoad 2024
     %31 = ConstantLoad month
@@ -59,15 +60,15 @@ main() -> nil|error{
     %33 = ConstantLoad day
     %34 = ConstantLoad 15
     %35 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, anydata... |}{%29=%30, %31=%32, %33=%34}
-    %36 = dateValidate(%35) -> bb10;
+    %36 = dateValidate(%35) -> bb11;
   }
-  bb10 {
+  bb11 {
     valid = %36;
     %38 = valid is nil
     %39 = %38;
-    %40 = println(%39) -> bb11;
+    %40 = println(%39) -> bb12;
   }
-  bb11 {
+  bb12 {
     %41 = ConstantLoad year
     %42 = ConstantLoad 2024
     %43 = ConstantLoad month
@@ -75,15 +76,15 @@ main() -> nil|error{
     %45 = ConstantLoad day
     %46 = ConstantLoad 1
     %47 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, anydata... |}{%41=%42, %43=%44, %45=%46}
-    %48 = dateValidate(%47) -> bb12;
+    %48 = dateValidate(%47) -> bb13;
   }
-  bb12 {
+  bb13 {
     invalid = %48;
     %50 = invalid is error
     %51 = %50;
-    %52 = println(%51) -> bb13;
+    %52 = println(%51) -> bb14;
   }
-  bb13 {
+  bb14 {
     %53 = ConstantLoad year
     %54 = ConstantLoad 2024
     %55 = ConstantLoad month
@@ -91,162 +92,167 @@ main() -> nil|error{
     %57 = ConstantLoad day
     %58 = ConstantLoad 15
     %59 = newMap {| day: int, hour: int, minute: int, month: int, second: decimal, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, year: int, anydata... |}{%53=%54, %55=%56, %57=%58}
-    %60 = dayOfWeek(%59) -> bb14;
+    %60 = dayOfWeek(%59) -> bb15;
   }
-  bb14 {
+  bb15 {
     dow = %60;
     %63 = dow;
     %64 = ConstantLoad 6
     %65 = %64;
     %62 = == %63 %65;
     %66 = %62;
-    %67 = println(%66) -> bb15;
-  }
-  bb15 {
-    %68 = utcToCivil(base) -> bb16;
+    %67 = println(%66) -> bb16;
   }
   bb16 {
+    %68 = utcToCivil(base) -> bb17;
+  }
+  bb17 {
     civil = %68;
     %71 = ConstantLoad year
     %70 = civil[%71];
     %72 = %70;
-    %73 = println(%72) -> bb17;
+    %73 = println(%72) -> bb18;
   }
-  bb17 {
+  bb18 {
     %75 = ConstantLoad month
     %74 = civil[%75];
     %76 = %74;
-    %77 = println(%76) -> bb18;
+    %77 = println(%76) -> bb19;
   }
-  bb18 {
+  bb19 {
     %79 = ConstantLoad day
     %78 = civil[%79];
     %80 = %78;
-    %81 = println(%80) -> bb19;
-  }
-  bb19 {
-    %82 = newObject ballerina/time:TimeZone
-    %83 = ConstantLoad +05:30
-    %84 = init(%82,%83) -> bb20;
+    %81 = println(%80) -> bb20;
   }
   bb20 {
-    %86 = %84 is nil
-    %86 ? bb21 : bb22;
+    %83 = newObject ballerina/time:TimeZone
+    %84 = ConstantLoad +05:30
+    %85 = init(%83,%84) -> bb21;
   }
   bb21 {
-    %85 = %82;
-    GOTO bb23;
+    %87 = %85 is nil
+    %87 ? bb22 : bb23;
   }
   bb22 {
-    %85 = %84;
-    GOTO bb23;
+    %86 = %83;
+    GOTO bb24;
   }
   bb23 {
-    $desugar$1 = %85;
-    %88 = $desugar$1 is error
-    %88 ? bb24 : bb25;
+    %86 = %85;
+    GOTO bb24;
   }
   bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %88 = %86 is error
+    %88 ? bb25 : bb26;
   }
   bb25 {
-    tz = $desugar$1;
-    %90 = ConstantLoad 2021-04-12T17:50:50.00Z
-    %91 = utcFromString(%90) -> bb26;
+    %0 = %86;
+    return;
   }
   bb26 {
-    $desugar$2 = %91;
-    %93 = $desugar$2 is error
-    %93 ? bb27 : bb28;
+    %82 = %86;
+    GOTO bb27;
   }
   bb27 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    tz = %82;
+    %91 = ConstantLoad 2021-04-12T17:50:50.00Z
+    %92 = utcFromString(%91) -> bb28;
   }
   bb28 {
-    utcBase = $desugar$2;
-    %95 = utcToCivil(tz,utcBase) -> bb29;
+    %93 = %92 is error
+    %93 ? bb29 : bb30;
   }
   bb29 {
-    civilOffset = %95;
-    %97 = utcFromCivil(tz,civilOffset) -> bb30;
+    %0 = %92;
+    return;
   }
   bb30 {
-    $desugar$3 = %97;
-    %99 = $desugar$3 is error
-    %99 ? bb31 : bb32;
+    %90 = %92;
+    GOTO bb31;
   }
   bb31 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    utcBase = %90;
+    %95 = utcToCivil(tz,utcBase) -> bb32;
   }
   bb32 {
-    roundTripped = $desugar$3;
-    %101 = utcToString(roundTripped) -> bb33;
+    civilOffset = %95;
+    %98 = utcFromCivil(tz,civilOffset) -> bb33;
   }
   bb33 {
-    %102 = println(%101) -> bb34;
+    %99 = %98 is error
+    %99 ? bb34 : bb35;
   }
   bb34 {
-    %103 = civilToString(civilOffset) -> bb35;
-  }
-  bb35 {
-    $desugar$4 = %103;
-    %105 = $desugar$4 is error
-    %105 ? bb36 : bb37;
-  }
-  bb36 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %98;
     return;
   }
+  bb35 {
+    %97 = %98;
+    GOTO bb36;
+  }
+  bb36 {
+    roundTripped = %97;
+    %101 = utcToString(roundTripped) -> bb37;
+  }
   bb37 {
-    civilStr = $desugar$4;
-    %107 = println(civilStr) -> bb38;
+    %102 = println(%101) -> bb38;
   }
   bb38 {
-    %108 = ConstantLoad 2021-04-12T23:20:50.520+05:30[Asia/Colombo]
-    %109 = civilFromString(%108) -> bb39;
+    %104 = civilToString(civilOffset) -> bb39;
   }
   bb39 {
-    $desugar$5 = %109;
-    %111 = $desugar$5 is error
-    %111 ? bb40 : bb41;
+    %105 = %104 is error
+    %105 ? bb40 : bb41;
   }
   bb40 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %104;
     return;
   }
   bb41 {
-    parsed = $desugar$5;
+    %103 = %104;
+    GOTO bb42;
+  }
+  bb42 {
+    civilStr = %103;
+    %107 = println(civilStr) -> bb43;
+  }
+  bb43 {
+    %109 = ConstantLoad 2021-04-12T23:20:50.520+05:30[Asia/Colombo]
+    %110 = civilFromString(%109) -> bb44;
+  }
+  bb44 {
+    %111 = %110 is error
+    %111 ? bb45 : bb46;
+  }
+  bb45 {
+    %0 = %110;
+    return;
+  }
+  bb46 {
+    %108 = %110;
+    GOTO bb47;
+  }
+  bb47 {
+    parsed = %108;
     %114 = ConstantLoad year
     %113 = parsed[%114];
     %115 = %113;
-    %116 = println(%115) -> bb42;
+    %116 = println(%115) -> bb48;
   }
-  bb42 {
+  bb48 {
     %118 = ConstantLoad month
     %117 = parsed[%118];
     %119 = %117;
-    %120 = println(%119) -> bb43;
+    %120 = println(%119) -> bb49;
   }
-  bb43 {
+  bb49 {
     %122 = ConstantLoad day
     %121 = parsed[%122];
     %123 = %121;
-    %124 = println(%123) -> bb44;
+    %124 = println(%123) -> bb50;
   }
-  bb44 {
+  bb50 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/civil-iana-zone-v.txt
+++ b/corpus/bir/library/subset2/civil-iana-zone-v.txt
@@ -1,57 +1,58 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 2021-04-12T23:20:50.520+05:30[Asia/Colombo]
-    %2 = civilFromString(%1) -> bb1;
+    %2 = ConstantLoad 2021-04-12T23:20:50.520+05:30[Asia/Colombo]
+    %3 = civilFromString(%2) -> bb1;
   }
   bb1 {
-    $desugar$0 = %2;
-    %4 = $desugar$0 is error
+    %4 = %3 is error
     %4 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %3;
     return;
   }
   bb3 {
-    c = $desugar$0;
+    %1 = %3;
+    GOTO bb4;
+  }
+  bb4 {
+    c = %1;
     %7 = ConstantLoad year
     %6 = c[%7];
     %8 = %6;
-    %9 = println(%8) -> bb4;
+    %9 = println(%8) -> bb5;
   }
-  bb4 {
+  bb5 {
     %11 = ConstantLoad month
     %10 = c[%11];
     %12 = %10;
-    %13 = println(%12) -> bb5;
+    %13 = println(%12) -> bb6;
   }
-  bb5 {
+  bb6 {
     %15 = ConstantLoad day
     %14 = c[%15];
     %16 = %14;
-    %17 = println(%16) -> bb6;
+    %17 = println(%16) -> bb7;
   }
-  bb6 {
+  bb7 {
     %19 = ConstantLoad hour
     %18 = c[%19];
     %20 = %18;
-    %21 = println(%20) -> bb7;
+    %21 = println(%20) -> bb8;
   }
-  bb7 {
+  bb8 {
     %23 = ConstantLoad minute
     %22 = c[%23];
     %24 = %22;
-    %25 = println(%24) -> bb8;
-  }
-  bb8 {
-    %27 = ConstantLoad timeAbbrev
-    %26 = c[%27];
-    %28 = println(%26) -> bb9;
+    %25 = println(%24) -> bb9;
   }
   bb9 {
+    %27 = ConstantLoad timeAbbrev
+    %26 = c[%27];
+    %28 = println(%26) -> bb10;
+  }
+  bb10 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/civil-zone-handling-v.txt
+++ b/corpus/bir/library/subset2/civil-zone-handling-v.txt
@@ -1,105 +1,108 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad year
-    %2 = ConstantLoad 2021
-    %3 = ConstantLoad month
-    %4 = ConstantLoad 4
-    %5 = ConstantLoad day
-    %6 = ConstantLoad 12
-    %7 = ConstantLoad hour
-    %8 = ConstantLoad 23
-    %9 = ConstantLoad minute
-    %10 = ConstantLoad 20
-    %11 = ConstantLoad second
-    %12 = ConstantLoad 50
-    %13 = ConstantLoad timeAbbrev
-    %14 = ConstantLoad Asia/Colombo
-    %15 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%1=%2, %3=%4, %5=%6, %7=%8, %9=%10, %11=%12, %13=%14}
-    %16 = civilToString(%15) -> bb1;
+    %2 = ConstantLoad year
+    %3 = ConstantLoad 2021
+    %4 = ConstantLoad month
+    %5 = ConstantLoad 4
+    %6 = ConstantLoad day
+    %7 = ConstantLoad 12
+    %8 = ConstantLoad hour
+    %9 = ConstantLoad 23
+    %10 = ConstantLoad minute
+    %11 = ConstantLoad 20
+    %12 = ConstantLoad second
+    %13 = ConstantLoad 50
+    %14 = ConstantLoad timeAbbrev
+    %15 = ConstantLoad Asia/Colombo
+    %16 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%2=%3, %4=%5, %6=%7, %8=%9, %10=%11, %12=%13, %14=%15}
+    %17 = civilToString(%16) -> bb1;
   }
   bb1 {
-    $desugar$0 = %16;
-    %18 = $desugar$0 is error
+    %18 = %17 is error
     %18 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %17;
     return;
   }
   bb3 {
-    named = $desugar$0;
-    %20 = println(named) -> bb4;
+    %1 = %17;
+    GOTO bb4;
   }
   bb4 {
-    %21 = ConstantLoad year
-    %22 = ConstantLoad 2021
-    %23 = ConstantLoad month
-    %24 = ConstantLoad 4
-    %25 = ConstantLoad day
-    %26 = ConstantLoad 12
-    %27 = ConstantLoad hour
-    %28 = ConstantLoad 23
-    %29 = ConstantLoad minute
-    %30 = ConstantLoad 20
-    %31 = ConstantLoad second
-    %32 = ConstantLoad 50
-    %33 = ConstantLoad timeAbbrev
-    %34 = ConstantLoad +05:30
-    %35 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%21=%22, %23=%24, %25=%26, %27=%28, %29=%30, %31=%32, %33=%34}
-    %36 = civilToString(%35) -> bb5;
+    named = %1;
+    %20 = println(named) -> bb5;
   }
   bb5 {
-    $desugar$1 = %36;
-    %38 = $desugar$1 is error
-    %38 ? bb6 : bb7;
+    %22 = ConstantLoad year
+    %23 = ConstantLoad 2021
+    %24 = ConstantLoad month
+    %25 = ConstantLoad 4
+    %26 = ConstantLoad day
+    %27 = ConstantLoad 12
+    %28 = ConstantLoad hour
+    %29 = ConstantLoad 23
+    %30 = ConstantLoad minute
+    %31 = ConstantLoad 20
+    %32 = ConstantLoad second
+    %33 = ConstantLoad 50
+    %34 = ConstantLoad timeAbbrev
+    %35 = ConstantLoad +05:30
+    %36 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%22=%23, %24=%25, %26=%27, %28=%29, %30=%31, %32=%33, %34=%35}
+    %37 = civilToString(%36) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %38 = %37 is error
+    %38 ? bb7 : bb8;
   }
   bb7 {
-    numeric = $desugar$1;
-    %40 = println(numeric) -> bb8;
-  }
-  bb8 {
-    %41 = ConstantLoad year
-    %42 = ConstantLoad 2021
-    %43 = ConstantLoad month
-    %44 = ConstantLoad 4
-    %45 = ConstantLoad day
-    %46 = ConstantLoad 12
-    %47 = ConstantLoad hour
-    %48 = ConstantLoad 17
-    %49 = ConstantLoad minute
-    %50 = ConstantLoad 50
-    %51 = ConstantLoad second
-    %52 = ConstantLoad 50
-    %53 = ConstantLoad timeAbbrev
-    %54 = ConstantLoad Z
-    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%41=%42, %43=%44, %45=%46, %47=%48, %49=%50, %51=%52, %53=%54}
-    %56 = civilToString(%55) -> bb9;
-  }
-  bb9 {
-    $desugar$2 = %56;
-    %58 = $desugar$2 is error
-    %58 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %37;
     return;
   }
+  bb8 {
+    %21 = %37;
+    GOTO bb9;
+  }
+  bb9 {
+    numeric = %21;
+    %40 = println(numeric) -> bb10;
+  }
+  bb10 {
+    %42 = ConstantLoad year
+    %43 = ConstantLoad 2021
+    %44 = ConstantLoad month
+    %45 = ConstantLoad 4
+    %46 = ConstantLoad day
+    %47 = ConstantLoad 12
+    %48 = ConstantLoad hour
+    %49 = ConstantLoad 17
+    %50 = ConstantLoad minute
+    %51 = ConstantLoad 50
+    %52 = ConstantLoad second
+    %53 = ConstantLoad 50
+    %54 = ConstantLoad timeAbbrev
+    %55 = ConstantLoad Z
+    %56 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%42=%43, %44=%45, %46=%47, %48=%49, %50=%51, %52=%53, %54=%55}
+    %57 = civilToString(%56) -> bb11;
+  }
   bb11 {
-    utc = $desugar$2;
-    %60 = println(utc) -> bb12;
+    %58 = %57 is error
+    %58 ? bb12 : bb13;
   }
   bb12 {
+    %0 = %57;
+    return;
+  }
+  bb13 {
+    %41 = %57;
+    GOTO bb14;
+  }
+  bb14 {
+    utc = %41;
+    %60 = println(utc) -> bb15;
+  }
+  bb15 {
     %61 = ConstantLoad year
     %62 = ConstantLoad 2021
     %63 = ConstantLoad month
@@ -111,162 +114,165 @@ main() -> nil|error{
     %69 = ConstantLoad minute
     %70 = ConstantLoad 50
     %71 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%61=%62, %63=%64, %65=%66, %67=%68, %69=%70}
-    %72 = civilToString(%71) -> bb13;
+    %72 = civilToString(%71) -> bb16;
   }
-  bb13 {
+  bb16 {
     noZone = %72;
     %74 = noZone is error
     %75 = %74;
-    %76 = println(%75) -> bb14;
-  }
-  bb14 {
-    %77 = ConstantLoad year
-    %78 = ConstantLoad 2021
-    %79 = ConstantLoad month
-    %80 = ConstantLoad 4
-    %81 = ConstantLoad day
-    %82 = ConstantLoad 12
-    %83 = ConstantLoad hour
-    %84 = ConstantLoad 23
-    %85 = ConstantLoad minute
-    %86 = ConstantLoad 20
-    %87 = ConstantLoad second
-    %88 = ConstantLoad 50
-    %89 = ConstantLoad utcOffset
-    %90 = ConstantLoad hours
-    %91 = ConstantLoad 5
-    %92 = ConstantLoad minutes
-    %93 = ConstantLoad 30
-    %94 = ConstantLoad seconds
-    %95 = ConstantLoad 30
-    %96 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%90=%91, %92=%93, %94=%95} defaults{minutes=ballerina/time:$desugar$0}
-    %97 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%77=%78, %79=%80, %81=%82, %83=%84, %85=%86, %87=%88, %89=%96}
-    %98 = civilToString(%97) -> bb15;
-  }
-  bb15 {
-    $desugar$3 = %98;
-    %100 = $desugar$3 is error
-    %100 ? bb16 : bb17;
-  }
-  bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %76 = println(%75) -> bb17;
   }
   bb17 {
-    withSeconds = $desugar$3;
-    %102 = println(withSeconds) -> bb18;
+    %78 = ConstantLoad year
+    %79 = ConstantLoad 2021
+    %80 = ConstantLoad month
+    %81 = ConstantLoad 4
+    %82 = ConstantLoad day
+    %83 = ConstantLoad 12
+    %84 = ConstantLoad hour
+    %85 = ConstantLoad 23
+    %86 = ConstantLoad minute
+    %87 = ConstantLoad 20
+    %88 = ConstantLoad second
+    %89 = ConstantLoad 50
+    %90 = ConstantLoad utcOffset
+    %91 = ConstantLoad hours
+    %92 = ConstantLoad 5
+    %93 = ConstantLoad minutes
+    %94 = ConstantLoad 30
+    %95 = ConstantLoad seconds
+    %96 = ConstantLoad 30
+    %97 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%91=%92, %93=%94, %95=%96} defaults{minutes=ballerina/time:$desugar$0}
+    %98 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%78=%79, %80=%81, %82=%83, %84=%85, %86=%87, %88=%89, %90=%97}
+    %99 = civilToString(%98) -> bb18;
   }
   bb18 {
-    %103 = newObject ballerina/time:TimeZone
-    %104 = ConstantLoad -05:00
-    %105 = init(%103,%104) -> bb19;
+    %100 = %99 is error
+    %100 ? bb19 : bb20;
   }
   bb19 {
-    %107 = %105 is nil
-    %107 ? bb20 : bb21;
-  }
-  bb20 {
-    %106 = %103;
-    GOTO bb22;
-  }
-  bb21 {
-    %106 = %105;
-    GOTO bb22;
-  }
-  bb22 {
-    $desugar$4 = %106;
-    %109 = $desugar$4 is error
-    %109 ? bb23 : bb24;
-  }
-  bb23 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %99;
     return;
   }
+  bb20 {
+    %77 = %99;
+    GOTO bb21;
+  }
+  bb21 {
+    withSeconds = %77;
+    %102 = println(withSeconds) -> bb22;
+  }
+  bb22 {
+    %104 = newObject ballerina/time:TimeZone
+    %105 = ConstantLoad -05:00
+    %106 = init(%104,%105) -> bb23;
+  }
+  bb23 {
+    %108 = %106 is nil
+    %108 ? bb24 : bb25;
+  }
   bb24 {
-    west = $desugar$4;
-    %111 = fixedOffset(west) -> bb25;
+    %107 = %104;
+    GOTO bb26;
   }
   bb25 {
-    westOffset = %111;
-    %113 = westOffset !is nil
-    %113 ? bb26 : bb29;
+    %107 = %106;
+    GOTO bb26;
   }
   bb26 {
+    %109 = %107 is error
+    %109 ? bb27 : bb28;
+  }
+  bb27 {
+    %0 = %107;
+    return;
+  }
+  bb28 {
+    %103 = %107;
+    GOTO bb29;
+  }
+  bb29 {
+    west = %103;
+    %111 = fixedOffset(west) -> bb30;
+  }
+  bb30 {
+    westOffset = %111;
+    %113 = westOffset !is nil
+    %113 ? bb31 : bb34;
+  }
+  bb31 {
     PushScopeFrame 8
     %1 = ConstantLoad hours
     %0 = (1, westOffset)[%1];
     %2 = %0;
-    %3 = println(%2) -> bb27;
+    %3 = println(%2) -> bb32;
   }
-  bb27 {
+  bb32 {
     %5 = ConstantLoad minutes
     %4 = (1, westOffset)[%5];
     %6 = %4;
-    %7 = println(%6) -> bb28;
+    %7 = println(%6) -> bb33;
   }
-  bb28 {
+  bb33 {
     PopScopeFrame
-    GOTO bb29;
+    GOTO bb34;
   }
-  bb29 {
+  bb34 {
     PushScopeFrame 87
     %0 = newObject ballerina/time:TimeZone
     %1 = ConstantLoad +25:00
-    %2 = init(%0,%1) -> bb30;
-  }
-  bb30 {
-    %4 = %2 is nil
-    %4 ? bb31 : bb32;
-  }
-  bb31 {
-    %3 = %0;
-    GOTO bb33;
-  }
-  bb32 {
-    %3 = %2;
-    GOTO bb33;
-  }
-  bb33 {
-    tooBig = %3;
-    %6 = tooBig is error
-    %7 = %6;
-    %8 = println(%7) -> bb34;
-  }
-  bb34 {
-    %9 = newObject ballerina/time:TimeZone
-    %10 = ConstantLoad UTC
-    %11 = init(%9,%10) -> bb35;
+    %2 = init(%0,%1) -> bb35;
   }
   bb35 {
-    %13 = %11 is nil
-    %13 ? bb36 : bb37;
+    %4 = %2 is nil
+    %4 ? bb36 : bb37;
   }
   bb36 {
-    %12 = %9;
+    %3 = %0;
     GOTO bb38;
   }
   bb37 {
-    %12 = %11;
+    %3 = %2;
     GOTO bb38;
   }
   bb38 {
-    $desugar$5 = %12;
-    %15 = $desugar$5 is error
-    %15 ? bb39 : bb40;
+    tooBig = %3;
+    %6 = tooBig is error
+    %7 = %6;
+    %8 = println(%7) -> bb39;
   }
   bb39 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %10 = newObject ballerina/time:TimeZone
+    %11 = ConstantLoad UTC
+    %12 = init(%10,%11) -> bb40;
+  }
+  bb40 {
+    %14 = %12 is nil
+    %14 ? bb41 : bb42;
+  }
+  bb41 {
+    %13 = %10;
+    GOTO bb43;
+  }
+  bb42 {
+    %13 = %12;
+    GOTO bb43;
+  }
+  bb43 {
+    %15 = %13 is error
+    %15 ? bb44 : bb45;
+  }
+  bb44 {
+    (1, %0) = %13;
     PopScopeFrame
     return;
   }
-  bb40 {
-    utcZone = $desugar$5;
+  bb45 {
+    %9 = %13;
+    GOTO bb46;
+  }
+  bb46 {
+    utcZone = %9;
     %17 = ConstantLoad year
     %18 = ConstantLoad 2021
     %19 = ConstantLoad month
@@ -280,95 +286,97 @@ main() -> nil|error{
     %27 = ConstantLoad timeAbbrev
     %28 = ConstantLoad Z
     %29 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%17=%18, %19=%20, %21=%22, %23=%24, %25=%26, %27=%28}
-    %30 = utcFromCivil(utcZone,%29) -> bb41;
+    %30 = utcFromCivil(utcZone,%29) -> bb47;
   }
-  bb41 {
+  bb47 {
     invalidDate = %30;
     %32 = invalidDate is error
     %33 = %32;
-    %34 = println(%33) -> bb42;
-  }
-  bb42 {
-    %35 = ConstantLoad year
-    %36 = ConstantLoad 2024
-    %37 = ConstantLoad month
-    %38 = ConstantLoad 6
-    %39 = ConstantLoad day
-    %40 = ConstantLoad 15
-    %41 = ConstantLoad hour
-    %42 = ConstantLoad 10
-    %43 = ConstantLoad minute
-    %44 = ConstantLoad 30
-    %45 = ConstantLoad second
-    %46 = ConstantLoad 45
-    %47 = ConstantLoad utcOffset
-    %48 = ConstantLoad hours
-    %49 = ConstantLoad 0
-    %50 = ConstantLoad minutes
-    %51 = ConstantLoad 0
-    %52 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%48=%49, %50=%51} defaults{minutes=ballerina/time:$desugar$0}
-    %53 = ConstantLoad timeAbbrev
-    %54 = ConstantLoad GMT
-    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%35=%36, %37=%38, %39=%40, %41=%42, %43=%44, %45=%46, %47=%52, %53=%54}
-    %56 = ConstantLoad ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT
-    %57 = civilToEmailString(%55,%56) -> bb43;
-  }
-  bb43 {
-    $desugar$6 = %57;
-    %59 = $desugar$6 is error
-    %59 ? bb44 : bb45;
-  }
-  bb44 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$6);
-    PopScopeFrame
-    PopScopeFrame
-    return;
-  }
-  bb45 {
-    emailComment = $desugar$6;
-    %61 = println(emailComment) -> bb46;
-  }
-  bb46 {
-    %62 = ConstantLoad year
-    %63 = ConstantLoad 2024
-    %64 = ConstantLoad month
-    %65 = ConstantLoad 6
-    %66 = ConstantLoad day
-    %67 = ConstantLoad 15
-    %68 = ConstantLoad hour
-    %69 = ConstantLoad 10
-    %70 = ConstantLoad minute
-    %71 = ConstantLoad 30
-    %72 = ConstantLoad second
-    %73 = ConstantLoad 45
-    %74 = ConstantLoad utcOffset
-    %75 = ConstantLoad hours
-    %76 = ConstantLoad 0
-    %77 = ConstantLoad minutes
-    %78 = ConstantLoad 0
-    %79 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%75=%76, %77=%78} defaults{minutes=ballerina/time:$desugar$0}
-    %80 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%62=%63, %64=%65, %66=%67, %68=%69, %70=%71, %72=%73, %74=%79}
-    %81 = ConstantLoad ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT
-    %82 = civilToEmailString(%80,%81) -> bb47;
-  }
-  bb47 {
-    $desugar$7 = %82;
-    %84 = $desugar$7 is error
-    %84 ? bb48 : bb49;
+    %34 = println(%33) -> bb48;
   }
   bb48 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$7);
-    PopScopeFrame
+    %36 = ConstantLoad year
+    %37 = ConstantLoad 2024
+    %38 = ConstantLoad month
+    %39 = ConstantLoad 6
+    %40 = ConstantLoad day
+    %41 = ConstantLoad 15
+    %42 = ConstantLoad hour
+    %43 = ConstantLoad 10
+    %44 = ConstantLoad minute
+    %45 = ConstantLoad 30
+    %46 = ConstantLoad second
+    %47 = ConstantLoad 45
+    %48 = ConstantLoad utcOffset
+    %49 = ConstantLoad hours
+    %50 = ConstantLoad 0
+    %51 = ConstantLoad minutes
+    %52 = ConstantLoad 0
+    %53 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%49=%50, %51=%52} defaults{minutes=ballerina/time:$desugar$0}
+    %54 = ConstantLoad timeAbbrev
+    %55 = ConstantLoad GMT
+    %56 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%36=%37, %38=%39, %40=%41, %42=%43, %44=%45, %46=%47, %48=%53, %54=%55}
+    %57 = ConstantLoad ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT
+    %58 = civilToEmailString(%56,%57) -> bb49;
+  }
+  bb49 {
+    %59 = %58 is error
+    %59 ? bb50 : bb51;
+  }
+  bb50 {
+    (1, %0) = %58;
     PopScopeFrame
     return;
   }
-  bb49 {
-    noAbbrev = $desugar$7;
-    %86 = println(noAbbrev) -> bb50;
+  bb51 {
+    %35 = %58;
+    GOTO bb52;
   }
-  bb50 {
+  bb52 {
+    emailComment = %35;
+    %61 = println(emailComment) -> bb53;
+  }
+  bb53 {
+    %63 = ConstantLoad year
+    %64 = ConstantLoad 2024
+    %65 = ConstantLoad month
+    %66 = ConstantLoad 6
+    %67 = ConstantLoad day
+    %68 = ConstantLoad 15
+    %69 = ConstantLoad hour
+    %70 = ConstantLoad 10
+    %71 = ConstantLoad minute
+    %72 = ConstantLoad 30
+    %73 = ConstantLoad second
+    %74 = ConstantLoad 45
+    %75 = ConstantLoad utcOffset
+    %76 = ConstantLoad hours
+    %77 = ConstantLoad 0
+    %78 = ConstantLoad minutes
+    %79 = ConstantLoad 0
+    %80 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%76=%77, %78=%79} defaults{minutes=ballerina/time:$desugar$0}
+    %81 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%63=%64, %65=%66, %67=%68, %69=%70, %71=%72, %73=%74, %75=%80}
+    %82 = ConstantLoad ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT
+    %83 = civilToEmailString(%81,%82) -> bb54;
+  }
+  bb54 {
+    %84 = %83 is error
+    %84 ? bb55 : bb56;
+  }
+  bb55 {
+    (1, %0) = %83;
+    PopScopeFrame
+    return;
+  }
+  bb56 {
+    %62 = %83;
+    GOTO bb57;
+  }
+  bb57 {
+    noAbbrev = %62;
+    %86 = println(noAbbrev) -> bb58;
+  }
+  bb58 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset2/crypto-aes1-v.txt
+++ b/corpus/bir/library/subset2/crypto-aes1-v.txt
@@ -74,204 +74,212 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$3 = %70;
-    %72 = encryptAesCbc($desugar$0,$desugar$1,$desugar$2,$desugar$3) -> bb2;
+    %73 = encryptAesCbc($desugar$0,$desugar$1,$desugar$2,$desugar$3) -> bb2;
   }
   bb2 {
-    $desugar$4 = %72;
-    %74 = $desugar$4 is error
+    %74 = %73 is error
     %74 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %73;
     return;
   }
   bb4 {
-    cbc = $desugar$4;
-    %77 = length(cbc) -> bb5;
+    %72 = %73;
+    GOTO bb5;
   }
   bb5 {
-    %78 = %77;
-    %79 = length(plaintext) -> bb6;
+    cbc = %72;
+    %77 = length(cbc) -> bb6;
   }
   bb6 {
+    %78 = %77;
+    %79 = length(plaintext) -> bb7;
+  }
+  bb7 {
     %80 = %79;
     %76 = > %78 %80;
     %81 = %76;
-    %82 = println(%81) -> bb7;
-  }
-  bb7 {
-    $desugar$5 = cbc;
-    $desugar$6 = key;
-    $desugar$7 = iv;
-    %86 = $default$23($desugar$5,$desugar$6,$desugar$7) -> bb8;
+    %82 = println(%81) -> bb8;
   }
   bb8 {
-    $desugar$8 = %86;
-    %88 = decryptAesCbc($desugar$5,$desugar$6,$desugar$7,$desugar$8) -> bb9;
+    $desugar$4 = cbc;
+    $desugar$5 = key;
+    $desugar$6 = iv;
+    %86 = $default$23($desugar$4,$desugar$5,$desugar$6) -> bb9;
   }
   bb9 {
-    $desugar$9 = %88;
-    %90 = $desugar$9 is error
-    %90 ? bb10 : bb11;
+    $desugar$7 = %86;
+    %90 = decryptAesCbc($desugar$4,$desugar$5,$desugar$6,$desugar$7) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
-    return;
+    %91 = %90 is error
+    %91 ? bb11 : bb12;
   }
   bb11 {
-    %91 = == $desugar$9 plaintext;
-    %92 = %91;
-    %93 = println(%92) -> bb12;
+    %0 = %90;
+    return;
   }
   bb12 {
-    $desugar$10 = plaintext;
-    $desugar$11 = key;
-    %96 = $default$19($desugar$10,$desugar$11) -> bb13;
+    %89 = %90;
+    GOTO bb13;
   }
   bb13 {
-    $desugar$12 = %96;
-    %98 = encryptAesEcb($desugar$10,$desugar$11,$desugar$12) -> bb14;
+    %88 = == %89 plaintext;
+    %92 = %88;
+    %93 = println(%92) -> bb14;
   }
   bb14 {
-    $desugar$13 = %98;
-    %100 = $desugar$13 is error
-    %100 ? bb15 : bb16;
+    $desugar$8 = plaintext;
+    $desugar$9 = key;
+    %96 = $default$19($desugar$8,$desugar$9) -> bb15;
   }
   bb15 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
-    return;
+    $desugar$10 = %96;
+    %99 = encryptAesEcb($desugar$8,$desugar$9,$desugar$10) -> bb16;
   }
   bb16 {
-    ecb = $desugar$13;
-    $desugar$14 = ecb;
-    $desugar$15 = key;
-    %104 = $default$24($desugar$14,$desugar$15) -> bb17;
+    %100 = %99 is error
+    %100 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$16 = %104;
-    %106 = decryptAesEcb($desugar$14,$desugar$15,$desugar$16) -> bb18;
+    %0 = %99;
+    return;
   }
   bb18 {
-    $desugar$17 = %106;
-    %108 = $desugar$17 is error
-    %108 ? bb19 : bb20;
+    %98 = %99;
+    GOTO bb19;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
-    return;
+    ecb = %98;
+    $desugar$11 = ecb;
+    $desugar$12 = key;
+    %104 = $default$24($desugar$11,$desugar$12) -> bb20;
   }
   bb20 {
-    %109 = == $desugar$17 plaintext;
-    %110 = %109;
-    %111 = println(%110) -> bb21;
+    $desugar$13 = %104;
+    %108 = decryptAesEcb($desugar$11,$desugar$12,$desugar$13) -> bb21;
   }
   bb21 {
-    $desugar$18 = plaintext;
-    $desugar$19 = key;
-    $desugar$20 = iv12;
-    %115 = $default$20($desugar$18,$desugar$19,$desugar$20) -> bb22;
+    %109 = %108 is error
+    %109 ? bb22 : bb23;
   }
   bb22 {
-    $desugar$21 = %115;
-    %117 = $default$21($desugar$18,$desugar$19,$desugar$20,$desugar$21) -> bb23;
+    %0 = %108;
+    return;
   }
   bb23 {
-    $desugar$22 = %117;
-    %119 = $desugar$22;
-    %120 = encryptAesGcm($desugar$18,$desugar$19,$desugar$20,$desugar$21,%119) -> bb24;
+    %107 = %108;
+    GOTO bb24;
   }
   bb24 {
-    $desugar$23 = %120;
-    %122 = $desugar$23 is error
-    %122 ? bb25 : bb26;
+    %106 = == %107 plaintext;
+    %110 = %106;
+    %111 = println(%110) -> bb25;
   }
   bb25 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$23);
-    PopScopeFrame
-    return;
+    $desugar$14 = plaintext;
+    $desugar$15 = key;
+    $desugar$16 = iv12;
+    %115 = $default$20($desugar$14,$desugar$15,$desugar$16) -> bb26;
   }
   bb26 {
-    gcm = $desugar$23;
-    $desugar$24 = gcm;
-    $desugar$25 = key;
-    $desugar$26 = iv12;
-    %127 = $default$25($desugar$24,$desugar$25,$desugar$26) -> bb27;
+    $desugar$17 = %115;
+    %117 = $default$21($desugar$14,$desugar$15,$desugar$16,$desugar$17) -> bb27;
   }
   bb27 {
-    $desugar$27 = %127;
-    %129 = $default$26($desugar$24,$desugar$25,$desugar$26,$desugar$27) -> bb28;
+    $desugar$18 = %117;
+    %120 = $desugar$18;
+    %121 = encryptAesGcm($desugar$14,$desugar$15,$desugar$16,$desugar$17,%120) -> bb28;
   }
   bb28 {
-    $desugar$28 = %129;
-    %131 = $desugar$28;
-    %132 = decryptAesGcm($desugar$24,$desugar$25,$desugar$26,$desugar$27,%131) -> bb29;
+    %122 = %121 is error
+    %122 ? bb29 : bb30;
   }
   bb29 {
-    $desugar$29 = %132;
-    %134 = $desugar$29 is error
-    %134 ? bb30 : bb31;
+    %0 = %121;
+    return;
   }
   bb30 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$29);
-    PopScopeFrame
-    return;
+    %119 = %121;
+    GOTO bb31;
   }
   bb31 {
-    %135 = == $desugar$29 plaintext;
-    %136 = %135;
-    %137 = println(%136) -> bb32;
+    gcm = %119;
+    $desugar$19 = gcm;
+    $desugar$20 = key;
+    $desugar$21 = iv12;
+    %127 = $default$25($desugar$19,$desugar$20,$desugar$21) -> bb32;
   }
   bb32 {
-    %138 = ConstantLoad NONE
-    %139 = ConstantLoad 96
-    %140 = %139;
-    %141 = encryptAesGcm(plaintext,key,iv12,%138,%140) -> bb33;
+    $desugar$22 = %127;
+    %129 = $default$26($desugar$19,$desugar$20,$desugar$21,$desugar$22) -> bb33;
   }
   bb33 {
-    $desugar$30 = %141;
-    %143 = $desugar$30 is error
-    %143 ? bb34 : bb35;
+    $desugar$23 = %129;
+    %133 = $desugar$23;
+    %134 = decryptAesGcm($desugar$19,$desugar$20,$desugar$21,$desugar$22,%133) -> bb34;
   }
   bb34 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$30);
-    PopScopeFrame
-    return;
+    %135 = %134 is error
+    %135 ? bb35 : bb36;
   }
   bb35 {
-    gcm96 = $desugar$30;
-    %145 = ConstantLoad NONE
-    %146 = ConstantLoad 96
-    %147 = %146;
-    %148 = decryptAesGcm(gcm96,key,iv12,%145,%147) -> bb36;
-  }
-  bb36 {
-    $desugar$31 = %148;
-    %150 = $desugar$31 is error
-    %150 ? bb37 : bb38;
-  }
-  bb37 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$31);
-    PopScopeFrame
+    %0 = %134;
     return;
   }
+  bb36 {
+    %132 = %134;
+    GOTO bb37;
+  }
+  bb37 {
+    %131 = == %132 plaintext;
+    %136 = %131;
+    %137 = println(%136) -> bb38;
+  }
   bb38 {
-    %151 = == $desugar$31 plaintext;
-    %152 = %151;
-    %153 = println(%152) -> bb39;
+    %139 = ConstantLoad NONE
+    %140 = ConstantLoad 96
+    %141 = %140;
+    %142 = encryptAesGcm(plaintext,key,iv12,%139,%141) -> bb39;
   }
   bb39 {
+    %143 = %142 is error
+    %143 ? bb40 : bb41;
+  }
+  bb40 {
+    %0 = %142;
+    return;
+  }
+  bb41 {
+    %138 = %142;
+    GOTO bb42;
+  }
+  bb42 {
+    gcm96 = %138;
+    %147 = ConstantLoad NONE
+    %148 = ConstantLoad 96
+    %149 = %148;
+    %150 = decryptAesGcm(gcm96,key,iv12,%147,%149) -> bb43;
+  }
+  bb43 {
+    %151 = %150 is error
+    %151 ? bb44 : bb45;
+  }
+  bb44 {
+    %0 = %150;
+    return;
+  }
+  bb45 {
+    %146 = %150;
+    GOTO bb46;
+  }
+  bb46 {
+    %145 = == %146 plaintext;
+    %152 = %145;
+    %153 = println(%152) -> bb47;
+  }
+  bb47 {
     %154 = ConstantLoad 0
     %155 = ConstantLoad 1
     %156 = ConstantLoad 2
@@ -280,58 +288,58 @@ main() -> nil|error{
     %159 = ConstantLoad 5
     %160 = newArray [int:Unsigned8...][%159]{%154, %155, %156, %157, %158}
     badKey = %160;
-    $desugar$32 = plaintext;
-    $desugar$33 = badKey;
-    $desugar$34 = iv;
-    %165 = $default$18($desugar$32,$desugar$33,$desugar$34) -> bb40;
+    $desugar$24 = plaintext;
+    $desugar$25 = badKey;
+    $desugar$26 = iv;
+    %165 = $default$18($desugar$24,$desugar$25,$desugar$26) -> bb48;
   }
-  bb40 {
-    $desugar$35 = %165;
-    %167 = encryptAesCbc($desugar$32,$desugar$33,$desugar$34,$desugar$35) -> bb41;
+  bb48 {
+    $desugar$27 = %165;
+    %167 = encryptAesCbc($desugar$24,$desugar$25,$desugar$26,$desugar$27) -> bb49;
   }
-  bb41 {
+  bb49 {
     cbcErr = %167;
     %169 = cbcErr is error
     %170 = %169;
-    %171 = println(%170) -> bb42;
+    %171 = println(%170) -> bb50;
   }
-  bb42 {
-    $desugar$36 = plaintext;
-    $desugar$37 = badKey;
-    %174 = $default$19($desugar$36,$desugar$37) -> bb43;
+  bb50 {
+    $desugar$28 = plaintext;
+    $desugar$29 = badKey;
+    %174 = $default$19($desugar$28,$desugar$29) -> bb51;
   }
-  bb43 {
-    $desugar$38 = %174;
-    %176 = encryptAesEcb($desugar$36,$desugar$37,$desugar$38) -> bb44;
+  bb51 {
+    $desugar$30 = %174;
+    %176 = encryptAesEcb($desugar$28,$desugar$29,$desugar$30) -> bb52;
   }
-  bb44 {
+  bb52 {
     ecbErr = %176;
     %178 = ecbErr is error
     %179 = %178;
-    %180 = println(%179) -> bb45;
+    %180 = println(%179) -> bb53;
   }
-  bb45 {
-    $desugar$39 = plaintext;
-    $desugar$40 = badKey;
-    $desugar$41 = iv12;
-    %184 = $default$20($desugar$39,$desugar$40,$desugar$41) -> bb46;
+  bb53 {
+    $desugar$31 = plaintext;
+    $desugar$32 = badKey;
+    $desugar$33 = iv12;
+    %184 = $default$20($desugar$31,$desugar$32,$desugar$33) -> bb54;
   }
-  bb46 {
-    $desugar$42 = %184;
-    %186 = $default$21($desugar$39,$desugar$40,$desugar$41,$desugar$42) -> bb47;
+  bb54 {
+    $desugar$34 = %184;
+    %186 = $default$21($desugar$31,$desugar$32,$desugar$33,$desugar$34) -> bb55;
   }
-  bb47 {
-    $desugar$43 = %186;
-    %188 = $desugar$43;
-    %189 = encryptAesGcm($desugar$39,$desugar$40,$desugar$41,$desugar$42,%188) -> bb48;
+  bb55 {
+    $desugar$35 = %186;
+    %188 = $desugar$35;
+    %189 = encryptAesGcm($desugar$31,$desugar$32,$desugar$33,$desugar$34,%188) -> bb56;
   }
-  bb48 {
+  bb56 {
     gcmErr = %189;
     %191 = gcmErr is error
     %192 = %191;
-    %193 = println(%192) -> bb49;
+    %193 = println(%192) -> bb57;
   }
-  bb49 {
+  bb57 {
     %194 = ConstantLoad 0
     %195 = ConstantLoad 0
     %196 = ConstantLoad 0
@@ -351,196 +359,196 @@ main() -> nil|error{
     %210 = ConstantLoad 16
     %211 = newArray [int:Unsigned8...][%210]{%194, %195, %196, %197, %198, %199, %200, %201, %202, %203, %204, %205, %206, %207, %208, %209}
     zeros = %211;
-    $desugar$44 = zeros;
-    $desugar$45 = key;
-    $desugar$46 = iv;
-    %216 = $default$23($desugar$44,$desugar$45,$desugar$46) -> bb50;
+    $desugar$36 = zeros;
+    $desugar$37 = key;
+    $desugar$38 = iv;
+    %216 = $default$23($desugar$36,$desugar$37,$desugar$38) -> bb58;
   }
-  bb50 {
-    $desugar$47 = %216;
-    %218 = decryptAesCbc($desugar$44,$desugar$45,$desugar$46,$desugar$47) -> bb51;
+  bb58 {
+    $desugar$39 = %216;
+    %218 = decryptAesCbc($desugar$36,$desugar$37,$desugar$38,$desugar$39) -> bb59;
   }
-  bb51 {
+  bb59 {
     padErr = %218;
     %220 = padErr is error
     %221 = %220;
-    %222 = println(%221) -> bb52;
+    %222 = println(%221) -> bb60;
   }
-  bb52 {
+  bb60 {
     %223 = ConstantLoad 1
     %224 = ConstantLoad 2
     %225 = ConstantLoad 3
     %226 = ConstantLoad 3
     %227 = newArray [int:Unsigned8...][%226]{%223, %224, %225}
-    $desugar$48 = %227;
-    $desugar$49 = key;
-    $desugar$50 = iv;
-    %231 = $default$23($desugar$48,$desugar$49,$desugar$50) -> bb53;
+    $desugar$40 = %227;
+    $desugar$41 = key;
+    $desugar$42 = iv;
+    %231 = $default$23($desugar$40,$desugar$41,$desugar$42) -> bb61;
   }
-  bb53 {
-    $desugar$51 = %231;
-    %233 = decryptAesCbc($desugar$48,$desugar$49,$desugar$50,$desugar$51) -> bb54;
+  bb61 {
+    $desugar$43 = %231;
+    %233 = decryptAesCbc($desugar$40,$desugar$41,$desugar$42,$desugar$43) -> bb62;
   }
-  bb54 {
+  bb62 {
     sizeErr = %233;
     %235 = sizeErr is error
     %236 = %235;
-    %237 = println(%236) -> bb55;
+    %237 = println(%236) -> bb63;
   }
-  bb55 {
-    $desugar$52 = cbc;
-    $desugar$53 = badKey;
-    $desugar$54 = iv;
-    %241 = $default$23($desugar$52,$desugar$53,$desugar$54) -> bb56;
+  bb63 {
+    $desugar$44 = cbc;
+    $desugar$45 = badKey;
+    $desugar$46 = iv;
+    %241 = $default$23($desugar$44,$desugar$45,$desugar$46) -> bb64;
   }
-  bb56 {
-    $desugar$55 = %241;
-    %243 = decryptAesCbc($desugar$52,$desugar$53,$desugar$54,$desugar$55) -> bb57;
+  bb64 {
+    $desugar$47 = %241;
+    %243 = decryptAesCbc($desugar$44,$desugar$45,$desugar$46,$desugar$47) -> bb65;
   }
-  bb57 {
+  bb65 {
     cbcDecErr = %243;
     %245 = cbcDecErr is error
     %246 = %245;
-    %247 = println(%246) -> bb58;
+    %247 = println(%246) -> bb66;
   }
-  bb58 {
-    $desugar$56 = ecb;
-    $desugar$57 = badKey;
-    %250 = $default$24($desugar$56,$desugar$57) -> bb59;
+  bb66 {
+    $desugar$48 = ecb;
+    $desugar$49 = badKey;
+    %250 = $default$24($desugar$48,$desugar$49) -> bb67;
   }
-  bb59 {
-    $desugar$58 = %250;
-    %252 = decryptAesEcb($desugar$56,$desugar$57,$desugar$58) -> bb60;
+  bb67 {
+    $desugar$50 = %250;
+    %252 = decryptAesEcb($desugar$48,$desugar$49,$desugar$50) -> bb68;
   }
-  bb60 {
+  bb68 {
     ecbDecErr = %252;
     %254 = ecbDecErr is error
     %255 = %254;
-    %256 = println(%255) -> bb61;
+    %256 = println(%255) -> bb69;
   }
-  bb61 {
+  bb69 {
     %257 = ConstantLoad 1
     %258 = ConstantLoad 2
     %259 = ConstantLoad 3
     %260 = ConstantLoad 3
     %261 = newArray [int:Unsigned8...][%260]{%257, %258, %259}
-    $desugar$59 = %261;
-    $desugar$60 = key;
-    %264 = $default$24($desugar$59,$desugar$60) -> bb62;
+    $desugar$51 = %261;
+    $desugar$52 = key;
+    %264 = $default$24($desugar$51,$desugar$52) -> bb70;
   }
-  bb62 {
-    $desugar$61 = %264;
-    %266 = decryptAesEcb($desugar$59,$desugar$60,$desugar$61) -> bb63;
+  bb70 {
+    $desugar$53 = %264;
+    %266 = decryptAesEcb($desugar$51,$desugar$52,$desugar$53) -> bb71;
   }
-  bb63 {
+  bb71 {
     ecbSizeErr = %266;
     %268 = ecbSizeErr is error
     %269 = %268;
-    %270 = println(%269) -> bb64;
+    %270 = println(%269) -> bb72;
   }
-  bb64 {
-    $desugar$62 = zeros;
-    $desugar$63 = key;
-    %273 = $default$24($desugar$62,$desugar$63) -> bb65;
+  bb72 {
+    $desugar$54 = zeros;
+    $desugar$55 = key;
+    %273 = $default$24($desugar$54,$desugar$55) -> bb73;
   }
-  bb65 {
-    $desugar$64 = %273;
-    %275 = decryptAesEcb($desugar$62,$desugar$63,$desugar$64) -> bb66;
+  bb73 {
+    $desugar$56 = %273;
+    %275 = decryptAesEcb($desugar$54,$desugar$55,$desugar$56) -> bb74;
   }
-  bb66 {
+  bb74 {
     ecbPadErr = %275;
     %277 = ecbPadErr is error
     %278 = %277;
-    %279 = println(%278) -> bb67;
+    %279 = println(%278) -> bb75;
   }
-  bb67 {
+  bb75 {
     %280 = ConstantLoad 0
     %281 = newArray [int:Unsigned8...][%280]{}
-    $desugar$65 = %281;
-    $desugar$66 = key;
-    $desugar$67 = iv;
-    %285 = $default$23($desugar$65,$desugar$66,$desugar$67) -> bb68;
+    $desugar$57 = %281;
+    $desugar$58 = key;
+    $desugar$59 = iv;
+    %285 = $default$23($desugar$57,$desugar$58,$desugar$59) -> bb76;
   }
-  bb68 {
-    $desugar$68 = %285;
-    %287 = decryptAesCbc($desugar$65,$desugar$66,$desugar$67,$desugar$68) -> bb69;
+  bb76 {
+    $desugar$60 = %285;
+    %287 = decryptAesCbc($desugar$57,$desugar$58,$desugar$59,$desugar$60) -> bb77;
   }
-  bb69 {
+  bb77 {
     emptyErr = %287;
     %289 = emptyErr is error
     %290 = %289;
-    %291 = println(%290) -> bb70;
+    %291 = println(%290) -> bb78;
   }
-  bb70 {
+  bb78 {
     %292 = ConstantLoad NONE
     %293 = ConstantLoad 48
     %294 = %293;
-    %295 = encryptAesGcm(plaintext,key,iv12,%292,%294) -> bb71;
+    %295 = encryptAesGcm(plaintext,key,iv12,%292,%294) -> bb79;
   }
-  bb71 {
+  bb79 {
     gcmEncTagErr = %295;
     %297 = gcmEncTagErr is error
     %298 = %297;
-    %299 = println(%298) -> bb72;
+    %299 = println(%298) -> bb80;
   }
-  bb72 {
+  bb80 {
     %300 = ConstantLoad NONE
     %301 = ConstantLoad 48
     %302 = %301;
-    %303 = decryptAesGcm(gcm,key,iv12,%300,%302) -> bb73;
+    %303 = decryptAesGcm(gcm,key,iv12,%300,%302) -> bb81;
   }
-  bb73 {
+  bb81 {
     gcmDecTagErr = %303;
     %305 = gcmDecTagErr is error
     %306 = %305;
-    %307 = println(%306) -> bb74;
+    %307 = println(%306) -> bb82;
   }
-  bb74 {
+  bb82 {
     %308 = ConstantLoad NONE
     %309 = ConstantLoad 96
     %310 = %309;
-    %311 = encryptAesGcm(plaintext,key,iv,%308,%310) -> bb75;
+    %311 = encryptAesGcm(plaintext,key,iv,%308,%310) -> bb83;
   }
-  bb75 {
+  bb83 {
     gcmEncCombo = %311;
     %313 = gcmEncCombo is error
     %314 = %313;
-    %315 = println(%314) -> bb76;
+    %315 = println(%314) -> bb84;
   }
-  bb76 {
+  bb84 {
     %316 = ConstantLoad NONE
     %317 = ConstantLoad 96
     %318 = %317;
-    %319 = decryptAesGcm(gcm,key,iv,%316,%318) -> bb77;
+    %319 = decryptAesGcm(gcm,key,iv,%316,%318) -> bb85;
   }
-  bb77 {
+  bb85 {
     gcmDecCombo = %319;
     %321 = gcmDecCombo is error
     %322 = %321;
-    %323 = println(%322) -> bb78;
+    %323 = println(%322) -> bb86;
   }
-  bb78 {
-    $desugar$69 = gcm;
-    $desugar$70 = badKey;
-    $desugar$71 = iv12;
-    %327 = $default$25($desugar$69,$desugar$70,$desugar$71) -> bb79;
+  bb86 {
+    $desugar$61 = gcm;
+    $desugar$62 = badKey;
+    $desugar$63 = iv12;
+    %327 = $default$25($desugar$61,$desugar$62,$desugar$63) -> bb87;
   }
-  bb79 {
-    $desugar$72 = %327;
-    %329 = $default$26($desugar$69,$desugar$70,$desugar$71,$desugar$72) -> bb80;
+  bb87 {
+    $desugar$64 = %327;
+    %329 = $default$26($desugar$61,$desugar$62,$desugar$63,$desugar$64) -> bb88;
   }
-  bb80 {
-    $desugar$73 = %329;
-    %331 = $desugar$73;
-    %332 = decryptAesGcm($desugar$69,$desugar$70,$desugar$71,$desugar$72,%331) -> bb81;
+  bb88 {
+    $desugar$65 = %329;
+    %331 = $desugar$65;
+    %332 = decryptAesGcm($desugar$61,$desugar$62,$desugar$63,$desugar$64,%331) -> bb89;
   }
-  bb81 {
+  bb89 {
     gcmDecKeyErr = %332;
     %334 = gcmDecKeyErr is error
     %335 = %334;
-    %336 = println(%335) -> bb82;
+    %336 = println(%335) -> bb90;
   }
-  bb82 {
+  bb90 {
     %337 = ConstantLoad 15
     %338 = ConstantLoad 14
     %339 = ConstantLoad 13
@@ -560,27 +568,27 @@ main() -> nil|error{
     %353 = ConstantLoad 16
     %354 = newArray [int:Unsigned8...][%353]{%337, %338, %339, %340, %341, %342, %343, %344, %345, %346, %347, %348, %349, %350, %351, %352}
     key2 = %354;
-    $desugar$74 = gcm;
-    $desugar$75 = key2;
-    $desugar$76 = iv12;
-    %359 = $default$25($desugar$74,$desugar$75,$desugar$76) -> bb83;
+    $desugar$66 = gcm;
+    $desugar$67 = key2;
+    $desugar$68 = iv12;
+    %359 = $default$25($desugar$66,$desugar$67,$desugar$68) -> bb91;
   }
-  bb83 {
-    $desugar$77 = %359;
-    %361 = $default$26($desugar$74,$desugar$75,$desugar$76,$desugar$77) -> bb84;
+  bb91 {
+    $desugar$69 = %359;
+    %361 = $default$26($desugar$66,$desugar$67,$desugar$68,$desugar$69) -> bb92;
   }
-  bb84 {
-    $desugar$78 = %361;
-    %363 = $desugar$78;
-    %364 = decryptAesGcm($desugar$74,$desugar$75,$desugar$76,$desugar$77,%363) -> bb85;
+  bb92 {
+    $desugar$70 = %361;
+    %363 = $desugar$70;
+    %364 = decryptAesGcm($desugar$66,$desugar$67,$desugar$68,$desugar$69,%363) -> bb93;
   }
-  bb85 {
+  bb93 {
     gcmAuthErr = %364;
     %366 = gcmAuthErr is error
     %367 = %366;
-    %368 = println(%367) -> bb86;
+    %368 = println(%367) -> bb94;
   }
-  bb86 {
+  bb94 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/crypto-content-v.txt
+++ b/corpus/bir/library/subset2/crypto-content-v.txt
@@ -101,316 +101,330 @@ Eubczj1asLiR3WmG1u2v/ntgx3FESVPFlpEMX66jA4DTWUF8aSNSNZIhKoIorIVZ
   }
   bb1 {
     $desugar$2 = %17;
-    %19 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %20 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %19;
-    %21 = $desugar$3 is error
+    %21 = %20 is error
     %21 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %20;
     return;
   }
   bb4 {
-    %22 = ConstantLoad /tmp/bal_crypto_content.pem
-    %23 = fileReadBytes(%22) -> bb5;
+    %19 = %20;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %23;
-    %25 = $desugar$4 is error
-    %25 ? bb6 : bb7;
+    %23 = ConstantLoad /tmp/bal_crypto_content.pem
+    %24 = fileReadBytes(%23) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %25 = %24 is error
+    %25 ? bb7 : bb8;
   }
   bb7 {
-    certBytes = $desugar$4;
-    %27 = decodeRsaPublicKeyFromContent(certBytes) -> bb8;
+    %0 = %24;
+    return;
   }
   bb8 {
-    $desugar$5 = %27;
-    %29 = $desugar$5 is error
-    %29 ? bb9 : bb10;
+    %22 = %24;
+    GOTO bb9;
   }
   bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    certBytes = %22;
+    %28 = decodeRsaPublicKeyFromContent(certBytes) -> bb10;
   }
   bb10 {
-    pub = $desugar$5;
-    $desugar$6 = data;
-    $desugar$7 = pub;
-    %33 = $default$17($desugar$6,$desugar$7) -> bb11;
+    %29 = %28 is error
+    %29 ? bb11 : bb12;
   }
   bb11 {
-    $desugar$8 = %33;
-    %35 = encryptRsaEcb($desugar$6,$desugar$7,$desugar$8) -> bb12;
-  }
-  bb12 {
-    $desugar$9 = %35;
-    %37 = $desugar$9 is error
-    %37 ? bb13 : bb14;
-  }
-  bb13 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %28;
     return;
   }
+  bb12 {
+    %27 = %28;
+    GOTO bb13;
+  }
+  bb13 {
+    pub = %27;
+    $desugar$3 = data;
+    $desugar$4 = pub;
+    %33 = $default$17($desugar$3,$desugar$4) -> bb14;
+  }
   bb14 {
-    %39 = length($desugar$9) -> bb15;
+    $desugar$5 = %33;
+    %37 = encryptRsaEcb($desugar$3,$desugar$4,$desugar$5) -> bb15;
   }
   bb15 {
+    %38 = %37 is error
+    %38 ? bb16 : bb17;
+  }
+  bb16 {
+    %0 = %37;
+    return;
+  }
+  bb17 {
+    %36 = %37;
+    GOTO bb18;
+  }
+  bb18 {
+    %39 = length(%36) -> bb19;
+  }
+  bb19 {
     %40 = %39;
     %41 = ConstantLoad 0
     %42 = %41;
-    %38 = > %40 %42;
-    %43 = %38;
-    %44 = println(%43) -> bb16;
-  }
-  bb16 {
-    %45 = ConstantLoad /tmp/bal_crypto_content.pem
-    $desugar$10 = %45;
-    $desugar$11 = keyPem;
-    %48 = $default$1($desugar$10,$desugar$11) -> bb17;
-  }
-  bb17 {
-    $desugar$12 = %48;
-    %50 = fileWriteString($desugar$10,$desugar$11,$desugar$12) -> bb18;
-  }
-  bb18 {
-    $desugar$13 = %50;
-    %52 = $desugar$13 is error
-    %52 ? bb19 : bb20;
-  }
-  bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
-    return;
+    %35 = > %40 %42;
+    %43 = %35;
+    %44 = println(%43) -> bb20;
   }
   bb20 {
-    %53 = ConstantLoad /tmp/bal_crypto_content.pem
-    %54 = fileReadBytes(%53) -> bb21;
+    %45 = ConstantLoad /tmp/bal_crypto_content.pem
+    $desugar$6 = %45;
+    $desugar$7 = keyPem;
+    %48 = $default$1($desugar$6,$desugar$7) -> bb21;
   }
   bb21 {
-    $desugar$14 = %54;
-    %56 = $desugar$14 is error
-    %56 ? bb22 : bb23;
+    $desugar$8 = %48;
+    %51 = fileWriteString($desugar$6,$desugar$7,$desugar$8) -> bb22;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
-    return;
+    %52 = %51 is error
+    %52 ? bb23 : bb24;
   }
   bb23 {
-    keyBytes = $desugar$14;
-    $desugar$15 = keyBytes;
-    %59 = $default$1($desugar$15) -> bb24;
+    %0 = %51;
+    return;
   }
   bb24 {
-    $desugar$16 = %59;
-    %61 = decodeRsaPrivateKeyFromContent($desugar$15,$desugar$16) -> bb25;
+    %50 = %51;
+    GOTO bb25;
   }
   bb25 {
-    $desugar$17 = %61;
-    %63 = $desugar$17 is error
-    %63 ? bb26 : bb27;
+    %54 = ConstantLoad /tmp/bal_crypto_content.pem
+    %55 = fileReadBytes(%54) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
-    return;
+    %56 = %55 is error
+    %56 ? bb27 : bb28;
   }
   bb27 {
-    pk = $desugar$17;
-    %65 = signRsaSha256(data,pk) -> bb28;
-  }
-  bb28 {
-    $desugar$18 = %65;
-    %67 = $desugar$18 is error
-    %67 ? bb29 : bb30;
-  }
-  bb29 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
+    %0 = %55;
     return;
   }
+  bb28 {
+    %53 = %55;
+    GOTO bb29;
+  }
+  bb29 {
+    keyBytes = %53;
+    $desugar$9 = keyBytes;
+    %59 = $default$1($desugar$9) -> bb30;
+  }
   bb30 {
-    %69 = length($desugar$18) -> bb31;
+    $desugar$10 = %59;
+    %62 = decodeRsaPrivateKeyFromContent($desugar$9,$desugar$10) -> bb31;
   }
   bb31 {
+    %63 = %62 is error
+    %63 ? bb32 : bb33;
+  }
+  bb32 {
+    %0 = %62;
+    return;
+  }
+  bb33 {
+    %61 = %62;
+    GOTO bb34;
+  }
+  bb34 {
+    pk = %61;
+    %67 = signRsaSha256(data,pk) -> bb35;
+  }
+  bb35 {
+    %68 = %67 is error
+    %68 ? bb36 : bb37;
+  }
+  bb36 {
+    %0 = %67;
+    return;
+  }
+  bb37 {
+    %66 = %67;
+    GOTO bb38;
+  }
+  bb38 {
+    %69 = length(%66) -> bb39;
+  }
+  bb39 {
     %70 = %69;
     %71 = ConstantLoad 0
     %72 = %71;
-    %68 = > %70 %72;
-    %73 = %68;
-    %74 = println(%73) -> bb32;
-  }
-  bb32 {
-    %75 = ConstantLoad /tmp/bal_crypto_content.pem
-    $desugar$19 = %75;
-    $desugar$20 = encKeyPem;
-    %78 = $default$1($desugar$19,$desugar$20) -> bb33;
-  }
-  bb33 {
-    $desugar$21 = %78;
-    %80 = fileWriteString($desugar$19,$desugar$20,$desugar$21) -> bb34;
-  }
-  bb34 {
-    $desugar$22 = %80;
-    %82 = $desugar$22 is error
-    %82 ? bb35 : bb36;
-  }
-  bb35 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
-    return;
-  }
-  bb36 {
-    %83 = ConstantLoad /tmp/bal_crypto_content.pem
-    %84 = fileReadBytes(%83) -> bb37;
-  }
-  bb37 {
-    $desugar$23 = %84;
-    %86 = $desugar$23 is error
-    %86 ? bb38 : bb39;
-  }
-  bb38 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$23);
-    PopScopeFrame
-    return;
-  }
-  bb39 {
-    encBytes = $desugar$23;
-    %88 = ConstantLoad secret
-    %89 = decodeRsaPrivateKeyFromContent(encBytes,%88) -> bb40;
+    %65 = > %70 %72;
+    %73 = %65;
+    %74 = println(%73) -> bb40;
   }
   bb40 {
-    $desugar$24 = %89;
-    %91 = $desugar$24 is error
-    %91 ? bb41 : bb42;
+    %75 = ConstantLoad /tmp/bal_crypto_content.pem
+    $desugar$11 = %75;
+    $desugar$12 = encKeyPem;
+    %78 = $default$1($desugar$11,$desugar$12) -> bb41;
   }
   bb41 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$24);
-    PopScopeFrame
-    return;
+    $desugar$13 = %78;
+    %81 = fileWriteString($desugar$11,$desugar$12,$desugar$13) -> bb42;
   }
   bb42 {
-    encPk = $desugar$24;
-    %93 = signRsaSha256(data,encPk) -> bb43;
+    %82 = %81 is error
+    %82 ? bb43 : bb44;
   }
   bb43 {
-    $desugar$25 = %93;
-    %95 = $desugar$25 is error
-    %95 ? bb44 : bb45;
-  }
-  bb44 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$25);
-    PopScopeFrame
+    %0 = %81;
     return;
   }
+  bb44 {
+    %80 = %81;
+    GOTO bb45;
+  }
   bb45 {
-    %97 = length($desugar$25) -> bb46;
+    %84 = ConstantLoad /tmp/bal_crypto_content.pem
+    %85 = fileReadBytes(%84) -> bb46;
   }
   bb46 {
+    %86 = %85 is error
+    %86 ? bb47 : bb48;
+  }
+  bb47 {
+    %0 = %85;
+    return;
+  }
+  bb48 {
+    %83 = %85;
+    GOTO bb49;
+  }
+  bb49 {
+    encBytes = %83;
+    %89 = ConstantLoad secret
+    %90 = decodeRsaPrivateKeyFromContent(encBytes,%89) -> bb50;
+  }
+  bb50 {
+    %91 = %90 is error
+    %91 ? bb51 : bb52;
+  }
+  bb51 {
+    %0 = %90;
+    return;
+  }
+  bb52 {
+    %88 = %90;
+    GOTO bb53;
+  }
+  bb53 {
+    encPk = %88;
+    %95 = signRsaSha256(data,encPk) -> bb54;
+  }
+  bb54 {
+    %96 = %95 is error
+    %96 ? bb55 : bb56;
+  }
+  bb55 {
+    %0 = %95;
+    return;
+  }
+  bb56 {
+    %94 = %95;
+    GOTO bb57;
+  }
+  bb57 {
+    %97 = length(%94) -> bb58;
+  }
+  bb58 {
     %98 = %97;
     %99 = ConstantLoad 0
     %100 = %99;
-    %96 = > %98 %100;
-    %101 = %96;
-    %102 = println(%101) -> bb47;
+    %93 = > %98 %100;
+    %101 = %93;
+    %102 = println(%101) -> bb59;
   }
-  bb47 {
+  bb59 {
     %103 = ConstantLoad 1
     %104 = ConstantLoad 2
     %105 = ConstantLoad 3
     %106 = ConstantLoad 3
     %107 = newArray [int:Unsigned8...][%106]{%103, %104, %105}
     junk = %107;
-    %109 = decodeRsaPublicKeyFromContent(junk) -> bb48;
+    %109 = decodeRsaPublicKeyFromContent(junk) -> bb60;
   }
-  bb48 {
+  bb60 {
     bad = %109;
     %111 = bad is error
     %112 = %111;
-    %113 = println(%112) -> bb49;
+    %113 = println(%112) -> bb61;
   }
-  bb49 {
-    %114 = ConstantLoad B53CF3F3B675BF146DDCEDBA46A69ED21618D27CC15479FE2606D11649CD5945491F84D6FF7C722CA1030FECF46FEE4184FD9C66290F4AA290F1A04BD9FB2227747B00985A08CF5778A87168F6CFD96C626394F1C8D2B3DB9A475EDFF8127AF420B34A7CCEA4B81ED156759479C8862463495D23B6C3EDB4DA632324C5E061834EA74DB67752AAB02B0BFE737F330D6F9ED4CA8D76537E5CB5911DEF71573D395A85B2A5958509D7E4E18795A28EDC7007EA36FE8088A5AC93C54F89CA0CCF9DE41E88AD94644CE841A32DA56E8969F8575F0DD0735818CEF373BE3757145DE5DED5203D823BB98DD9F8831C68FAE7E6F040B921E75F3C57469B8E2C1BCE1365
-    %115 = ConstantLoad 10001
-    %116 = buildRsaPublicKey(%114,%115) -> bb50;
+  bb61 {
+    %115 = ConstantLoad B53CF3F3B675BF146DDCEDBA46A69ED21618D27CC15479FE2606D11649CD5945491F84D6FF7C722CA1030FECF46FEE4184FD9C66290F4AA290F1A04BD9FB2227747B00985A08CF5778A87168F6CFD96C626394F1C8D2B3DB9A475EDFF8127AF420B34A7CCEA4B81ED156759479C8862463495D23B6C3EDB4DA632324C5E061834EA74DB67752AAB02B0BFE737F330D6F9ED4CA8D76537E5CB5911DEF71573D395A85B2A5958509D7E4E18795A28EDC7007EA36FE8088A5AC93C54F89CA0CCF9DE41E88AD94644CE841A32DA56E8969F8575F0DD0735818CEF373BE3757145DE5DED5203D823BB98DD9F8831C68FAE7E6F040B921E75F3C57469B8E2C1BCE1365
+    %116 = ConstantLoad 10001
+    %117 = buildRsaPublicKey(%115,%116) -> bb62;
   }
-  bb50 {
-    $desugar$26 = %116;
-    %118 = $desugar$26 is error
-    %118 ? bb51 : bb52;
+  bb62 {
+    %118 = %117 is error
+    %118 ? bb63 : bb64;
   }
-  bb51 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$26);
-    PopScopeFrame
+  bb63 {
+    %0 = %117;
     return;
   }
-  bb52 {
-    built = $desugar$26;
-    $desugar$27 = data;
-    $desugar$28 = built;
-    %122 = $default$17($desugar$27,$desugar$28) -> bb53;
+  bb64 {
+    %114 = %117;
+    GOTO bb65;
   }
-  bb53 {
-    $desugar$29 = %122;
-    %124 = encryptRsaEcb($desugar$27,$desugar$28,$desugar$29) -> bb54;
+  bb65 {
+    built = %114;
+    $desugar$14 = data;
+    $desugar$15 = built;
+    %122 = $default$17($desugar$14,$desugar$15) -> bb66;
   }
-  bb54 {
-    $desugar$30 = %124;
-    %126 = $desugar$30 is error
-    %126 ? bb55 : bb56;
+  bb66 {
+    $desugar$16 = %122;
+    %126 = encryptRsaEcb($desugar$14,$desugar$15,$desugar$16) -> bb67;
   }
-  bb55 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$30);
-    PopScopeFrame
+  bb67 {
+    %127 = %126 is error
+    %127 ? bb68 : bb69;
+  }
+  bb68 {
+    %0 = %126;
     return;
   }
-  bb56 {
-    %128 = length($desugar$30) -> bb57;
+  bb69 {
+    %125 = %126;
+    GOTO bb70;
   }
-  bb57 {
+  bb70 {
+    %128 = length(%125) -> bb71;
+  }
+  bb71 {
     %129 = %128;
     %130 = ConstantLoad 0
     %131 = %130;
-    %127 = > %129 %131;
-    %132 = %127;
-    %133 = println(%132) -> bb58;
+    %124 = > %129 %131;
+    %132 = %124;
+    %133 = println(%132) -> bb72;
   }
-  bb58 {
+  bb72 {
     %134 = ConstantLoad nothex
     %135 = ConstantLoad 10001
-    %136 = buildRsaPublicKey(%134,%135) -> bb59;
+    %136 = buildRsaPublicKey(%134,%135) -> bb73;
   }
-  bb59 {
+  bb73 {
     badBuilt = %136;
     %138 = badBuilt is error
     %139 = %138;
-    %140 = println(%139) -> bb60;
+    %140 = println(%139) -> bb74;
   }
-  bb60 {
+  bb74 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/crypto-hmac1-v.txt
+++ b/corpus/bir/library/subset2/crypto-hmac1-v.txt
@@ -18,28 +18,29 @@ main() -> nil|error{
     %15 = ConstantLoad 6
     %16 = newArray [int:Unsigned8...][%15]{%9, %10, %11, %12, %13, %14}
     key = %16;
-    %18 = hmacSha256(input,key) -> bb1;
+    %19 = hmacSha256(input,key) -> bb1;
   }
   bb1 {
-    $desugar$0 = %18;
-    %20 = $desugar$0 is error
+    %20 = %19 is error
     %20 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %19;
     return;
   }
   bb3 {
-    mac = $desugar$0;
-    %22 = length(mac) -> bb4;
+    %18 = %19;
+    GOTO bb4;
   }
   bb4 {
-    %23 = %22;
-    %24 = println(%23) -> bb5;
+    mac = %18;
+    %22 = length(mac) -> bb5;
   }
   bb5 {
+    %23 = %22;
+    %24 = println(%23) -> bb6;
+  }
+  bb6 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/crypto-hmac2-v.txt
+++ b/corpus/bir/library/subset2/crypto-hmac2-v.txt
@@ -18,90 +18,94 @@ main() -> nil|error{
     %15 = ConstantLoad 6
     %16 = newArray [int:Unsigned8...][%15]{%9, %10, %11, %12, %13, %14}
     key = %16;
-    %18 = hmacMd5(input,key) -> bb1;
+    %19 = hmacMd5(input,key) -> bb1;
   }
   bb1 {
-    $desugar$0 = %18;
-    %20 = $desugar$0 is error
+    %20 = %19 is error
     %20 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %19;
     return;
   }
   bb3 {
-    %21 = length($desugar$0) -> bb4;
+    %18 = %19;
+    GOTO bb4;
   }
   bb4 {
-    %22 = %21;
-    %23 = println(%22) -> bb5;
+    %21 = length(%18) -> bb5;
   }
   bb5 {
-    %24 = hmacSha1(input,key) -> bb6;
+    %22 = %21;
+    %23 = println(%22) -> bb6;
   }
   bb6 {
-    $desugar$1 = %24;
-    %26 = $desugar$1 is error
-    %26 ? bb7 : bb8;
+    %25 = hmacSha1(input,key) -> bb7;
   }
   bb7 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %26 = %25 is error
+    %26 ? bb8 : bb9;
   }
   bb8 {
-    %27 = length($desugar$1) -> bb9;
+    %0 = %25;
+    return;
   }
   bb9 {
-    %28 = %27;
-    %29 = println(%28) -> bb10;
+    %24 = %25;
+    GOTO bb10;
   }
   bb10 {
-    %30 = hmacSha384(input,key) -> bb11;
+    %27 = length(%24) -> bb11;
   }
   bb11 {
-    $desugar$2 = %30;
-    %32 = $desugar$2 is error
-    %32 ? bb12 : bb13;
+    %28 = %27;
+    %29 = println(%28) -> bb12;
   }
   bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %31 = hmacSha384(input,key) -> bb13;
   }
   bb13 {
-    %33 = length($desugar$2) -> bb14;
+    %32 = %31 is error
+    %32 ? bb14 : bb15;
   }
   bb14 {
-    %34 = %33;
-    %35 = println(%34) -> bb15;
-  }
-  bb15 {
-    %36 = hmacSha512(input,key) -> bb16;
-  }
-  bb16 {
-    $desugar$3 = %36;
-    %38 = $desugar$3 is error
-    %38 ? bb17 : bb18;
-  }
-  bb17 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %31;
     return;
   }
+  bb15 {
+    %30 = %31;
+    GOTO bb16;
+  }
+  bb16 {
+    %33 = length(%30) -> bb17;
+  }
+  bb17 {
+    %34 = %33;
+    %35 = println(%34) -> bb18;
+  }
   bb18 {
-    %39 = length($desugar$3) -> bb19;
+    %37 = hmacSha512(input,key) -> bb19;
   }
   bb19 {
-    %40 = %39;
-    %41 = println(%40) -> bb20;
+    %38 = %37 is error
+    %38 ? bb20 : bb21;
   }
   bb20 {
+    %0 = %37;
+    return;
+  }
+  bb21 {
+    %36 = %37;
+    GOTO bb22;
+  }
+  bb22 {
+    %39 = length(%36) -> bb23;
+  }
+  bb23 {
+    %40 = %39;
+    %41 = println(%40) -> bb24;
+  }
+  bb24 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/crypto-kdf1-v.txt
+++ b/corpus/bir/library/subset2/crypto-kdf1-v.txt
@@ -36,134 +36,138 @@ main() -> nil|error{
   }
   bb2 {
     $desugar$3 = %30;
-    %32 = $desugar$1;
-    %33 = hkdfSha256($desugar$0,%32,$desugar$2,$desugar$3) -> bb3;
+    %33 = $desugar$1;
+    %34 = hkdfSha256($desugar$0,%33,$desugar$2,$desugar$3) -> bb3;
   }
   bb3 {
-    $desugar$4 = %33;
-    %35 = $desugar$4 is error
+    %35 = %34 is error
     %35 ? bb4 : bb5;
   }
   bb4 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %34;
     return;
   }
   bb5 {
-    %36 = length($desugar$4) -> bb6;
+    %32 = %34;
+    GOTO bb6;
   }
   bb6 {
-    %37 = %36;
-    %38 = println(%37) -> bb7;
+    %36 = length(%32) -> bb7;
   }
   bb7 {
-    %39 = ConstantLoad 64
-    %40 = %39;
-    %41 = hkdfSha256(input,%40,salt,info) -> bb8;
+    %37 = %36;
+    %38 = println(%37) -> bb8;
   }
   bb8 {
-    $desugar$5 = %41;
-    %43 = $desugar$5 is error
-    %43 ? bb9 : bb10;
+    %40 = ConstantLoad 64
+    %41 = %40;
+    %42 = hkdfSha256(input,%41,salt,info) -> bb9;
   }
   bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %43 = %42 is error
+    %43 ? bb10 : bb11;
   }
   bb10 {
-    d1 = $desugar$5;
-    %45 = length(d1) -> bb11;
+    %0 = %42;
+    return;
   }
   bb11 {
-    %46 = %45;
-    %47 = println(%46) -> bb12;
+    %39 = %42;
+    GOTO bb12;
   }
   bb12 {
-    %48 = ConstantLoad 64
-    %49 = %48;
-    %50 = hkdfSha256(input,%49,salt,info) -> bb13;
+    d1 = %39;
+    %45 = length(d1) -> bb13;
   }
   bb13 {
-    $desugar$6 = %50;
-    %52 = $desugar$6 is error
-    %52 ? bb14 : bb15;
+    %46 = %45;
+    %47 = println(%46) -> bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    %49 = ConstantLoad 64
+    %50 = %49;
+    %51 = hkdfSha256(input,%50,salt,info) -> bb15;
   }
   bb15 {
-    d2 = $desugar$6;
-    %54 = == d1 d2;
-    %55 = %54;
-    %56 = println(%55) -> bb16;
+    %52 = %51 is error
+    %52 ? bb16 : bb17;
   }
   bb16 {
-    %57 = equalConstantTime(d1,d2) -> bb17;
-  }
-  bb17 {
-    %58 = %57;
-    %59 = println(%58) -> bb18;
-  }
-  bb18 {
-    %60 = ConstantLoad 64
-    %61 = %60;
-    %62 = hkdfSha256(input,%61,info,salt) -> bb19;
-  }
-  bb19 {
-    $desugar$7 = %62;
-    %64 = $desugar$7 is error
-    %64 ? bb20 : bb21;
-  }
-  bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
+    %0 = %51;
     return;
   }
+  bb17 {
+    %48 = %51;
+    GOTO bb18;
+  }
+  bb18 {
+    d2 = %48;
+    %54 = == d1 d2;
+    %55 = %54;
+    %56 = println(%55) -> bb19;
+  }
+  bb19 {
+    %57 = equalConstantTime(d1,d2) -> bb20;
+  }
+  bb20 {
+    %58 = %57;
+    %59 = println(%58) -> bb21;
+  }
   bb21 {
-    other = $desugar$7;
-    %66 = equalConstantTime(d1,other) -> bb22;
+    %61 = ConstantLoad 64
+    %62 = %61;
+    %63 = hkdfSha256(input,%62,info,salt) -> bb22;
   }
   bb22 {
-    %67 = %66;
-    %68 = println(%67) -> bb23;
+    %64 = %63 is error
+    %64 ? bb23 : bb24;
   }
   bb23 {
-    %69 = ConstantLoad abc123
-    %70 = ConstantLoad abc123
-    %71 = equalConstantTime(%69,%70) -> bb24;
+    %0 = %63;
+    return;
   }
   bb24 {
-    %72 = %71;
-    %73 = println(%72) -> bb25;
+    %60 = %63;
+    GOTO bb25;
   }
   bb25 {
-    %74 = ConstantLoad abc123
-    %75 = ConstantLoad def456
-    %76 = equalConstantTime(%74,%75) -> bb26;
+    other = %60;
+    %66 = equalConstantTime(d1,other) -> bb26;
   }
   bb26 {
-    %77 = %76;
-    %78 = println(%77) -> bb27;
+    %67 = %66;
+    %68 = println(%67) -> bb27;
   }
   bb27 {
-    %79 = ConstantLoad 0
-    %80 = %79;
-    %81 = hkdfSha256(input,%80,salt,info) -> bb28;
+    %69 = ConstantLoad abc123
+    %70 = ConstantLoad abc123
+    %71 = equalConstantTime(%69,%70) -> bb28;
   }
   bb28 {
+    %72 = %71;
+    %73 = println(%72) -> bb29;
+  }
+  bb29 {
+    %74 = ConstantLoad abc123
+    %75 = ConstantLoad def456
+    %76 = equalConstantTime(%74,%75) -> bb30;
+  }
+  bb30 {
+    %77 = %76;
+    %78 = println(%77) -> bb31;
+  }
+  bb31 {
+    %79 = ConstantLoad 0
+    %80 = %79;
+    %81 = hkdfSha256(input,%80,salt,info) -> bb32;
+  }
+  bb32 {
     badLen = %81;
     %83 = badLen is error
     %84 = %83;
-    %85 = println(%84) -> bb29;
+    %85 = println(%84) -> bb33;
   }
-  bb29 {
+  bb33 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/crypto-keys-enc-v.txt
+++ b/corpus/bir/library/subset2/crypto-keys-enc-v.txt
@@ -112,220 +112,230 @@ O7ekKjOszIhNsvlgkHI=
   }
   bb1 {
     $desugar$2 = %17;
-    %19 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %20 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %19;
-    %21 = $desugar$3 is error
+    %21 = %20 is error
     %21 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %20;
     return;
   }
   bb4 {
-    %22 = ConstantLoad /tmp/bal_crypto_enc.pem
-    %23 = ConstantLoad secret
-    %24 = decodeRsaPrivateKeyFromKeyFile(%22,%23) -> bb5;
+    %19 = %20;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %24;
-    %26 = $desugar$4 is error
-    %26 ? bb6 : bb7;
+    %23 = ConstantLoad /tmp/bal_crypto_enc.pem
+    %24 = ConstantLoad secret
+    %25 = decodeRsaPrivateKeyFromKeyFile(%23,%24) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %26 = %25 is error
+    %26 ? bb7 : bb8;
   }
   bb7 {
-    pkPbes2 = $desugar$4;
-    %28 = signRsaSha256(data,pkPbes2) -> bb8;
-  }
-  bb8 {
-    $desugar$5 = %28;
-    %30 = $desugar$5 is error
-    %30 ? bb9 : bb10;
-  }
-  bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %25;
     return;
   }
+  bb8 {
+    %22 = %25;
+    GOTO bb9;
+  }
+  bb9 {
+    pkPbes2 = %22;
+    %30 = signRsaSha256(data,pkPbes2) -> bb10;
+  }
   bb10 {
-    %32 = length($desugar$5) -> bb11;
+    %31 = %30 is error
+    %31 ? bb11 : bb12;
   }
   bb11 {
+    %0 = %30;
+    return;
+  }
+  bb12 {
+    %29 = %30;
+    GOTO bb13;
+  }
+  bb13 {
+    %32 = length(%29) -> bb14;
+  }
+  bb14 {
     %33 = %32;
     %34 = ConstantLoad 0
     %35 = %34;
-    %31 = > %33 %35;
-    %36 = %31;
-    %37 = println(%36) -> bb12;
-  }
-  bb12 {
-    %38 = ConstantLoad /tmp/bal_crypto_enc.pem
-    $desugar$6 = %38;
-    $desugar$7 = pbe3des;
-    %41 = $default$1($desugar$6,$desugar$7) -> bb13;
-  }
-  bb13 {
-    $desugar$8 = %41;
-    %43 = fileWriteString($desugar$6,$desugar$7,$desugar$8) -> bb14;
-  }
-  bb14 {
-    $desugar$9 = %43;
-    %45 = $desugar$9 is error
-    %45 ? bb15 : bb16;
+    %28 = > %33 %35;
+    %36 = %28;
+    %37 = println(%36) -> bb15;
   }
   bb15 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
-    return;
+    %38 = ConstantLoad /tmp/bal_crypto_enc.pem
+    $desugar$3 = %38;
+    $desugar$4 = pbe3des;
+    %41 = $default$1($desugar$3,$desugar$4) -> bb16;
   }
   bb16 {
-    %46 = ConstantLoad /tmp/bal_crypto_enc.pem
-    %47 = ConstantLoad secret
-    %48 = decodeRsaPrivateKeyFromKeyFile(%46,%47) -> bb17;
+    $desugar$5 = %41;
+    %44 = fileWriteString($desugar$3,$desugar$4,$desugar$5) -> bb17;
   }
   bb17 {
-    $desugar$10 = %48;
-    %50 = $desugar$10 is error
-    %50 ? bb18 : bb19;
+    %45 = %44 is error
+    %45 ? bb18 : bb19;
   }
   bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
+    %0 = %44;
     return;
   }
   bb19 {
-    pk3des = $desugar$10;
-    %52 = signRsaSha256(data,pk3des) -> bb20;
+    %43 = %44;
+    GOTO bb20;
   }
   bb20 {
-    $desugar$11 = %52;
-    %54 = $desugar$11 is error
-    %54 ? bb21 : bb22;
+    %47 = ConstantLoad /tmp/bal_crypto_enc.pem
+    %48 = ConstantLoad secret
+    %49 = decodeRsaPrivateKeyFromKeyFile(%47,%48) -> bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
-    return;
+    %50 = %49 is error
+    %50 ? bb22 : bb23;
   }
   bb22 {
-    %56 = length($desugar$11) -> bb23;
+    %0 = %49;
+    return;
   }
   bb23 {
+    %46 = %49;
+    GOTO bb24;
+  }
+  bb24 {
+    pk3des = %46;
+    %54 = signRsaSha256(data,pk3des) -> bb25;
+  }
+  bb25 {
+    %55 = %54 is error
+    %55 ? bb26 : bb27;
+  }
+  bb26 {
+    %0 = %54;
+    return;
+  }
+  bb27 {
+    %53 = %54;
+    GOTO bb28;
+  }
+  bb28 {
+    %56 = length(%53) -> bb29;
+  }
+  bb29 {
     %57 = %56;
     %58 = ConstantLoad 0
     %59 = %58;
-    %55 = > %57 %59;
-    %60 = %55;
-    %61 = println(%60) -> bb24;
-  }
-  bb24 {
-    %62 = ConstantLoad /tmp/bal_crypto_enc.pem
-    $desugar$12 = %62;
-    $desugar$13 = pbeRc2;
-    %65 = $default$1($desugar$12,$desugar$13) -> bb25;
-  }
-  bb25 {
-    $desugar$14 = %65;
-    %67 = fileWriteString($desugar$12,$desugar$13,$desugar$14) -> bb26;
-  }
-  bb26 {
-    $desugar$15 = %67;
-    %69 = $desugar$15 is error
-    %69 ? bb27 : bb28;
-  }
-  bb27 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$15);
-    PopScopeFrame
-    return;
-  }
-  bb28 {
-    %70 = ConstantLoad /tmp/bal_crypto_enc.pem
-    %71 = ConstantLoad secret
-    %72 = decodeRsaPrivateKeyFromKeyFile(%70,%71) -> bb29;
-  }
-  bb29 {
-    $desugar$16 = %72;
-    %74 = $desugar$16 is error
-    %74 ? bb30 : bb31;
+    %52 = > %57 %59;
+    %60 = %52;
+    %61 = println(%60) -> bb30;
   }
   bb30 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$16);
-    PopScopeFrame
-    return;
+    %62 = ConstantLoad /tmp/bal_crypto_enc.pem
+    $desugar$6 = %62;
+    $desugar$7 = pbeRc2;
+    %65 = $default$1($desugar$6,$desugar$7) -> bb31;
   }
   bb31 {
-    pkRc2 = $desugar$16;
-    %76 = signRsaSha256(data,pkRc2) -> bb32;
+    $desugar$8 = %65;
+    %68 = fileWriteString($desugar$6,$desugar$7,$desugar$8) -> bb32;
   }
   bb32 {
-    $desugar$17 = %76;
-    %78 = $desugar$17 is error
-    %78 ? bb33 : bb34;
+    %69 = %68 is error
+    %69 ? bb33 : bb34;
   }
   bb33 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
+    %0 = %68;
     return;
   }
   bb34 {
-    %80 = length($desugar$17) -> bb35;
+    %67 = %68;
+    GOTO bb35;
   }
   bb35 {
+    %71 = ConstantLoad /tmp/bal_crypto_enc.pem
+    %72 = ConstantLoad secret
+    %73 = decodeRsaPrivateKeyFromKeyFile(%71,%72) -> bb36;
+  }
+  bb36 {
+    %74 = %73 is error
+    %74 ? bb37 : bb38;
+  }
+  bb37 {
+    %0 = %73;
+    return;
+  }
+  bb38 {
+    %70 = %73;
+    GOTO bb39;
+  }
+  bb39 {
+    pkRc2 = %70;
+    %78 = signRsaSha256(data,pkRc2) -> bb40;
+  }
+  bb40 {
+    %79 = %78 is error
+    %79 ? bb41 : bb42;
+  }
+  bb41 {
+    %0 = %78;
+    return;
+  }
+  bb42 {
+    %77 = %78;
+    GOTO bb43;
+  }
+  bb43 {
+    %80 = length(%77) -> bb44;
+  }
+  bb44 {
     %81 = %80;
     %82 = ConstantLoad 0
     %83 = %82;
-    %79 = > %81 %83;
-    %84 = %79;
-    %85 = println(%84) -> bb36;
+    %76 = > %81 %83;
+    %84 = %76;
+    %85 = println(%84) -> bb45;
   }
-  bb36 {
+  bb45 {
     %86 = ConstantLoad /tmp/bal_crypto_enc.pem
-    $desugar$18 = %86;
-    $desugar$19 = pbes2;
-    %89 = $default$1($desugar$18,$desugar$19) -> bb37;
+    $desugar$9 = %86;
+    $desugar$10 = pbes2;
+    %89 = $default$1($desugar$9,$desugar$10) -> bb46;
   }
-  bb37 {
-    $desugar$20 = %89;
-    %91 = fileWriteString($desugar$18,$desugar$19,$desugar$20) -> bb38;
+  bb46 {
+    $desugar$11 = %89;
+    %92 = fileWriteString($desugar$9,$desugar$10,$desugar$11) -> bb47;
   }
-  bb38 {
-    $desugar$21 = %91;
-    %93 = $desugar$21 is error
-    %93 ? bb39 : bb40;
+  bb47 {
+    %93 = %92 is error
+    %93 ? bb48 : bb49;
   }
-  bb39 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$21);
-    PopScopeFrame
+  bb48 {
+    %0 = %92;
     return;
   }
-  bb40 {
+  bb49 {
+    %91 = %92;
+    GOTO bb50;
+  }
+  bb50 {
     %94 = ConstantLoad /tmp/bal_crypto_enc.pem
     %95 = ConstantLoad wrong
-    %96 = decodeRsaPrivateKeyFromKeyFile(%94,%95) -> bb41;
+    %96 = decodeRsaPrivateKeyFromKeyFile(%94,%95) -> bb51;
   }
-  bb41 {
+  bb51 {
     bad = %96;
     %98 = bad is error
     %99 = %98;
-    %100 = println(%99) -> bb42;
+    %100 = println(%99) -> bb52;
   }
-  bb42 {
+  bb52 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/crypto-keys-v.txt
+++ b/corpus/bir/library/subset2/crypto-keys-v.txt
@@ -82,130 +82,136 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
   }
   bb1 {
     $desugar$2 = %12;
-    %14 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %15 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %14;
-    %16 = $desugar$3 is error
+    %16 = %15 is error
     %16 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %15;
     return;
   }
   bb4 {
-    %17 = ConstantLoad /tmp/bal_rsa_cert.pem
-    $desugar$4 = %17;
-    $desugar$5 = rsaCert;
-    %20 = $default$1($desugar$4,$desugar$5) -> bb5;
+    %14 = %15;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$6 = %20;
-    %22 = fileWriteString($desugar$4,$desugar$5,$desugar$6) -> bb6;
+    %17 = ConstantLoad /tmp/bal_rsa_cert.pem
+    $desugar$3 = %17;
+    $desugar$4 = rsaCert;
+    %20 = $default$1($desugar$3,$desugar$4) -> bb6;
   }
   bb6 {
-    $desugar$7 = %22;
-    %24 = $desugar$7 is error
-    %24 ? bb7 : bb8;
+    $desugar$5 = %20;
+    %23 = fileWriteString($desugar$3,$desugar$4,$desugar$5) -> bb7;
   }
   bb7 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    %24 = %23 is error
+    %24 ? bb8 : bb9;
   }
   bb8 {
-    %25 = ConstantLoad /tmp/bal_ec_key.pem
-    $desugar$8 = %25;
-    $desugar$9 = ecKey;
-    %28 = $default$1($desugar$8,$desugar$9) -> bb9;
+    %0 = %23;
+    return;
   }
   bb9 {
-    $desugar$10 = %28;
-    %30 = fileWriteString($desugar$8,$desugar$9,$desugar$10) -> bb10;
+    %22 = %23;
+    GOTO bb10;
   }
   bb10 {
-    $desugar$11 = %30;
-    %32 = $desugar$11 is error
-    %32 ? bb11 : bb12;
+    %25 = ConstantLoad /tmp/bal_ec_key.pem
+    $desugar$6 = %25;
+    $desugar$7 = ecKey;
+    %28 = $default$1($desugar$6,$desugar$7) -> bb11;
   }
   bb11 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
-    return;
+    $desugar$8 = %28;
+    %31 = fileWriteString($desugar$6,$desugar$7,$desugar$8) -> bb12;
   }
   bb12 {
-    %33 = ConstantLoad /tmp/bal_ec_cert.pem
-    $desugar$12 = %33;
-    $desugar$13 = ecCert;
-    %36 = $default$1($desugar$12,$desugar$13) -> bb13;
+    %32 = %31 is error
+    %32 ? bb13 : bb14;
   }
   bb13 {
-    $desugar$14 = %36;
-    %38 = fileWriteString($desugar$12,$desugar$13,$desugar$14) -> bb14;
+    %0 = %31;
+    return;
   }
   bb14 {
-    $desugar$15 = %38;
-    %40 = $desugar$15 is error
-    %40 ? bb15 : bb16;
+    %30 = %31;
+    GOTO bb15;
   }
   bb15 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$15);
-    PopScopeFrame
-    return;
+    %33 = ConstantLoad /tmp/bal_ec_cert.pem
+    $desugar$9 = %33;
+    $desugar$10 = ecCert;
+    %36 = $default$1($desugar$9,$desugar$10) -> bb16;
   }
   bb16 {
-    %41 = ConstantLoad /tmp/bal_rsa_key.pem
-    $desugar$16 = %41;
-    %43 = $default$0($desugar$16) -> bb17;
+    $desugar$11 = %36;
+    %39 = fileWriteString($desugar$9,$desugar$10,$desugar$11) -> bb17;
   }
   bb17 {
-    $desugar$17 = %43;
-    %45 = decodeRsaPrivateKeyFromKeyFile($desugar$16,$desugar$17) -> bb18;
+    %40 = %39 is error
+    %40 ? bb18 : bb19;
   }
   bb18 {
-    $desugar$18 = %45;
-    %47 = $desugar$18 is error
-    %47 ? bb19 : bb20;
+    %0 = %39;
+    return;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
-    return;
+    %38 = %39;
+    GOTO bb20;
   }
   bb20 {
-    rsaPk = $desugar$18;
-    %49 = ConstantLoad /tmp/bal_rsa_cert.pem
-    %50 = decodeRsaPublicKeyFromCertFile(%49) -> bb21;
+    %41 = ConstantLoad /tmp/bal_rsa_key.pem
+    $desugar$12 = %41;
+    %43 = $default$0($desugar$12) -> bb21;
   }
   bb21 {
-    $desugar$19 = %50;
-    %52 = $desugar$19 is error
-    %52 ? bb22 : bb23;
+    $desugar$13 = %43;
+    %46 = decodeRsaPrivateKeyFromKeyFile($desugar$12,$desugar$13) -> bb22;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$19);
-    PopScopeFrame
-    return;
+    %47 = %46 is error
+    %47 ? bb23 : bb24;
   }
   bb23 {
-    rsaPub = $desugar$19;
-    %55 = ConstantLoad algorithm
-    %54 = rsaPk[%55];
-    %56 = println(%54) -> bb24;
+    %0 = %46;
+    return;
   }
   bb24 {
-    %58 = ConstantLoad algorithm
-    %57 = rsaPub[%58];
-    %59 = println(%57) -> bb25;
+    %45 = %46;
+    GOTO bb25;
   }
   bb25 {
+    rsaPk = %45;
+    %50 = ConstantLoad /tmp/bal_rsa_cert.pem
+    %51 = decodeRsaPublicKeyFromCertFile(%50) -> bb26;
+  }
+  bb26 {
+    %52 = %51 is error
+    %52 ? bb27 : bb28;
+  }
+  bb27 {
+    %0 = %51;
+    return;
+  }
+  bb28 {
+    %49 = %51;
+    GOTO bb29;
+  }
+  bb29 {
+    rsaPub = %49;
+    %55 = ConstantLoad algorithm
+    %54 = rsaPk[%55];
+    %56 = println(%54) -> bb30;
+  }
+  bb30 {
+    %58 = ConstantLoad algorithm
+    %57 = rsaPub[%58];
+    %59 = println(%57) -> bb31;
+  }
+  bb31 {
     %60 = ConstantLoad 1
     %61 = ConstantLoad 2
     %62 = ConstantLoad 3
@@ -217,874 +223,920 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
     %68 = ConstantLoad 8
     %69 = newArray [int:Unsigned8...][%68]{%60, %61, %62, %63, %64, %65, %66, %67}
     data = %69;
-    %71 = signRsaSha256(data,rsaPk) -> bb26;
-  }
-  bb26 {
-    $desugar$20 = %71;
-    %73 = $desugar$20 is error
-    %73 ? bb27 : bb28;
-  }
-  bb27 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
-  }
-  bb28 {
-    s256 = $desugar$20;
-    %75 = verifyRsaSha256Signature(data,s256,rsaPub) -> bb29;
-  }
-  bb29 {
-    $desugar$21 = %75;
-    %77 = $desugar$21 is error
-    %77 ? bb30 : bb31;
-  }
-  bb30 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$21);
-    PopScopeFrame
-    return;
-  }
-  bb31 {
-    %78 = println($desugar$21) -> bb32;
+    %72 = signRsaSha256(data,rsaPk) -> bb32;
   }
   bb32 {
-    %79 = signRsaSha384(data,rsaPk) -> bb33;
+    %73 = %72 is error
+    %73 ? bb33 : bb34;
   }
   bb33 {
-    $desugar$22 = %79;
-    %81 = $desugar$22 is error
-    %81 ? bb34 : bb35;
-  }
-  bb34 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
+    %0 = %72;
     return;
   }
+  bb34 {
+    %71 = %72;
+    GOTO bb35;
+  }
   bb35 {
-    s384 = $desugar$22;
-    %83 = verifyRsaSha384Signature(data,s384,rsaPub) -> bb36;
+    s256 = %71;
+    %76 = verifyRsaSha256Signature(data,s256,rsaPub) -> bb36;
   }
   bb36 {
-    $desugar$23 = %83;
-    %85 = $desugar$23 is error
-    %85 ? bb37 : bb38;
+    %77 = %76 is error
+    %77 ? bb37 : bb38;
   }
   bb37 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$23);
-    PopScopeFrame
+    %0 = %76;
     return;
   }
   bb38 {
-    %86 = println($desugar$23) -> bb39;
+    %75 = %76;
+    GOTO bb39;
   }
   bb39 {
-    %87 = signRsaSha512(data,rsaPk) -> bb40;
+    %78 = %75;
+    %79 = println(%78) -> bb40;
   }
   bb40 {
-    $desugar$24 = %87;
-    %89 = $desugar$24 is error
-    %89 ? bb41 : bb42;
+    %81 = signRsaSha384(data,rsaPk) -> bb41;
   }
   bb41 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$24);
-    PopScopeFrame
-    return;
+    %82 = %81 is error
+    %82 ? bb42 : bb43;
   }
   bb42 {
-    s512 = $desugar$24;
-    %91 = verifyRsaSha512Signature(data,s512,rsaPub) -> bb43;
+    %0 = %81;
+    return;
   }
   bb43 {
-    $desugar$25 = %91;
-    %93 = $desugar$25 is error
-    %93 ? bb44 : bb45;
+    %80 = %81;
+    GOTO bb44;
   }
   bb44 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$25);
-    PopScopeFrame
-    return;
+    s384 = %80;
+    %85 = verifyRsaSha384Signature(data,s384,rsaPub) -> bb45;
   }
   bb45 {
-    %94 = println($desugar$25) -> bb46;
+    %86 = %85 is error
+    %86 ? bb46 : bb47;
   }
   bb46 {
-    %95 = signRsaSha1(data,rsaPk) -> bb47;
-  }
-  bb47 {
-    $desugar$26 = %95;
-    %97 = $desugar$26 is error
-    %97 ? bb48 : bb49;
-  }
-  bb48 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$26);
-    PopScopeFrame
+    %0 = %85;
     return;
   }
+  bb47 {
+    %84 = %85;
+    GOTO bb48;
+  }
+  bb48 {
+    %87 = %84;
+    %88 = println(%87) -> bb49;
+  }
   bb49 {
-    s1 = $desugar$26;
-    %99 = verifyRsaSha1Signature(data,s1,rsaPub) -> bb50;
+    %90 = signRsaSha512(data,rsaPk) -> bb50;
   }
   bb50 {
-    $desugar$27 = %99;
-    %101 = $desugar$27 is error
-    %101 ? bb51 : bb52;
+    %91 = %90 is error
+    %91 ? bb51 : bb52;
   }
   bb51 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$27);
-    PopScopeFrame
+    %0 = %90;
     return;
   }
   bb52 {
-    %102 = println($desugar$27) -> bb53;
+    %89 = %90;
+    GOTO bb53;
   }
   bb53 {
-    %103 = signRsaMd5(data,rsaPk) -> bb54;
+    s512 = %89;
+    %94 = verifyRsaSha512Signature(data,s512,rsaPub) -> bb54;
   }
   bb54 {
-    $desugar$28 = %103;
-    %105 = $desugar$28 is error
-    %105 ? bb55 : bb56;
+    %95 = %94 is error
+    %95 ? bb55 : bb56;
   }
   bb55 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$28);
-    PopScopeFrame
+    %0 = %94;
     return;
   }
   bb56 {
-    sMd5 = $desugar$28;
-    %107 = verifyRsaMd5Signature(data,sMd5,rsaPub) -> bb57;
+    %93 = %94;
+    GOTO bb57;
   }
   bb57 {
-    $desugar$29 = %107;
-    %109 = $desugar$29 is error
-    %109 ? bb58 : bb59;
+    %96 = %93;
+    %97 = println(%96) -> bb58;
   }
   bb58 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$29);
-    PopScopeFrame
-    return;
+    %99 = signRsaSha1(data,rsaPk) -> bb59;
   }
   bb59 {
-    %110 = println($desugar$29) -> bb60;
+    %100 = %99 is error
+    %100 ? bb60 : bb61;
   }
   bb60 {
-    %111 = signRsaSsaPss256(data,rsaPk) -> bb61;
+    %0 = %99;
+    return;
   }
   bb61 {
-    $desugar$30 = %111;
-    %113 = $desugar$30 is error
-    %113 ? bb62 : bb63;
+    %98 = %99;
+    GOTO bb62;
   }
   bb62 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$30);
-    PopScopeFrame
-    return;
+    s1 = %98;
+    %103 = verifyRsaSha1Signature(data,s1,rsaPub) -> bb63;
   }
   bb63 {
-    sPss = $desugar$30;
-    %115 = verifyRsaSsaPss256Signature(data,sPss,rsaPub) -> bb64;
+    %104 = %103 is error
+    %104 ? bb64 : bb65;
   }
   bb64 {
-    $desugar$31 = %115;
-    %117 = $desugar$31 is error
-    %117 ? bb65 : bb66;
-  }
-  bb65 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$31);
-    PopScopeFrame
+    %0 = %103;
     return;
   }
+  bb65 {
+    %102 = %103;
+    GOTO bb66;
+  }
   bb66 {
-    %118 = println($desugar$31) -> bb67;
+    %105 = %102;
+    %106 = println(%105) -> bb67;
   }
   bb67 {
-    %119 = ConstantLoad 9
-    %120 = ConstantLoad 9
-    %121 = ConstantLoad 9
-    %122 = ConstantLoad 3
-    %123 = newArray [int:Unsigned8...][%122]{%119, %120, %121}
-    %124 = verifyRsaSha256Signature(%123,s256,rsaPub) -> bb68;
+    %108 = signRsaMd5(data,rsaPk) -> bb68;
   }
   bb68 {
-    $desugar$32 = %124;
-    %126 = $desugar$32 is error
-    %126 ? bb69 : bb70;
+    %109 = %108 is error
+    %109 ? bb69 : bb70;
   }
   bb69 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$32);
-    PopScopeFrame
+    %0 = %108;
     return;
   }
   bb70 {
-    %127 = println($desugar$32) -> bb71;
+    %107 = %108;
+    GOTO bb71;
   }
   bb71 {
-    $desugar$33 = data;
-    $desugar$34 = rsaPub;
-    %130 = $default$17($desugar$33,$desugar$34) -> bb72;
+    sMd5 = %107;
+    %112 = verifyRsaMd5Signature(data,sMd5,rsaPub) -> bb72;
   }
   bb72 {
-    $desugar$35 = %130;
-    %132 = encryptRsaEcb($desugar$33,$desugar$34,$desugar$35) -> bb73;
+    %113 = %112 is error
+    %113 ? bb73 : bb74;
   }
   bb73 {
-    $desugar$36 = %132;
-    %134 = $desugar$36 is error
-    %134 ? bb74 : bb75;
-  }
-  bb74 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$36);
-    PopScopeFrame
+    %0 = %112;
     return;
   }
+  bb74 {
+    %111 = %112;
+    GOTO bb75;
+  }
   bb75 {
-    ct = $desugar$36;
-    $desugar$37 = ct;
-    $desugar$38 = rsaPk;
-    %138 = $default$22($desugar$37,$desugar$38) -> bb76;
+    %114 = %111;
+    %115 = println(%114) -> bb76;
   }
   bb76 {
-    $desugar$39 = %138;
-    %140 = decryptRsaEcb($desugar$37,$desugar$38,$desugar$39) -> bb77;
+    %117 = signRsaSsaPss256(data,rsaPk) -> bb77;
   }
   bb77 {
-    $desugar$40 = %140;
-    %142 = $desugar$40 is error
-    %142 ? bb78 : bb79;
+    %118 = %117 is error
+    %118 ? bb78 : bb79;
   }
   bb78 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$40);
-    PopScopeFrame
+    %0 = %117;
     return;
   }
   bb79 {
-    %143 = == $desugar$40 data;
-    %144 = %143;
-    %145 = println(%144) -> bb80;
+    %116 = %117;
+    GOTO bb80;
   }
   bb80 {
-    %146 = ConstantLoad OAEPwithMD5andMGF1
-    %147 = encryptRsaEcb(data,rsaPub,%146) -> bb81;
+    sPss = %116;
+    %121 = verifyRsaSsaPss256Signature(data,sPss,rsaPub) -> bb81;
   }
   bb81 {
-    $desugar$41 = %147;
-    %149 = $desugar$41 is error
-    %149 ? bb82 : bb83;
+    %122 = %121 is error
+    %122 ? bb82 : bb83;
   }
   bb82 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$41);
-    PopScopeFrame
+    %0 = %121;
     return;
   }
   bb83 {
-    oaepMd5 = $desugar$41;
-    %151 = ConstantLoad OAEPwithMD5andMGF1
-    %152 = decryptRsaEcb(oaepMd5,rsaPk,%151) -> bb84;
+    %120 = %121;
+    GOTO bb84;
   }
   bb84 {
-    $desugar$42 = %152;
-    %154 = $desugar$42 is error
-    %154 ? bb85 : bb86;
+    %123 = %120;
+    %124 = println(%123) -> bb85;
   }
   bb85 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$42);
-    PopScopeFrame
-    return;
+    %126 = ConstantLoad 9
+    %127 = ConstantLoad 9
+    %128 = ConstantLoad 9
+    %129 = ConstantLoad 3
+    %130 = newArray [int:Unsigned8...][%129]{%126, %127, %128}
+    %131 = verifyRsaSha256Signature(%130,s256,rsaPub) -> bb86;
   }
   bb86 {
-    %155 = == $desugar$42 data;
-    %156 = %155;
-    %157 = println(%156) -> bb87;
+    %132 = %131 is error
+    %132 ? bb87 : bb88;
   }
   bb87 {
-    %158 = ConstantLoad OAEPWithSHA1AndMGF1
-    %159 = encryptRsaEcb(data,rsaPub,%158) -> bb88;
+    %0 = %131;
+    return;
   }
   bb88 {
-    $desugar$43 = %159;
-    %161 = $desugar$43 is error
-    %161 ? bb89 : bb90;
+    %125 = %131;
+    GOTO bb89;
   }
   bb89 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$43);
-    PopScopeFrame
-    return;
+    %133 = %125;
+    %134 = println(%133) -> bb90;
   }
   bb90 {
-    oaep1 = $desugar$43;
-    %163 = ConstantLoad OAEPWithSHA1AndMGF1
-    %164 = decryptRsaEcb(oaep1,rsaPk,%163) -> bb91;
+    $desugar$14 = data;
+    $desugar$15 = rsaPub;
+    %137 = $default$17($desugar$14,$desugar$15) -> bb91;
   }
   bb91 {
-    $desugar$44 = %164;
-    %166 = $desugar$44 is error
-    %166 ? bb92 : bb93;
+    $desugar$16 = %137;
+    %140 = encryptRsaEcb($desugar$14,$desugar$15,$desugar$16) -> bb92;
   }
   bb92 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$44);
-    PopScopeFrame
-    return;
+    %141 = %140 is error
+    %141 ? bb93 : bb94;
   }
   bb93 {
-    %167 = == $desugar$44 data;
-    %168 = %167;
-    %169 = println(%168) -> bb94;
+    %0 = %140;
+    return;
   }
   bb94 {
-    %170 = ConstantLoad OAEPWithSHA256AndMGF1
-    %171 = encryptRsaEcb(data,rsaPub,%170) -> bb95;
+    %139 = %140;
+    GOTO bb95;
   }
   bb95 {
-    $desugar$45 = %171;
-    %173 = $desugar$45 is error
-    %173 ? bb96 : bb97;
+    ct = %139;
+    $desugar$17 = ct;
+    $desugar$18 = rsaPk;
+    %145 = $default$22($desugar$17,$desugar$18) -> bb96;
   }
   bb96 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$45);
-    PopScopeFrame
-    return;
+    $desugar$19 = %145;
+    %149 = decryptRsaEcb($desugar$17,$desugar$18,$desugar$19) -> bb97;
   }
   bb97 {
-    oaep256 = $desugar$45;
-    %175 = ConstantLoad OAEPWithSHA256AndMGF1
-    %176 = decryptRsaEcb(oaep256,rsaPk,%175) -> bb98;
+    %150 = %149 is error
+    %150 ? bb98 : bb99;
   }
   bb98 {
-    $desugar$46 = %176;
-    %178 = $desugar$46 is error
-    %178 ? bb99 : bb100;
-  }
-  bb99 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$46);
-    PopScopeFrame
+    %0 = %149;
     return;
   }
+  bb99 {
+    %148 = %149;
+    GOTO bb100;
+  }
   bb100 {
-    %179 = == $desugar$46 data;
-    %180 = %179;
-    %181 = println(%180) -> bb101;
+    %147 = == %148 data;
+    %151 = %147;
+    %152 = println(%151) -> bb101;
   }
   bb101 {
-    %182 = ConstantLoad OAEPwithSHA384andMGF1
-    %183 = encryptRsaEcb(data,rsaPub,%182) -> bb102;
+    %154 = ConstantLoad OAEPwithMD5andMGF1
+    %155 = encryptRsaEcb(data,rsaPub,%154) -> bb102;
   }
   bb102 {
-    $desugar$47 = %183;
-    %185 = $desugar$47 is error
-    %185 ? bb103 : bb104;
+    %156 = %155 is error
+    %156 ? bb103 : bb104;
   }
   bb103 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$47);
-    PopScopeFrame
+    %0 = %155;
     return;
   }
   bb104 {
-    oaep384 = $desugar$47;
-    %187 = ConstantLoad OAEPwithSHA384andMGF1
-    %188 = decryptRsaEcb(oaep384,rsaPk,%187) -> bb105;
+    %153 = %155;
+    GOTO bb105;
   }
   bb105 {
-    $desugar$48 = %188;
-    %190 = $desugar$48 is error
-    %190 ? bb106 : bb107;
+    oaepMd5 = %153;
+    %160 = ConstantLoad OAEPwithMD5andMGF1
+    %161 = decryptRsaEcb(oaepMd5,rsaPk,%160) -> bb106;
   }
   bb106 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$48);
-    PopScopeFrame
-    return;
+    %162 = %161 is error
+    %162 ? bb107 : bb108;
   }
   bb107 {
-    %191 = == $desugar$48 data;
-    %192 = %191;
-    %193 = println(%192) -> bb108;
+    %0 = %161;
+    return;
   }
   bb108 {
-    %194 = ConstantLoad OAEPwithSHA512andMGF1
-    %195 = encryptRsaEcb(data,rsaPub,%194) -> bb109;
+    %159 = %161;
+    GOTO bb109;
   }
   bb109 {
-    $desugar$49 = %195;
-    %197 = $desugar$49 is error
-    %197 ? bb110 : bb111;
+    %158 = == %159 data;
+    %163 = %158;
+    %164 = println(%163) -> bb110;
   }
   bb110 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$49);
-    PopScopeFrame
-    return;
+    %166 = ConstantLoad OAEPWithSHA1AndMGF1
+    %167 = encryptRsaEcb(data,rsaPub,%166) -> bb111;
   }
   bb111 {
-    oaep512 = $desugar$49;
-    %199 = ConstantLoad OAEPwithSHA512andMGF1
-    %200 = decryptRsaEcb(oaep512,rsaPk,%199) -> bb112;
+    %168 = %167 is error
+    %168 ? bb112 : bb113;
   }
   bb112 {
-    $desugar$50 = %200;
-    %202 = $desugar$50 is error
-    %202 ? bb113 : bb114;
+    %0 = %167;
+    return;
   }
   bb113 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$50);
-    PopScopeFrame
-    return;
+    %165 = %167;
+    GOTO bb114;
   }
   bb114 {
-    %203 = == $desugar$50 data;
-    %204 = %203;
-    %205 = println(%204) -> bb115;
+    oaep1 = %165;
+    %172 = ConstantLoad OAEPWithSHA1AndMGF1
+    %173 = decryptRsaEcb(oaep1,rsaPk,%172) -> bb115;
   }
   bb115 {
-    %206 = ConstantLoad /tmp/bal_ec_key.pem
-    $desugar$51 = %206;
-    %208 = $default$2($desugar$51) -> bb116;
+    %174 = %173 is error
+    %174 ? bb116 : bb117;
   }
   bb116 {
-    $desugar$52 = %208;
-    %210 = decodeEcPrivateKeyFromKeyFile($desugar$51,$desugar$52) -> bb117;
-  }
-  bb117 {
-    $desugar$53 = %210;
-    %212 = $desugar$53 is error
-    %212 ? bb118 : bb119;
-  }
-  bb118 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$53);
-    PopScopeFrame
+    %0 = %173;
     return;
   }
+  bb117 {
+    %171 = %173;
+    GOTO bb118;
+  }
+  bb118 {
+    %170 = == %171 data;
+    %175 = %170;
+    %176 = println(%175) -> bb119;
+  }
   bb119 {
-    ecPk = $desugar$53;
-    %214 = ConstantLoad /tmp/bal_ec_cert.pem
-    %215 = decodeEcPublicKeyFromCertFile(%214) -> bb120;
+    %178 = ConstantLoad OAEPWithSHA256AndMGF1
+    %179 = encryptRsaEcb(data,rsaPub,%178) -> bb120;
   }
   bb120 {
-    $desugar$54 = %215;
-    %217 = $desugar$54 is error
-    %217 ? bb121 : bb122;
+    %180 = %179 is error
+    %180 ? bb121 : bb122;
   }
   bb121 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$54);
-    PopScopeFrame
+    %0 = %179;
     return;
   }
   bb122 {
-    ecPub = $desugar$54;
-    %219 = signSha256withEcdsa(data,ecPk) -> bb123;
+    %177 = %179;
+    GOTO bb123;
   }
   bb123 {
-    $desugar$55 = %219;
-    %221 = $desugar$55 is error
-    %221 ? bb124 : bb125;
+    oaep256 = %177;
+    %184 = ConstantLoad OAEPWithSHA256AndMGF1
+    %185 = decryptRsaEcb(oaep256,rsaPk,%184) -> bb124;
   }
   bb124 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$55);
-    PopScopeFrame
-    return;
+    %186 = %185 is error
+    %186 ? bb125 : bb126;
   }
   bb125 {
-    e256 = $desugar$55;
-    %223 = verifySha256withEcdsaSignature(data,e256,ecPub) -> bb126;
+    %0 = %185;
+    return;
   }
   bb126 {
-    $desugar$56 = %223;
-    %225 = $desugar$56 is error
-    %225 ? bb127 : bb128;
+    %183 = %185;
+    GOTO bb127;
   }
   bb127 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$56);
-    PopScopeFrame
-    return;
+    %182 = == %183 data;
+    %187 = %182;
+    %188 = println(%187) -> bb128;
   }
   bb128 {
-    %226 = println($desugar$56) -> bb129;
+    %190 = ConstantLoad OAEPwithSHA384andMGF1
+    %191 = encryptRsaEcb(data,rsaPub,%190) -> bb129;
   }
   bb129 {
-    %227 = signSha384withEcdsa(data,ecPk) -> bb130;
+    %192 = %191 is error
+    %192 ? bb130 : bb131;
   }
   bb130 {
-    $desugar$57 = %227;
-    %229 = $desugar$57 is error
-    %229 ? bb131 : bb132;
-  }
-  bb131 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$57);
-    PopScopeFrame
+    %0 = %191;
     return;
   }
+  bb131 {
+    %189 = %191;
+    GOTO bb132;
+  }
   bb132 {
-    e384 = $desugar$57;
-    %231 = verifySha384withEcdsaSignature(data,e384,ecPub) -> bb133;
+    oaep384 = %189;
+    %196 = ConstantLoad OAEPwithSHA384andMGF1
+    %197 = decryptRsaEcb(oaep384,rsaPk,%196) -> bb133;
   }
   bb133 {
-    $desugar$58 = %231;
-    %233 = $desugar$58 is error
-    %233 ? bb134 : bb135;
+    %198 = %197 is error
+    %198 ? bb134 : bb135;
   }
   bb134 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$58);
-    PopScopeFrame
+    %0 = %197;
     return;
   }
   bb135 {
-    %234 = println($desugar$58) -> bb136;
+    %195 = %197;
+    GOTO bb136;
   }
   bb136 {
-    $desugar$59 = data;
-    $desugar$60 = rsaPk;
-    %237 = $default$17($desugar$59,$desugar$60) -> bb137;
+    %194 = == %195 data;
+    %199 = %194;
+    %200 = println(%199) -> bb137;
   }
   bb137 {
-    $desugar$61 = %237;
-    %239 = encryptRsaEcb($desugar$59,$desugar$60,$desugar$61) -> bb138;
+    %202 = ConstantLoad OAEPwithSHA512andMGF1
+    %203 = encryptRsaEcb(data,rsaPub,%202) -> bb138;
   }
   bb138 {
-    $desugar$62 = %239;
-    %241 = $desugar$62 is error
-    %241 ? bb139 : bb140;
+    %204 = %203 is error
+    %204 ? bb139 : bb140;
   }
   bb139 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$62);
-    PopScopeFrame
+    %0 = %203;
     return;
   }
   bb140 {
-    ctPriv = $desugar$62;
-    $desugar$63 = ctPriv;
-    $desugar$64 = rsaPk;
-    %245 = $default$22($desugar$63,$desugar$64) -> bb141;
+    %201 = %203;
+    GOTO bb141;
   }
   bb141 {
-    $desugar$65 = %245;
-    %247 = decryptRsaEcb($desugar$63,$desugar$64,$desugar$65) -> bb142;
+    oaep512 = %201;
+    %208 = ConstantLoad OAEPwithSHA512andMGF1
+    %209 = decryptRsaEcb(oaep512,rsaPk,%208) -> bb142;
   }
   bb142 {
-    $desugar$66 = %247;
-    %249 = $desugar$66 is error
-    %249 ? bb143 : bb144;
+    %210 = %209 is error
+    %210 ? bb143 : bb144;
   }
   bb143 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$66);
-    PopScopeFrame
+    %0 = %209;
     return;
   }
   bb144 {
-    %250 = == $desugar$66 data;
-    %251 = %250;
-    %252 = println(%251) -> bb145;
+    %207 = %209;
+    GOTO bb145;
   }
   bb145 {
-    $desugar$67 = data;
-    $desugar$68 = rsaPk;
-    %255 = $default$22($desugar$67,$desugar$68) -> bb146;
+    %206 = == %207 data;
+    %211 = %206;
+    %212 = println(%211) -> bb146;
   }
   bb146 {
-    $desugar$69 = %255;
-    %257 = decryptRsaEcb($desugar$67,$desugar$68,$desugar$69) -> bb147;
+    %213 = ConstantLoad /tmp/bal_ec_key.pem
+    $desugar$20 = %213;
+    %215 = $default$2($desugar$20) -> bb147;
   }
   bb147 {
-    decErr = %257;
-    %259 = decErr is error
-    %260 = %259;
-    %261 = println(%260) -> bb148;
+    $desugar$21 = %215;
+    %218 = decodeEcPrivateKeyFromKeyFile($desugar$20,$desugar$21) -> bb148;
   }
   bb148 {
-    $desugar$70 = ct;
-    $desugar$71 = rsaPub;
-    %264 = $default$22($desugar$70,$desugar$71) -> bb149;
+    %219 = %218 is error
+    %219 ? bb149 : bb150;
   }
   bb149 {
-    $desugar$72 = %264;
-    %266 = decryptRsaEcb($desugar$70,$desugar$71,$desugar$72) -> bb150;
+    %0 = %218;
+    return;
   }
   bb150 {
-    decPubErr = %266;
-    %268 = decPubErr is error
-    %269 = %268;
-    %270 = println(%269) -> bb151;
+    %217 = %218;
+    GOTO bb151;
   }
   bb151 {
-    %271 = ConstantLoad 9
-    %272 = ConstantLoad 9
-    %273 = ConstantLoad 9
-    %274 = ConstantLoad 3
-    %275 = newArray [int:Unsigned8...][%274]{%271, %272, %273}
-    %276 = verifyRsaSsaPss256Signature(%275,sPss,rsaPub) -> bb152;
+    ecPk = %217;
+    %222 = ConstantLoad /tmp/bal_ec_cert.pem
+    %223 = decodeEcPublicKeyFromCertFile(%222) -> bb152;
   }
   bb152 {
-    $desugar$73 = %276;
-    %278 = $desugar$73 is error
-    %278 ? bb153 : bb154;
+    %224 = %223 is error
+    %224 ? bb153 : bb154;
   }
   bb153 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$73);
-    PopScopeFrame
+    %0 = %223;
     return;
   }
   bb154 {
-    %279 = println($desugar$73) -> bb155;
+    %221 = %223;
+    GOTO bb155;
   }
   bb155 {
-    %280 = signRsaSha256(data,ecPk) -> bb156;
+    ecPub = %221;
+    %227 = signSha256withEcdsa(data,ecPk) -> bb156;
   }
   bb156 {
-    rsaSignEc = %280;
-    %282 = rsaSignEc is error
-    %283 = %282;
-    %284 = println(%283) -> bb157;
+    %228 = %227 is error
+    %228 ? bb157 : bb158;
   }
   bb157 {
-    %285 = verifyRsaSha256Signature(data,s256,ecPub) -> bb158;
+    %0 = %227;
+    return;
   }
   bb158 {
-    rsaVerifyEc = %285;
-    %287 = rsaVerifyEc is error
-    %288 = %287;
-    %289 = println(%288) -> bb159;
+    %226 = %227;
+    GOTO bb159;
   }
   bb159 {
-    %290 = signRsaSsaPss256(data,ecPk) -> bb160;
+    e256 = %226;
+    %231 = verifySha256withEcdsaSignature(data,e256,ecPub) -> bb160;
   }
   bb160 {
-    pssSignEc = %290;
-    %292 = pssSignEc is error
-    %293 = %292;
-    %294 = println(%293) -> bb161;
+    %232 = %231 is error
+    %232 ? bb161 : bb162;
   }
   bb161 {
-    %295 = verifyRsaSsaPss256Signature(data,sPss,ecPub) -> bb162;
+    %0 = %231;
+    return;
   }
   bb162 {
-    pssVerifyEc = %295;
-    %297 = pssVerifyEc is error
-    %298 = %297;
-    %299 = println(%298) -> bb163;
+    %230 = %231;
+    GOTO bb163;
   }
   bb163 {
-    %300 = signSha256withEcdsa(data,rsaPk) -> bb164;
+    %233 = %230;
+    %234 = println(%233) -> bb164;
   }
   bb164 {
-    ecSignRsa = %300;
-    %302 = ecSignRsa is error
-    %303 = %302;
-    %304 = println(%303) -> bb165;
+    %236 = signSha384withEcdsa(data,ecPk) -> bb165;
   }
   bb165 {
-    %305 = verifySha256withEcdsaSignature(data,e256,rsaPub) -> bb166;
+    %237 = %236 is error
+    %237 ? bb166 : bb167;
   }
   bb166 {
-    ecVerifyRsa = %305;
-    %307 = ecVerifyRsa is error
-    %308 = %307;
-    %309 = println(%308) -> bb167;
+    %0 = %236;
+    return;
   }
   bb167 {
-    %310 = ConstantLoad /tmp/bal_no_such.pem
-    $desugar$74 = %310;
-    %312 = $default$0($desugar$74) -> bb168;
+    %235 = %236;
+    GOTO bb168;
   }
   bb168 {
-    $desugar$75 = %312;
-    %314 = decodeRsaPrivateKeyFromKeyFile($desugar$74,$desugar$75) -> bb169;
+    e384 = %235;
+    %240 = verifySha384withEcdsaSignature(data,e384,ecPub) -> bb169;
   }
   bb169 {
-    rsaKeyMissing = %314;
-    %316 = rsaKeyMissing is error
-    %317 = %316;
-    %318 = println(%317) -> bb170;
+    %241 = %240 is error
+    %241 ? bb170 : bb171;
   }
   bb170 {
-    %319 = ConstantLoad /tmp/bal_no_such.pem
-    $desugar$76 = %319;
-    %321 = $default$2($desugar$76) -> bb171;
+    %0 = %240;
+    return;
   }
   bb171 {
-    $desugar$77 = %321;
-    %323 = decodeEcPrivateKeyFromKeyFile($desugar$76,$desugar$77) -> bb172;
+    %239 = %240;
+    GOTO bb172;
   }
   bb172 {
-    ecKeyMissing = %323;
-    %325 = ecKeyMissing is error
-    %326 = %325;
-    %327 = println(%326) -> bb173;
+    %242 = %239;
+    %243 = println(%242) -> bb173;
   }
   bb173 {
-    %328 = ConstantLoad /tmp/bal_no_such.pem
-    %329 = decodeRsaPublicKeyFromCertFile(%328) -> bb174;
+    $desugar$22 = data;
+    $desugar$23 = rsaPk;
+    %246 = $default$17($desugar$22,$desugar$23) -> bb174;
   }
   bb174 {
-    rsaCertMissing = %329;
-    %331 = rsaCertMissing is error
-    %332 = %331;
-    %333 = println(%332) -> bb175;
+    $desugar$24 = %246;
+    %249 = encryptRsaEcb($desugar$22,$desugar$23,$desugar$24) -> bb175;
   }
   bb175 {
-    %334 = ConstantLoad /tmp/bal_no_such.pem
-    %335 = decodeEcPublicKeyFromCertFile(%334) -> bb176;
+    %250 = %249 is error
+    %250 ? bb176 : bb177;
   }
   bb176 {
-    ecCertMissing = %335;
-    %337 = ecCertMissing is error
-    %338 = %337;
-    %339 = println(%338) -> bb177;
+    %0 = %249;
+    return;
   }
   bb177 {
-    %340 = ConstantLoad /tmp/bal_ec_key.pem
-    $desugar$78 = %340;
-    %342 = $default$0($desugar$78) -> bb178;
+    %248 = %249;
+    GOTO bb178;
   }
   bb178 {
-    $desugar$79 = %342;
-    %344 = decodeRsaPrivateKeyFromKeyFile($desugar$78,$desugar$79) -> bb179;
+    ctPriv = %248;
+    $desugar$25 = ctPriv;
+    $desugar$26 = rsaPk;
+    %254 = $default$22($desugar$25,$desugar$26) -> bb179;
   }
   bb179 {
-    ecAsRsaKey = %344;
-    %346 = ecAsRsaKey is error
-    %347 = %346;
-    %348 = println(%347) -> bb180;
+    $desugar$27 = %254;
+    %258 = decryptRsaEcb($desugar$25,$desugar$26,$desugar$27) -> bb180;
   }
   bb180 {
-    %349 = ConstantLoad /tmp/bal_rsa_key.pem
-    $desugar$80 = %349;
-    %351 = $default$2($desugar$80) -> bb181;
+    %259 = %258 is error
+    %259 ? bb181 : bb182;
   }
   bb181 {
-    $desugar$81 = %351;
-    %353 = decodeEcPrivateKeyFromKeyFile($desugar$80,$desugar$81) -> bb182;
+    %0 = %258;
+    return;
   }
   bb182 {
-    rsaAsEcKey = %353;
-    %355 = rsaAsEcKey is error
-    %356 = %355;
-    %357 = println(%356) -> bb183;
+    %257 = %258;
+    GOTO bb183;
   }
   bb183 {
-    %358 = ConstantLoad /tmp/bal_ec_cert.pem
-    %359 = decodeRsaPublicKeyFromCertFile(%358) -> bb184;
+    %256 = == %257 data;
+    %260 = %256;
+    %261 = println(%260) -> bb184;
   }
   bb184 {
-    ecAsRsaCert = %359;
-    %361 = ecAsRsaCert is error
-    %362 = %361;
-    %363 = println(%362) -> bb185;
+    $desugar$28 = data;
+    $desugar$29 = rsaPk;
+    %264 = $default$22($desugar$28,$desugar$29) -> bb185;
   }
   bb185 {
-    %364 = ConstantLoad /tmp/bal_rsa_cert.pem
-    %365 = decodeEcPublicKeyFromCertFile(%364) -> bb186;
+    $desugar$30 = %264;
+    %266 = decryptRsaEcb($desugar$28,$desugar$29,$desugar$30) -> bb186;
   }
   bb186 {
-    rsaAsEcCert = %365;
-    %367 = rsaAsEcCert is error
-    %368 = %367;
-    %369 = println(%368) -> bb187;
+    decErr = %266;
+    %268 = decErr is error
+    %269 = %268;
+    %270 = println(%269) -> bb187;
   }
   bb187 {
-    %370 = ConstantLoad 1
-    %371 = ConstantLoad 2
-    %372 = ConstantLoad 3
-    %373 = ConstantLoad 3
-    %374 = newArray [int:Unsigned8...][%373]{%370, %371, %372}
-    junk = %374;
-    $desugar$82 = junk;
-    %377 = $default$1($desugar$82) -> bb188;
+    $desugar$31 = ct;
+    $desugar$32 = rsaPub;
+    %273 = $default$22($desugar$31,$desugar$32) -> bb188;
   }
   bb188 {
-    $desugar$83 = %377;
-    %379 = decodeRsaPrivateKeyFromContent($desugar$82,$desugar$83) -> bb189;
+    $desugar$33 = %273;
+    %275 = decryptRsaEcb($desugar$31,$desugar$32,$desugar$33) -> bb189;
   }
   bb189 {
-    junkKey = %379;
-    %381 = junkKey is error
-    %382 = %381;
-    %383 = println(%382) -> bb190;
+    decPubErr = %275;
+    %277 = decPubErr is error
+    %278 = %277;
+    %279 = println(%278) -> bb190;
   }
   bb190 {
-    %384 = ConstantLoad /tmp/bal_ec_key.pem
-    %385 = fileReadBytes(%384) -> bb191;
+    %281 = ConstantLoad 9
+    %282 = ConstantLoad 9
+    %283 = ConstantLoad 9
+    %284 = ConstantLoad 3
+    %285 = newArray [int:Unsigned8...][%284]{%281, %282, %283}
+    %286 = verifyRsaSsaPss256Signature(%285,sPss,rsaPub) -> bb191;
   }
   bb191 {
-    $desugar$84 = %385;
-    %387 = $desugar$84 is error
-    %387 ? bb192 : bb193;
+    %287 = %286 is error
+    %287 ? bb192 : bb193;
   }
   bb192 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$84);
-    PopScopeFrame
+    %0 = %286;
     return;
   }
   bb193 {
-    ecKeyBytes = $desugar$84;
-    $desugar$85 = ecKeyBytes;
-    %390 = $default$1($desugar$85) -> bb194;
+    %280 = %286;
+    GOTO bb194;
   }
   bb194 {
-    $desugar$86 = %390;
-    %392 = decodeRsaPrivateKeyFromContent($desugar$85,$desugar$86) -> bb195;
+    %288 = %280;
+    %289 = println(%288) -> bb195;
   }
   bb195 {
-    ecAsRsaContent = %392;
-    %394 = ecAsRsaContent is error
-    %395 = %394;
-    %396 = println(%395) -> bb196;
+    %290 = signRsaSha256(data,ecPk) -> bb196;
   }
   bb196 {
-    %397 = ConstantLoad /tmp/bal_ec_cert.pem
-    %398 = fileReadBytes(%397) -> bb197;
+    rsaSignEc = %290;
+    %292 = rsaSignEc is error
+    %293 = %292;
+    %294 = println(%293) -> bb197;
   }
   bb197 {
-    $desugar$87 = %398;
-    %400 = $desugar$87 is error
-    %400 ? bb198 : bb199;
+    %295 = verifyRsaSha256Signature(data,s256,ecPub) -> bb198;
   }
   bb198 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$87);
-    PopScopeFrame
-    return;
+    rsaVerifyEc = %295;
+    %297 = rsaVerifyEc is error
+    %298 = %297;
+    %299 = println(%298) -> bb199;
   }
   bb199 {
-    ecCertBytes = $desugar$87;
-    %402 = decodeRsaPublicKeyFromContent(ecCertBytes) -> bb200;
+    %300 = signRsaSsaPss256(data,ecPk) -> bb200;
   }
   bb200 {
-    ecAsRsaCertContent = %402;
-    %404 = ecAsRsaCertContent is error
-    %405 = %404;
-    %406 = println(%405) -> bb201;
+    pssSignEc = %300;
+    %302 = pssSignEc is error
+    %303 = %302;
+    %304 = println(%303) -> bb201;
   }
   bb201 {
+    %305 = verifyRsaSsaPss256Signature(data,sPss,ecPub) -> bb202;
+  }
+  bb202 {
+    pssVerifyEc = %305;
+    %307 = pssVerifyEc is error
+    %308 = %307;
+    %309 = println(%308) -> bb203;
+  }
+  bb203 {
+    %310 = signSha256withEcdsa(data,rsaPk) -> bb204;
+  }
+  bb204 {
+    ecSignRsa = %310;
+    %312 = ecSignRsa is error
+    %313 = %312;
+    %314 = println(%313) -> bb205;
+  }
+  bb205 {
+    %315 = verifySha256withEcdsaSignature(data,e256,rsaPub) -> bb206;
+  }
+  bb206 {
+    ecVerifyRsa = %315;
+    %317 = ecVerifyRsa is error
+    %318 = %317;
+    %319 = println(%318) -> bb207;
+  }
+  bb207 {
+    %320 = ConstantLoad /tmp/bal_no_such.pem
+    $desugar$34 = %320;
+    %322 = $default$0($desugar$34) -> bb208;
+  }
+  bb208 {
+    $desugar$35 = %322;
+    %324 = decodeRsaPrivateKeyFromKeyFile($desugar$34,$desugar$35) -> bb209;
+  }
+  bb209 {
+    rsaKeyMissing = %324;
+    %326 = rsaKeyMissing is error
+    %327 = %326;
+    %328 = println(%327) -> bb210;
+  }
+  bb210 {
+    %329 = ConstantLoad /tmp/bal_no_such.pem
+    $desugar$36 = %329;
+    %331 = $default$2($desugar$36) -> bb211;
+  }
+  bb211 {
+    $desugar$37 = %331;
+    %333 = decodeEcPrivateKeyFromKeyFile($desugar$36,$desugar$37) -> bb212;
+  }
+  bb212 {
+    ecKeyMissing = %333;
+    %335 = ecKeyMissing is error
+    %336 = %335;
+    %337 = println(%336) -> bb213;
+  }
+  bb213 {
+    %338 = ConstantLoad /tmp/bal_no_such.pem
+    %339 = decodeRsaPublicKeyFromCertFile(%338) -> bb214;
+  }
+  bb214 {
+    rsaCertMissing = %339;
+    %341 = rsaCertMissing is error
+    %342 = %341;
+    %343 = println(%342) -> bb215;
+  }
+  bb215 {
+    %344 = ConstantLoad /tmp/bal_no_such.pem
+    %345 = decodeEcPublicKeyFromCertFile(%344) -> bb216;
+  }
+  bb216 {
+    ecCertMissing = %345;
+    %347 = ecCertMissing is error
+    %348 = %347;
+    %349 = println(%348) -> bb217;
+  }
+  bb217 {
+    %350 = ConstantLoad /tmp/bal_ec_key.pem
+    $desugar$38 = %350;
+    %352 = $default$0($desugar$38) -> bb218;
+  }
+  bb218 {
+    $desugar$39 = %352;
+    %354 = decodeRsaPrivateKeyFromKeyFile($desugar$38,$desugar$39) -> bb219;
+  }
+  bb219 {
+    ecAsRsaKey = %354;
+    %356 = ecAsRsaKey is error
+    %357 = %356;
+    %358 = println(%357) -> bb220;
+  }
+  bb220 {
+    %359 = ConstantLoad /tmp/bal_rsa_key.pem
+    $desugar$40 = %359;
+    %361 = $default$2($desugar$40) -> bb221;
+  }
+  bb221 {
+    $desugar$41 = %361;
+    %363 = decodeEcPrivateKeyFromKeyFile($desugar$40,$desugar$41) -> bb222;
+  }
+  bb222 {
+    rsaAsEcKey = %363;
+    %365 = rsaAsEcKey is error
+    %366 = %365;
+    %367 = println(%366) -> bb223;
+  }
+  bb223 {
+    %368 = ConstantLoad /tmp/bal_ec_cert.pem
+    %369 = decodeRsaPublicKeyFromCertFile(%368) -> bb224;
+  }
+  bb224 {
+    ecAsRsaCert = %369;
+    %371 = ecAsRsaCert is error
+    %372 = %371;
+    %373 = println(%372) -> bb225;
+  }
+  bb225 {
+    %374 = ConstantLoad /tmp/bal_rsa_cert.pem
+    %375 = decodeEcPublicKeyFromCertFile(%374) -> bb226;
+  }
+  bb226 {
+    rsaAsEcCert = %375;
+    %377 = rsaAsEcCert is error
+    %378 = %377;
+    %379 = println(%378) -> bb227;
+  }
+  bb227 {
+    %380 = ConstantLoad 1
+    %381 = ConstantLoad 2
+    %382 = ConstantLoad 3
+    %383 = ConstantLoad 3
+    %384 = newArray [int:Unsigned8...][%383]{%380, %381, %382}
+    junk = %384;
+    $desugar$42 = junk;
+    %387 = $default$1($desugar$42) -> bb228;
+  }
+  bb228 {
+    $desugar$43 = %387;
+    %389 = decodeRsaPrivateKeyFromContent($desugar$42,$desugar$43) -> bb229;
+  }
+  bb229 {
+    junkKey = %389;
+    %391 = junkKey is error
+    %392 = %391;
+    %393 = println(%392) -> bb230;
+  }
+  bb230 {
+    %395 = ConstantLoad /tmp/bal_ec_key.pem
+    %396 = fileReadBytes(%395) -> bb231;
+  }
+  bb231 {
+    %397 = %396 is error
+    %397 ? bb232 : bb233;
+  }
+  bb232 {
+    %0 = %396;
+    return;
+  }
+  bb233 {
+    %394 = %396;
+    GOTO bb234;
+  }
+  bb234 {
+    ecKeyBytes = %394;
+    $desugar$44 = ecKeyBytes;
+    %400 = $default$1($desugar$44) -> bb235;
+  }
+  bb235 {
+    $desugar$45 = %400;
+    %402 = decodeRsaPrivateKeyFromContent($desugar$44,$desugar$45) -> bb236;
+  }
+  bb236 {
+    ecAsRsaContent = %402;
+    %404 = ecAsRsaContent is error
+    %405 = %404;
+    %406 = println(%405) -> bb237;
+  }
+  bb237 {
+    %408 = ConstantLoad /tmp/bal_ec_cert.pem
+    %409 = fileReadBytes(%408) -> bb238;
+  }
+  bb238 {
+    %410 = %409 is error
+    %410 ? bb239 : bb240;
+  }
+  bb239 {
+    %0 = %409;
+    return;
+  }
+  bb240 {
+    %407 = %409;
+    GOTO bb241;
+  }
+  bb241 {
+    ecCertBytes = %407;
+    %412 = decodeRsaPublicKeyFromContent(ecCertBytes) -> bb242;
+  }
+  bb242 {
+    ecAsRsaCertContent = %412;
+    %414 = ecAsRsaCertContent is error
+    %415 = %414;
+    %416 = println(%415) -> bb243;
+  }
+  bb243 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/crypto-password1-v.txt
+++ b/corpus/bir/library/subset2/crypto-password1-v.txt
@@ -8,290 +8,311 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %4;
-    %6 = $desugar$1;
-    %7 = hashBcrypt($desugar$0,%6) -> bb2;
+    %7 = $desugar$1;
+    %8 = hashBcrypt($desugar$0,%7) -> bb2;
   }
   bb2 {
-    $desugar$2 = %7;
-    %9 = $desugar$2 is error
+    %9 = %8 is error
     %9 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb4 {
-    bcryptHash = $desugar$2;
-    %12 = length(bcryptHash) -> bb5;
+    %6 = %8;
+    GOTO bb5;
   }
   bb5 {
+    bcryptHash = %6;
+    %12 = length(bcryptHash) -> bb6;
+  }
+  bb6 {
     %13 = %12;
     %14 = ConstantLoad 0
     %15 = %14;
     %11 = > %13 %15;
     %16 = %11;
-    %17 = println(%16) -> bb6;
-  }
-  bb6 {
-    %18 = verifyBcrypt(password,bcryptHash) -> bb7;
+    %17 = println(%16) -> bb7;
   }
   bb7 {
-    $desugar$3 = %18;
-    %20 = $desugar$3 is error
-    %20 ? bb8 : bb9;
+    %19 = verifyBcrypt(password,bcryptHash) -> bb8;
   }
   bb8 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %20 = %19 is error
+    %20 ? bb9 : bb10;
   }
   bb9 {
-    %21 = println($desugar$3) -> bb10;
+    %0 = %19;
+    return;
   }
   bb10 {
-    %22 = ConstantLoad wrong
-    %23 = verifyBcrypt(%22,bcryptHash) -> bb11;
+    %18 = %19;
+    GOTO bb11;
   }
   bb11 {
-    $desugar$4 = %23;
-    %25 = $desugar$4 is error
-    %25 ? bb12 : bb13;
+    %21 = %18;
+    %22 = println(%21) -> bb12;
   }
   bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %24 = ConstantLoad wrong
+    %25 = verifyBcrypt(%24,bcryptHash) -> bb13;
   }
   bb13 {
-    %26 = println($desugar$4) -> bb14;
+    %26 = %25 is error
+    %26 ? bb14 : bb15;
   }
   bb14 {
-    $desugar$5 = password;
-    %28 = $default$10($desugar$5) -> bb15;
+    %0 = %25;
+    return;
   }
   bb15 {
-    $desugar$6 = %28;
-    %30 = $desugar$6;
-    %31 = $default$11($desugar$5,%30) -> bb16;
+    %23 = %25;
+    GOTO bb16;
   }
   bb16 {
-    $desugar$7 = %31;
-    %33 = $desugar$6;
-    %34 = $desugar$7;
-    %35 = $default$12($desugar$5,%33,%34) -> bb17;
+    %27 = %23;
+    %28 = println(%27) -> bb17;
   }
   bb17 {
-    $desugar$8 = %35;
-    %37 = $desugar$6;
-    %38 = $desugar$7;
-    %39 = $desugar$8;
-    %40 = hashArgon2($desugar$5,%37,%38,%39) -> bb18;
+    $desugar$2 = password;
+    %30 = $default$10($desugar$2) -> bb18;
   }
   bb18 {
-    $desugar$9 = %40;
-    %42 = $desugar$9 is error
-    %42 ? bb19 : bb20;
+    $desugar$3 = %30;
+    %32 = $desugar$3;
+    %33 = $default$11($desugar$2,%32) -> bb19;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
-    return;
+    $desugar$4 = %33;
+    %35 = $desugar$3;
+    %36 = $desugar$4;
+    %37 = $default$12($desugar$2,%35,%36) -> bb20;
   }
   bb20 {
-    argon2Hash = $desugar$9;
-    %45 = length(argon2Hash) -> bb21;
+    $desugar$5 = %37;
+    %40 = $desugar$3;
+    %41 = $desugar$4;
+    %42 = $desugar$5;
+    %43 = hashArgon2($desugar$2,%40,%41,%42) -> bb21;
   }
   bb21 {
-    %46 = %45;
-    %47 = ConstantLoad 0
-    %48 = %47;
-    %44 = > %46 %48;
-    %49 = %44;
-    %50 = println(%49) -> bb22;
+    %44 = %43 is error
+    %44 ? bb22 : bb23;
   }
   bb22 {
-    %51 = verifyArgon2(password,argon2Hash) -> bb23;
-  }
-  bb23 {
-    $desugar$10 = %51;
-    %53 = $desugar$10 is error
-    %53 ? bb24 : bb25;
-  }
-  bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
+    %0 = %43;
     return;
   }
+  bb23 {
+    %39 = %43;
+    GOTO bb24;
+  }
+  bb24 {
+    argon2Hash = %39;
+    %47 = length(argon2Hash) -> bb25;
+  }
   bb25 {
-    %54 = println($desugar$10) -> bb26;
+    %48 = %47;
+    %49 = ConstantLoad 0
+    %50 = %49;
+    %46 = > %48 %50;
+    %51 = %46;
+    %52 = println(%51) -> bb26;
   }
   bb26 {
-    %55 = ConstantLoad wrong
-    %56 = verifyArgon2(%55,argon2Hash) -> bb27;
+    %54 = verifyArgon2(password,argon2Hash) -> bb27;
   }
   bb27 {
-    $desugar$11 = %56;
-    %58 = $desugar$11 is error
-    %58 ? bb28 : bb29;
+    %55 = %54 is error
+    %55 ? bb28 : bb29;
   }
   bb28 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
+    %0 = %54;
     return;
   }
   bb29 {
-    %59 = println($desugar$11) -> bb30;
+    %53 = %54;
+    GOTO bb30;
   }
   bb30 {
-    $desugar$12 = password;
-    %61 = $default$13($desugar$12) -> bb31;
+    %56 = %53;
+    %57 = println(%56) -> bb31;
   }
   bb31 {
-    $desugar$13 = %61;
-    %63 = $desugar$13;
-    %64 = $default$14($desugar$12,%63) -> bb32;
+    %59 = ConstantLoad wrong
+    %60 = verifyArgon2(%59,argon2Hash) -> bb32;
   }
   bb32 {
-    $desugar$14 = %64;
-    %66 = $desugar$13;
-    %67 = hashPbkdf2($desugar$12,%66,$desugar$14) -> bb33;
+    %61 = %60 is error
+    %61 ? bb33 : bb34;
   }
   bb33 {
-    $desugar$15 = %67;
-    %69 = $desugar$15 is error
-    %69 ? bb34 : bb35;
+    %0 = %60;
+    return;
   }
   bb34 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$15);
-    PopScopeFrame
-    return;
+    %58 = %60;
+    GOTO bb35;
   }
   bb35 {
-    pbkdf2Hash = $desugar$15;
-    %72 = length(pbkdf2Hash) -> bb36;
+    %62 = %58;
+    %63 = println(%62) -> bb36;
   }
   bb36 {
-    %73 = %72;
-    %74 = ConstantLoad 0
-    %75 = %74;
-    %71 = > %73 %75;
-    %76 = %71;
-    %77 = println(%76) -> bb37;
+    $desugar$6 = password;
+    %65 = $default$13($desugar$6) -> bb37;
   }
   bb37 {
-    %78 = verifyPbkdf2(password,pbkdf2Hash) -> bb38;
+    $desugar$7 = %65;
+    %67 = $desugar$7;
+    %68 = $default$14($desugar$6,%67) -> bb38;
   }
   bb38 {
-    $desugar$16 = %78;
-    %80 = $desugar$16 is error
-    %80 ? bb39 : bb40;
+    $desugar$8 = %68;
+    %71 = $desugar$7;
+    %72 = hashPbkdf2($desugar$6,%71,$desugar$8) -> bb39;
   }
   bb39 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$16);
-    PopScopeFrame
-    return;
+    %73 = %72 is error
+    %73 ? bb40 : bb41;
   }
   bb40 {
-    %81 = println($desugar$16) -> bb41;
+    %0 = %72;
+    return;
   }
   bb41 {
-    %82 = ConstantLoad wrong
-    %83 = verifyPbkdf2(%82,pbkdf2Hash) -> bb42;
+    %70 = %72;
+    GOTO bb42;
   }
   bb42 {
-    $desugar$17 = %83;
-    %85 = $desugar$17 is error
-    %85 ? bb43 : bb44;
+    pbkdf2Hash = %70;
+    %76 = length(pbkdf2Hash) -> bb43;
   }
   bb43 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
-    return;
+    %77 = %76;
+    %78 = ConstantLoad 0
+    %79 = %78;
+    %75 = > %77 %79;
+    %80 = %75;
+    %81 = println(%80) -> bb44;
   }
   bb44 {
-    %86 = println($desugar$17) -> bb45;
+    %83 = verifyPbkdf2(password,pbkdf2Hash) -> bb45;
   }
   bb45 {
-    %87 = ConstantLoad 10000
-    %88 = %87;
-    %89 = ConstantLoad SHA512
-    %90 = hashPbkdf2(password,%88,%89) -> bb46;
+    %84 = %83 is error
+    %84 ? bb46 : bb47;
   }
   bb46 {
-    $desugar$18 = %90;
-    %92 = $desugar$18 is error
-    %92 ? bb47 : bb48;
+    %0 = %83;
+    return;
   }
   bb47 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
-    return;
+    %82 = %83;
+    GOTO bb48;
   }
   bb48 {
-    pbkdf2Sha512 = $desugar$18;
-    %94 = verifyPbkdf2(password,pbkdf2Sha512) -> bb49;
+    %85 = %82;
+    %86 = println(%85) -> bb49;
   }
   bb49 {
-    $desugar$19 = %94;
-    %96 = $desugar$19 is error
-    %96 ? bb50 : bb51;
+    %88 = ConstantLoad wrong
+    %89 = verifyPbkdf2(%88,pbkdf2Hash) -> bb50;
   }
   bb50 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$19);
-    PopScopeFrame
-    return;
+    %90 = %89 is error
+    %90 ? bb51 : bb52;
   }
   bb51 {
-    %97 = println($desugar$19) -> bb52;
+    %0 = %89;
+    return;
   }
   bb52 {
-    %98 = ConstantLoad 10000
-    %99 = %98;
-    %100 = ConstantLoad SHA1
-    %101 = hashPbkdf2(password,%99,%100) -> bb53;
+    %87 = %89;
+    GOTO bb53;
   }
   bb53 {
-    $desugar$20 = %101;
-    %103 = $desugar$20 is error
-    %103 ? bb54 : bb55;
+    %91 = %87;
+    %92 = println(%91) -> bb54;
   }
   bb54 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
+    %94 = ConstantLoad 10000
+    %95 = %94;
+    %96 = ConstantLoad SHA512
+    %97 = hashPbkdf2(password,%95,%96) -> bb55;
   }
   bb55 {
-    pbkdf2Sha1 = $desugar$20;
-    %105 = verifyPbkdf2(password,pbkdf2Sha1) -> bb56;
+    %98 = %97 is error
+    %98 ? bb56 : bb57;
   }
   bb56 {
-    $desugar$21 = %105;
-    %107 = $desugar$21 is error
-    %107 ? bb57 : bb58;
-  }
-  bb57 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$21);
-    PopScopeFrame
+    %0 = %97;
     return;
   }
+  bb57 {
+    %93 = %97;
+    GOTO bb58;
+  }
   bb58 {
-    %108 = println($desugar$21) -> bb59;
+    pbkdf2Sha512 = %93;
+    %101 = verifyPbkdf2(password,pbkdf2Sha512) -> bb59;
   }
   bb59 {
+    %102 = %101 is error
+    %102 ? bb60 : bb61;
+  }
+  bb60 {
+    %0 = %101;
+    return;
+  }
+  bb61 {
+    %100 = %101;
+    GOTO bb62;
+  }
+  bb62 {
+    %103 = %100;
+    %104 = println(%103) -> bb63;
+  }
+  bb63 {
+    %106 = ConstantLoad 10000
+    %107 = %106;
+    %108 = ConstantLoad SHA1
+    %109 = hashPbkdf2(password,%107,%108) -> bb64;
+  }
+  bb64 {
+    %110 = %109 is error
+    %110 ? bb65 : bb66;
+  }
+  bb65 {
+    %0 = %109;
+    return;
+  }
+  bb66 {
+    %105 = %109;
+    GOTO bb67;
+  }
+  bb67 {
+    pbkdf2Sha1 = %105;
+    %113 = verifyPbkdf2(password,pbkdf2Sha1) -> bb68;
+  }
+  bb68 {
+    %114 = %113 is error
+    %114 ? bb69 : bb70;
+  }
+  bb69 {
+    %0 = %113;
+    return;
+  }
+  bb70 {
+    %112 = %113;
+    GOTO bb71;
+  }
+  bb71 {
+    %115 = %112;
+    %116 = println(%115) -> bb72;
+  }
+  bb72 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/email-date-v.txt
+++ b/corpus/bir/library/subset2/email-date-v.txt
@@ -1,143 +1,146 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 2024-06-15T10:30:45.00Z
-    %2 = utcFromString(%1) -> bb1;
+    %2 = ConstantLoad 2024-06-15T10:30:45.00Z
+    %3 = utcFromString(%2) -> bb1;
   }
   bb1 {
-    $desugar$0 = %2;
-    %4 = $desugar$0 is error
+    %4 = %3 is error
     %4 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %3;
     return;
   }
   bb3 {
-    utc = $desugar$0;
-    $desugar$1 = utc;
-    %7 = $default$2($desugar$1) -> bb4;
+    %1 = %3;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$2 = %7;
-    %9 = utcToEmailString($desugar$1,$desugar$2) -> bb5;
+    utc = %1;
+    $desugar$0 = utc;
+    %7 = $default$2($desugar$0) -> bb5;
   }
   bb5 {
-    emailStr = %9;
-    %11 = println(emailStr) -> bb6;
+    $desugar$1 = %7;
+    %9 = utcToEmailString($desugar$0,$desugar$1) -> bb6;
   }
   bb6 {
-    %12 = ConstantLoad GMT
-    %13 = utcToEmailString(utc,%12) -> bb7;
+    emailStr = %9;
+    %11 = println(emailStr) -> bb7;
   }
   bb7 {
-    emailGmt = %13;
-    %15 = println(emailGmt) -> bb8;
+    %12 = ConstantLoad GMT
+    %13 = utcToEmailString(utc,%12) -> bb8;
   }
   bb8 {
-    %16 = ConstantLoad Sat, 15 Jun 2024 10:30:45 +0000
-    %17 = civilFromEmailString(%16) -> bb9;
+    emailGmt = %13;
+    %15 = println(emailGmt) -> bb9;
   }
   bb9 {
+    %16 = ConstantLoad Sat, 15 Jun 2024 10:30:45 +0000
+    %17 = civilFromEmailString(%16) -> bb10;
+  }
+  bb10 {
     parsed = %17;
     %19 = parsed is error
     %20 = %19;
-    %21 = println(%20) -> bb10;
-  }
-  bb10 {
-    %22 = ConstantLoad Mon, 3 Jun 2024 08:00:00 +0000
-    %23 = civilFromEmailString(%22) -> bb11;
+    %21 = println(%20) -> bb11;
   }
   bb11 {
+    %22 = ConstantLoad Mon, 3 Jun 2024 08:00:00 +0000
+    %23 = civilFromEmailString(%22) -> bb12;
+  }
+  bb12 {
     parsed2 = %23;
     %25 = parsed2 is error
     %26 = %25;
-    %27 = println(%26) -> bb12;
-  }
-  bb12 {
-    %28 = ConstantLoad not a date
-    %29 = civilFromEmailString(%28) -> bb13;
+    %27 = println(%26) -> bb13;
   }
   bb13 {
+    %28 = ConstantLoad not a date
+    %29 = civilFromEmailString(%28) -> bb14;
+  }
+  bb14 {
     bad = %29;
     %31 = bad is error
     %32 = %31;
-    %33 = println(%32) -> bb14;
-  }
-  bb14 {
-    %34 = newObject ballerina/time:TimeZone
-    %35 = ConstantLoad +00:00
-    %36 = init(%34,%35) -> bb15;
+    %33 = println(%32) -> bb15;
   }
   bb15 {
-    %38 = %36 is nil
-    %38 ? bb16 : bb17;
+    %35 = newObject ballerina/time:TimeZone
+    %36 = ConstantLoad +00:00
+    %37 = init(%35,%36) -> bb16;
   }
   bb16 {
-    %37 = %34;
-    GOTO bb18;
+    %39 = %37 is nil
+    %39 ? bb17 : bb18;
   }
   bb17 {
-    %37 = %36;
-    GOTO bb18;
+    %38 = %35;
+    GOTO bb19;
   }
   bb18 {
-    $desugar$3 = %37;
-    %40 = $desugar$3 is error
-    %40 ? bb19 : bb20;
+    %38 = %37;
+    GOTO bb19;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %40 = %38 is error
+    %40 ? bb20 : bb21;
   }
   bb20 {
-    tz = $desugar$3;
-    %42 = ConstantLoad 2024-06-15T10:30:45.00Z
-    %43 = utcFromString(%42) -> bb21;
-  }
-  bb21 {
-    $desugar$4 = %43;
-    %45 = $desugar$4 is error
-    %45 ? bb22 : bb23;
-  }
-  bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %38;
     return;
   }
+  bb21 {
+    %34 = %38;
+    GOTO bb22;
+  }
+  bb22 {
+    tz = %34;
+    %43 = ConstantLoad 2024-06-15T10:30:45.00Z
+    %44 = utcFromString(%43) -> bb23;
+  }
   bb23 {
-    utcBase = $desugar$4;
-    %47 = utcToCivil(tz,utcBase) -> bb24;
+    %45 = %44 is error
+    %45 ? bb24 : bb25;
   }
   bb24 {
-    civil = %47;
-    %49 = ConstantLoad PREFER_ZONE_OFFSET
-    %50 = civilToEmailString(civil,%49) -> bb25;
+    %0 = %44;
+    return;
   }
   bb25 {
+    %42 = %44;
+    GOTO bb26;
+  }
+  bb26 {
+    utcBase = %42;
+    %47 = utcToCivil(tz,utcBase) -> bb27;
+  }
+  bb27 {
+    civil = %47;
+    %49 = ConstantLoad PREFER_ZONE_OFFSET
+    %50 = civilToEmailString(civil,%49) -> bb28;
+  }
+  bb28 {
     emailCivil = %50;
     %52 = emailCivil is string
     %53 = %52;
-    %54 = println(%53) -> bb26;
-  }
-  bb26 {
-    %55 = emailCivil is string
-    %55 ? bb27 : bb29;
-  }
-  bb27 {
-    PushScopeFrame 1
-    %0 = println((1, emailCivil)) -> bb28;
-  }
-  bb28 {
-    PopScopeFrame
-    GOTO bb29;
+    %54 = println(%53) -> bb29;
   }
   bb29 {
+    %55 = emailCivil is string
+    %55 ? bb30 : bb32;
+  }
+  bb30 {
+    PushScopeFrame 1
+    %0 = println((1, emailCivil)) -> bb31;
+  }
+  bb31 {
+    PopScopeFrame
+    GOTO bb32;
+  }
+  bb32 {
     PushScopeFrame 0
     PopScopeFrame
     return;

--- a/corpus/bir/library/subset2/http-client-compression-v.txt
+++ b/corpus/bir/library/subset2/http-client-compression-v.txt
@@ -1,313 +1,323 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = newObject ballerina/http:Client
-    %2 = ConstantLoad https://example.com
-    %3 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %4 = init(%1,%2,%3) -> bb1;
+    %2 = newObject ballerina/http:Client
+    %3 = ConstantLoad https://example.com
+    %4 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %5 = init(%2,%3,%4) -> bb1;
   }
   bb1 {
-    %6 = %4 is nil
-    %6 ? bb2 : bb3;
+    %7 = %5 is nil
+    %7 ? bb2 : bb3;
   }
   bb2 {
-    %5 = %1;
+    %6 = %2;
     GOTO bb4;
   }
   bb3 {
-    %5 = %4;
+    %6 = %5;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %5;
-    %8 = $desugar$0 is error
+    %8 = %6 is error
     %8 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %6;
     return;
   }
   bb6 {
-    c1 = $desugar$0;
-    %10 = ConstantLoad /path
-    $desugar$1 = %10;
-    %12 = $default$21($desugar$1) -> bb7;
+    %1 = %6;
+    GOTO bb7;
   }
   bb7 {
-    $desugar$2 = %12;
-    %14 = ConstantLoad typedesc
-    $desugar$3 = %14;
-    %16 = $remote$get(c1,$desugar$1,$desugar$2,$desugar$3) -> bb8;
+    c1 = %1;
+    %10 = ConstantLoad /path
+    $desugar$0 = %10;
+    %12 = $default$21($desugar$0) -> bb8;
   }
   bb8 {
-    $desugar$4 = %16;
-    %18 = $desugar$4 is error
-    %18 ? bb9 : bb10;
+    $desugar$1 = %12;
+    %14 = ConstantLoad typedesc
+    $desugar$2 = %14;
+    %17 = $remote$get(c1,$desugar$0,$desugar$1,$desugar$2) -> bb9;
   }
   bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %18 = %17 is error
+    %18 ? bb10 : bb11;
   }
   bb10 {
-    r1 = $desugar$4;
+    %0 = %17;
+    return;
+  }
+  bb11 {
+    %16 = %17;
+    GOTO bb12;
+  }
+  bb12 {
+    r1 = %16;
     %21 = ConstantLoad statusCode
     %20 = r1[%21];
     %22 = %20;
-    %23 = println(%22) -> bb11;
-  }
-  bb11 {
-    %24 = newObject ballerina/http:Client
-    %25 = ConstantLoad https://example.com
-    %26 = ConstantLoad compression
-    %27 = ConstantLoad AUTO
-    %28 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%26=%27} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %29 = init(%24,%25,%28) -> bb12;
-  }
-  bb12 {
-    %31 = %29 is nil
-    %31 ? bb13 : bb14;
+    %23 = println(%22) -> bb13;
   }
   bb13 {
-    %30 = %24;
-    GOTO bb15;
+    %25 = newObject ballerina/http:Client
+    %26 = ConstantLoad https://example.com
+    %27 = ConstantLoad compression
+    %28 = ConstantLoad AUTO
+    %29 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%27=%28} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %30 = init(%25,%26,%29) -> bb14;
   }
   bb14 {
-    %30 = %29;
-    GOTO bb15;
+    %32 = %30 is nil
+    %32 ? bb15 : bb16;
   }
   bb15 {
-    $desugar$5 = %30;
-    %33 = $desugar$5 is error
-    %33 ? bb16 : bb17;
+    %31 = %25;
+    GOTO bb17;
   }
   bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %31 = %30;
+    GOTO bb17;
   }
   bb17 {
-    c2 = $desugar$5;
-    %35 = ConstantLoad /path
-    $desugar$6 = %35;
-    %37 = $default$21($desugar$6) -> bb18;
+    %33 = %31 is error
+    %33 ? bb18 : bb19;
   }
   bb18 {
-    $desugar$7 = %37;
-    %39 = ConstantLoad typedesc
-    $desugar$8 = %39;
-    %41 = $remote$get(c2,$desugar$6,$desugar$7,$desugar$8) -> bb19;
-  }
-  bb19 {
-    $desugar$9 = %41;
-    %43 = $desugar$9 is error
-    %43 ? bb20 : bb21;
-  }
-  bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %31;
     return;
   }
+  bb19 {
+    %24 = %31;
+    GOTO bb20;
+  }
+  bb20 {
+    c2 = %24;
+    %35 = ConstantLoad /path
+    $desugar$3 = %35;
+    %37 = $default$21($desugar$3) -> bb21;
+  }
   bb21 {
-    r2 = $desugar$9;
+    $desugar$4 = %37;
+    %39 = ConstantLoad typedesc
+    $desugar$5 = %39;
+    %42 = $remote$get(c2,$desugar$3,$desugar$4,$desugar$5) -> bb22;
+  }
+  bb22 {
+    %43 = %42 is error
+    %43 ? bb23 : bb24;
+  }
+  bb23 {
+    %0 = %42;
+    return;
+  }
+  bb24 {
+    %41 = %42;
+    GOTO bb25;
+  }
+  bb25 {
+    r2 = %41;
     %46 = ConstantLoad statusCode
     %45 = r2[%46];
     %47 = %45;
-    %48 = println(%47) -> bb22;
-  }
-  bb22 {
-    %49 = newObject ballerina/http:Client
-    %50 = ConstantLoad https://example.com
-    %51 = ConstantLoad compression
-    %52 = ConstantLoad ALWAYS
-    %53 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%51=%52} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %54 = init(%49,%50,%53) -> bb23;
-  }
-  bb23 {
-    %56 = %54 is nil
-    %56 ? bb24 : bb25;
-  }
-  bb24 {
-    %55 = %49;
-    GOTO bb26;
-  }
-  bb25 {
-    %55 = %54;
-    GOTO bb26;
+    %48 = println(%47) -> bb26;
   }
   bb26 {
-    $desugar$10 = %55;
-    %58 = $desugar$10 is error
-    %58 ? bb27 : bb28;
+    %50 = newObject ballerina/http:Client
+    %51 = ConstantLoad https://example.com
+    %52 = ConstantLoad compression
+    %53 = ConstantLoad ALWAYS
+    %54 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%52=%53} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %55 = init(%50,%51,%54) -> bb27;
   }
   bb27 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
-    return;
+    %57 = %55 is nil
+    %57 ? bb28 : bb29;
   }
   bb28 {
-    c3 = $desugar$10;
-    %60 = ConstantLoad /path
-    $desugar$11 = %60;
-    %62 = $default$21($desugar$11) -> bb29;
+    %56 = %50;
+    GOTO bb30;
   }
   bb29 {
-    $desugar$12 = %62;
-    %64 = ConstantLoad typedesc
-    $desugar$13 = %64;
-    %66 = $remote$get(c3,$desugar$11,$desugar$12,$desugar$13) -> bb30;
+    %56 = %55;
+    GOTO bb30;
   }
   bb30 {
-    $desugar$14 = %66;
-    %68 = $desugar$14 is error
-    %68 ? bb31 : bb32;
+    %58 = %56 is error
+    %58 ? bb31 : bb32;
   }
   bb31 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
+    %0 = %56;
     return;
   }
   bb32 {
-    r3 = $desugar$14;
+    %49 = %56;
+    GOTO bb33;
+  }
+  bb33 {
+    c3 = %49;
+    %60 = ConstantLoad /path
+    $desugar$6 = %60;
+    %62 = $default$21($desugar$6) -> bb34;
+  }
+  bb34 {
+    $desugar$7 = %62;
+    %64 = ConstantLoad typedesc
+    $desugar$8 = %64;
+    %67 = $remote$get(c3,$desugar$6,$desugar$7,$desugar$8) -> bb35;
+  }
+  bb35 {
+    %68 = %67 is error
+    %68 ? bb36 : bb37;
+  }
+  bb36 {
+    %0 = %67;
+    return;
+  }
+  bb37 {
+    %66 = %67;
+    GOTO bb38;
+  }
+  bb38 {
+    r3 = %66;
     %71 = ConstantLoad statusCode
     %70 = r3[%71];
     %72 = %70;
-    %73 = println(%72) -> bb33;
-  }
-  bb33 {
-    %74 = newObject ballerina/http:Client
-    %75 = ConstantLoad https://example.com
-    %76 = ConstantLoad compression
-    %77 = ConstantLoad NEVER
-    %78 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%76=%77} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %79 = init(%74,%75,%78) -> bb34;
-  }
-  bb34 {
-    %81 = %79 is nil
-    %81 ? bb35 : bb36;
-  }
-  bb35 {
-    %80 = %74;
-    GOTO bb37;
-  }
-  bb36 {
-    %80 = %79;
-    GOTO bb37;
-  }
-  bb37 {
-    $desugar$15 = %80;
-    %83 = $desugar$15 is error
-    %83 ? bb38 : bb39;
-  }
-  bb38 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$15);
-    PopScopeFrame
-    return;
+    %73 = println(%72) -> bb39;
   }
   bb39 {
-    c4 = $desugar$15;
-    %85 = ConstantLoad /path
-    $desugar$16 = %85;
-    %87 = $default$21($desugar$16) -> bb40;
+    %75 = newObject ballerina/http:Client
+    %76 = ConstantLoad https://example.com
+    %77 = ConstantLoad compression
+    %78 = ConstantLoad NEVER
+    %79 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%77=%78} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %80 = init(%75,%76,%79) -> bb40;
   }
   bb40 {
-    $desugar$17 = %87;
-    %89 = ConstantLoad typedesc
-    $desugar$18 = %89;
-    %91 = $remote$get(c4,$desugar$16,$desugar$17,$desugar$18) -> bb41;
+    %82 = %80 is nil
+    %82 ? bb41 : bb42;
   }
   bb41 {
-    $desugar$19 = %91;
-    %93 = $desugar$19 is error
-    %93 ? bb42 : bb43;
+    %81 = %75;
+    GOTO bb43;
   }
   bb42 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$19);
-    PopScopeFrame
-    return;
+    %81 = %80;
+    GOTO bb43;
   }
   bb43 {
-    r4 = $desugar$19;
-    %96 = ConstantLoad statusCode
-    %95 = r4[%96];
-    %97 = %95;
-    %98 = println(%97) -> bb44;
+    %83 = %81 is error
+    %83 ? bb44 : bb45;
   }
   bb44 {
-    %99 = newObject ballerina/http:Client
-    %100 = ConstantLoad https://example.com
-    %101 = ConstantLoad timeout
-    %102 = ConstantLoad 15
-    %103 = ConstantLoad httpVersion
-    %104 = ConstantLoad 1.1
-    %105 = ConstantLoad compression
-    %106 = ConstantLoad NEVER
-    %107 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%101=%102, %103=%104, %105=%106} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %108 = init(%99,%100,%107) -> bb45;
+    %0 = %81;
+    return;
   }
   bb45 {
-    %110 = %108 is nil
-    %110 ? bb46 : bb47;
+    %74 = %81;
+    GOTO bb46;
   }
   bb46 {
-    %109 = %99;
-    GOTO bb48;
+    c4 = %74;
+    %85 = ConstantLoad /path
+    $desugar$9 = %85;
+    %87 = $default$21($desugar$9) -> bb47;
   }
   bb47 {
-    %109 = %108;
-    GOTO bb48;
+    $desugar$10 = %87;
+    %89 = ConstantLoad typedesc
+    $desugar$11 = %89;
+    %92 = $remote$get(c4,$desugar$9,$desugar$10,$desugar$11) -> bb48;
   }
   bb48 {
-    $desugar$20 = %109;
-    %112 = $desugar$20 is error
-    %112 ? bb49 : bb50;
+    %93 = %92 is error
+    %93 ? bb49 : bb50;
   }
   bb49 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
+    %0 = %92;
     return;
   }
   bb50 {
-    c5 = $desugar$20;
-    %114 = ConstantLoad /path
-    $desugar$21 = %114;
-    %116 = $default$21($desugar$21) -> bb51;
+    %91 = %92;
+    GOTO bb51;
   }
   bb51 {
-    $desugar$22 = %116;
-    %118 = ConstantLoad typedesc
-    $desugar$23 = %118;
-    %120 = $remote$get(c5,$desugar$21,$desugar$22,$desugar$23) -> bb52;
+    r4 = %91;
+    %96 = ConstantLoad statusCode
+    %95 = r4[%96];
+    %97 = %95;
+    %98 = println(%97) -> bb52;
   }
   bb52 {
-    $desugar$24 = %120;
-    %122 = $desugar$24 is error
-    %122 ? bb53 : bb54;
+    %100 = newObject ballerina/http:Client
+    %101 = ConstantLoad https://example.com
+    %102 = ConstantLoad timeout
+    %103 = ConstantLoad 15
+    %104 = ConstantLoad httpVersion
+    %105 = ConstantLoad 1.1
+    %106 = ConstantLoad compression
+    %107 = ConstantLoad NEVER
+    %108 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%102=%103, %104=%105, %106=%107} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %109 = init(%100,%101,%108) -> bb53;
   }
   bb53 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$24);
-    PopScopeFrame
-    return;
+    %111 = %109 is nil
+    %111 ? bb54 : bb55;
   }
   bb54 {
-    r5 = $desugar$24;
+    %110 = %100;
+    GOTO bb56;
+  }
+  bb55 {
+    %110 = %109;
+    GOTO bb56;
+  }
+  bb56 {
+    %112 = %110 is error
+    %112 ? bb57 : bb58;
+  }
+  bb57 {
+    %0 = %110;
+    return;
+  }
+  bb58 {
+    %99 = %110;
+    GOTO bb59;
+  }
+  bb59 {
+    c5 = %99;
+    %114 = ConstantLoad /path
+    $desugar$12 = %114;
+    %116 = $default$21($desugar$12) -> bb60;
+  }
+  bb60 {
+    $desugar$13 = %116;
+    %118 = ConstantLoad typedesc
+    $desugar$14 = %118;
+    %121 = $remote$get(c5,$desugar$12,$desugar$13,$desugar$14) -> bb61;
+  }
+  bb61 {
+    %122 = %121 is error
+    %122 ? bb62 : bb63;
+  }
+  bb62 {
+    %0 = %121;
+    return;
+  }
+  bb63 {
+    %120 = %121;
+    GOTO bb64;
+  }
+  bb64 {
+    r5 = %120;
     %125 = ConstantLoad statusCode
     %124 = r5[%125];
     %126 = %124;
-    %127 = println(%126) -> bb55;
+    %127 = println(%126) -> bb65;
   }
-  bb55 {
+  bb65 {
     %128 = ConstantLoad <nil>
     %0 = %128;
     return;

--- a/corpus/bir/library/subset2/http-client-proxy-v.txt
+++ b/corpus/bir/library/subset2/http-client-proxy-v.txt
@@ -7,114 +7,117 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newObject ballerina/http:Client
-    %6 = init(%5,$desugar$0,$desugar$1) -> bb2;
+    %6 = newObject ballerina/http:Client
+    %7 = init(%6,$desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    %8 = %6 is nil
-    %8 ? bb3 : bb4;
+    %9 = %7 is nil
+    %9 ? bb3 : bb4;
   }
   bb3 {
-    %7 = %5;
+    %8 = %6;
     GOTO bb5;
   }
   bb4 {
-    %7 = %6;
+    %8 = %7;
     GOTO bb5;
   }
   bb5 {
-    $desugar$2 = %7;
-    %10 = $desugar$2 is error
+    %10 = %8 is error
     %10 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb7 {
-    _ = $desugar$2;
-    %12 = newObject ballerina/http:Client
-    %13 = ConstantLoad https://example.com
-    %14 = ConstantLoad proxy
-    %15 = ConstantLoad host
-    %16 = ConstantLoad proxy.example.com
-    %17 = ConstantLoad port
-    %18 = ConstantLoad 3128
-    %19 = newMap {| host: string, password: string, port: int, userName: string, never... |}{%15=%16, %17=%18} defaults{host=ballerina/http:$desugar$6, port=ballerina/http:$desugar$7, userName=ballerina/http:$desugar$8, password=ballerina/http:$desugar$9}
-    %20 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%14=%19} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %21 = init(%12,%13,%20) -> bb8;
+    %5 = %8;
+    GOTO bb8;
   }
   bb8 {
-    %23 = %21 is nil
-    %23 ? bb9 : bb10;
+    _ = %5;
+    %13 = newObject ballerina/http:Client
+    %14 = ConstantLoad https://example.com
+    %15 = ConstantLoad proxy
+    %16 = ConstantLoad host
+    %17 = ConstantLoad proxy.example.com
+    %18 = ConstantLoad port
+    %19 = ConstantLoad 3128
+    %20 = newMap {| host: string, password: string, port: int, userName: string, never... |}{%16=%17, %18=%19} defaults{host=ballerina/http:$desugar$6, port=ballerina/http:$desugar$7, userName=ballerina/http:$desugar$8, password=ballerina/http:$desugar$9}
+    %21 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%15=%20} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %22 = init(%13,%14,%21) -> bb9;
   }
   bb9 {
-    %22 = %12;
-    GOTO bb11;
+    %24 = %22 is nil
+    %24 ? bb10 : bb11;
   }
   bb10 {
-    %22 = %21;
-    GOTO bb11;
+    %23 = %13;
+    GOTO bb12;
   }
   bb11 {
-    $desugar$3 = %22;
-    %25 = $desugar$3 is error
-    %25 ? bb12 : bb13;
+    %23 = %22;
+    GOTO bb12;
   }
   bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %25 = %23 is error
+    %25 ? bb13 : bb14;
   }
   bb13 {
-    _ = $desugar$3;
-    %27 = newObject ballerina/http:Client
-    %28 = ConstantLoad https://example.com
-    %29 = ConstantLoad proxy
-    %30 = ConstantLoad host
-    %31 = ConstantLoad proxy.example.com
-    %32 = ConstantLoad port
-    %33 = ConstantLoad 3128
-    %34 = ConstantLoad userName
-    %35 = ConstantLoad user
-    %36 = ConstantLoad password
-    %37 = ConstantLoad secret
-    %38 = newMap {| host: string, password: string, port: int, userName: string, never... |}{%30=%31, %32=%33, %34=%35, %36=%37} defaults{host=ballerina/http:$desugar$6, port=ballerina/http:$desugar$7, userName=ballerina/http:$desugar$8, password=ballerina/http:$desugar$9}
-    %39 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%29=%38} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %40 = init(%27,%28,%39) -> bb14;
-  }
-  bb14 {
-    %42 = %40 is nil
-    %42 ? bb15 : bb16;
-  }
-  bb15 {
-    %41 = %27;
-    GOTO bb17;
-  }
-  bb16 {
-    %41 = %40;
-    GOTO bb17;
-  }
-  bb17 {
-    $desugar$4 = %41;
-    %44 = $desugar$4 is error
-    %44 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %23;
     return;
   }
+  bb14 {
+    %12 = %23;
+    GOTO bb15;
+  }
+  bb15 {
+    _ = %12;
+    %28 = newObject ballerina/http:Client
+    %29 = ConstantLoad https://example.com
+    %30 = ConstantLoad proxy
+    %31 = ConstantLoad host
+    %32 = ConstantLoad proxy.example.com
+    %33 = ConstantLoad port
+    %34 = ConstantLoad 3128
+    %35 = ConstantLoad userName
+    %36 = ConstantLoad user
+    %37 = ConstantLoad password
+    %38 = ConstantLoad secret
+    %39 = newMap {| host: string, password: string, port: int, userName: string, never... |}{%31=%32, %33=%34, %35=%36, %37=%38} defaults{host=ballerina/http:$desugar$6, port=ballerina/http:$desugar$7, userName=ballerina/http:$desugar$8, password=ballerina/http:$desugar$9}
+    %40 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%30=%39} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %41 = init(%28,%29,%40) -> bb16;
+  }
+  bb16 {
+    %43 = %41 is nil
+    %43 ? bb17 : bb18;
+  }
+  bb17 {
+    %42 = %28;
+    GOTO bb19;
+  }
+  bb18 {
+    %42 = %41;
+    GOTO bb19;
+  }
   bb19 {
-    _ = $desugar$4;
-    %46 = ConstantLoad ok
-    %47 = println(%46) -> bb20;
+    %44 = %42 is error
+    %44 ? bb20 : bb21;
   }
   bb20 {
+    %0 = %42;
+    return;
+  }
+  bb21 {
+    %27 = %42;
+    GOTO bb22;
+  }
+  bb22 {
+    _ = %27;
+    %46 = ConstantLoad ok
+    %47 = println(%46) -> bb23;
+  }
+  bb23 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/http-client-response-limits-v.txt
+++ b/corpus/bir/library/subset2/http-client-response-limits-v.txt
@@ -7,143 +7,147 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newObject ballerina/http:Client
-    %6 = init(%5,$desugar$0,$desugar$1) -> bb2;
+    %6 = newObject ballerina/http:Client
+    %7 = init(%6,$desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    %8 = %6 is nil
-    %8 ? bb3 : bb4;
+    %9 = %7 is nil
+    %9 ? bb3 : bb4;
   }
   bb3 {
-    %7 = %5;
+    %8 = %6;
     GOTO bb5;
   }
   bb4 {
-    %7 = %6;
+    %8 = %7;
     GOTO bb5;
   }
   bb5 {
-    $desugar$2 = %7;
-    %10 = $desugar$2 is error
+    %10 = %8 is error
     %10 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb7 {
-    _ = $desugar$2;
-    %12 = newObject ballerina/http:Client
-    %13 = ConstantLoad https://example.com
-    %14 = ConstantLoad responseLimits
-    %15 = ConstantLoad maxStatusLineLength
-    %16 = ConstantLoad 4096
-    %17 = ConstantLoad maxHeaderSize
-    %18 = ConstantLoad 8192
-    %19 = ConstantLoad maxEntityBodySize
-    %20 = ConstantLoad 1
-    %21 = unknown %20;
-    %22 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%15=%16, %17=%18, %19=%21} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
-    %23 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%14=%22} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %24 = init(%12,%13,%23) -> bb8;
+    %5 = %8;
+    GOTO bb8;
   }
   bb8 {
-    %26 = %24 is nil
-    %26 ? bb9 : bb10;
+    _ = %5;
+    %13 = newObject ballerina/http:Client
+    %14 = ConstantLoad https://example.com
+    %15 = ConstantLoad responseLimits
+    %16 = ConstantLoad maxStatusLineLength
+    %17 = ConstantLoad 4096
+    %18 = ConstantLoad maxHeaderSize
+    %19 = ConstantLoad 8192
+    %20 = ConstantLoad maxEntityBodySize
+    %21 = ConstantLoad 1
+    %22 = unknown %21;
+    %23 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%16=%17, %18=%19, %20=%22} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
+    %24 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%15=%23} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %25 = init(%13,%14,%24) -> bb9;
   }
   bb9 {
-    %25 = %12;
-    GOTO bb11;
+    %27 = %25 is nil
+    %27 ? bb10 : bb11;
   }
   bb10 {
-    %25 = %24;
-    GOTO bb11;
+    %26 = %13;
+    GOTO bb12;
   }
   bb11 {
-    $desugar$3 = %25;
-    %28 = $desugar$3 is error
-    %28 ? bb12 : bb13;
+    %26 = %25;
+    GOTO bb12;
   }
   bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %28 = %26 is error
+    %28 ? bb13 : bb14;
   }
   bb13 {
-    _ = $desugar$3;
-    %30 = newObject ballerina/http:Client
-    %31 = ConstantLoad https://example.com
-    %32 = ConstantLoad responseLimits
-    %33 = ConstantLoad maxHeaderSize
-    %34 = ConstantLoad 16384
-    %35 = ConstantLoad maxEntityBodySize
-    %36 = ConstantLoad 1000000
-    %37 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%33=%34, %35=%36} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
-    %38 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%32=%37} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %39 = init(%30,%31,%38) -> bb14;
+    %0 = %26;
+    return;
   }
   bb14 {
-    %41 = %39 is nil
-    %41 ? bb15 : bb16;
+    %12 = %26;
+    GOTO bb15;
   }
   bb15 {
-    %40 = %30;
-    GOTO bb17;
+    _ = %12;
+    %31 = newObject ballerina/http:Client
+    %32 = ConstantLoad https://example.com
+    %33 = ConstantLoad responseLimits
+    %34 = ConstantLoad maxHeaderSize
+    %35 = ConstantLoad 16384
+    %36 = ConstantLoad maxEntityBodySize
+    %37 = ConstantLoad 1000000
+    %38 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%34=%35, %36=%37} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
+    %39 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%33=%38} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %40 = init(%31,%32,%39) -> bb16;
   }
   bb16 {
-    %40 = %39;
-    GOTO bb17;
+    %42 = %40 is nil
+    %42 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %40;
-    %43 = $desugar$4 is error
-    %43 ? bb18 : bb19;
+    %41 = %31;
+    GOTO bb19;
   }
   bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %41 = %40;
+    GOTO bb19;
   }
   bb19 {
-    _ = $desugar$4;
-    %45 = newObject ballerina/http:Client
-    %46 = ConstantLoad https://example.com
-    %47 = ConstantLoad responseLimits
-    %48 = ConstantLoad maxEntityBodySize
-    %49 = ConstantLoad 0
-    %50 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%48=%49} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
-    %51 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%47=%50} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %52 = init(%45,%46,%51) -> bb20;
+    %43 = %41 is error
+    %43 ? bb20 : bb21;
   }
   bb20 {
-    %54 = %52 is nil
-    %54 ? bb21 : bb22;
-  }
-  bb21 {
-    %53 = %45;
-    GOTO bb23;
-  }
-  bb22 {
-    %53 = %52;
-    GOTO bb23;
-  }
-  bb23 {
-    $desugar$5 = %53;
-    %56 = $desugar$5 is error
-    %56 ? bb24 : bb25;
-  }
-  bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %41;
     return;
   }
+  bb21 {
+    %30 = %41;
+    GOTO bb22;
+  }
+  bb22 {
+    _ = %30;
+    %46 = newObject ballerina/http:Client
+    %47 = ConstantLoad https://example.com
+    %48 = ConstantLoad responseLimits
+    %49 = ConstantLoad maxEntityBodySize
+    %50 = ConstantLoad 0
+    %51 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%49=%50} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
+    %52 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%48=%51} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
+    %53 = init(%46,%47,%52) -> bb23;
+  }
+  bb23 {
+    %55 = %53 is nil
+    %55 ? bb24 : bb25;
+  }
+  bb24 {
+    %54 = %46;
+    GOTO bb26;
+  }
   bb25 {
-    _ = $desugar$5;
+    %54 = %53;
+    GOTO bb26;
+  }
+  bb26 {
+    %56 = %54 is error
+    %56 ? bb27 : bb28;
+  }
+  bb27 {
+    %0 = %54;
+    return;
+  }
+  bb28 {
+    %45 = %54;
+    GOTO bb29;
+  }
+  bb29 {
+    _ = %45;
     %58 = newObject ballerina/http:Client
     %59 = ConstantLoad https://example.com
     %60 = ConstantLoad responseLimits
@@ -152,27 +156,27 @@ main() -> nil|error{
     %63 = unknown %62;
     %64 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%61=%63} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
     %65 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%60=%64} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %66 = init(%58,%59,%65) -> bb26;
+    %66 = init(%58,%59,%65) -> bb30;
   }
-  bb26 {
+  bb30 {
     %68 = %66 is nil
-    %68 ? bb27 : bb28;
+    %68 ? bb31 : bb32;
   }
-  bb27 {
+  bb31 {
     %67 = %58;
-    GOTO bb29;
+    GOTO bb33;
   }
-  bb28 {
+  bb32 {
     %67 = %66;
-    GOTO bb29;
+    GOTO bb33;
   }
-  bb29 {
+  bb33 {
     negStatusLine = %67;
     %70 = negStatusLine is error
     %71 = %70;
-    %72 = println(%71) -> bb30;
+    %72 = println(%71) -> bb34;
   }
-  bb30 {
+  bb34 {
     %73 = newObject ballerina/http:Client
     %74 = ConstantLoad https://example.com
     %75 = ConstantLoad responseLimits
@@ -181,27 +185,27 @@ main() -> nil|error{
     %78 = unknown %77;
     %79 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%76=%78} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
     %80 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%75=%79} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %81 = init(%73,%74,%80) -> bb31;
+    %81 = init(%73,%74,%80) -> bb35;
   }
-  bb31 {
+  bb35 {
     %83 = %81 is nil
-    %83 ? bb32 : bb33;
+    %83 ? bb36 : bb37;
   }
-  bb32 {
+  bb36 {
     %82 = %73;
-    GOTO bb34;
+    GOTO bb38;
   }
-  bb33 {
+  bb37 {
     %82 = %81;
-    GOTO bb34;
+    GOTO bb38;
   }
-  bb34 {
+  bb38 {
     negHeaderSize = %82;
     %85 = negHeaderSize is error
     %86 = %85;
-    %87 = println(%86) -> bb35;
+    %87 = println(%86) -> bb39;
   }
-  bb35 {
+  bb39 {
     %88 = newObject ballerina/http:Client
     %89 = ConstantLoad https://example.com
     %90 = ConstantLoad responseLimits
@@ -210,27 +214,27 @@ main() -> nil|error{
     %93 = unknown %92;
     %94 = newMap {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}{%91=%93} defaults{maxStatusLineLength=ballerina/http:$desugar$3, maxHeaderSize=ballerina/http:$desugar$4, maxEntityBodySize=ballerina/http:$desugar$5}
     %95 = newMap {| compression: "ALWAYS"|"AUTO"|"NEVER", followRedirects: nil|{| allowAuthHeaders: boolean, enabled: boolean, maxCount: int, never... |}, httpVersion: "1.0"|"1.1"|"2.0", poolConfig: nil|{| maxActiveConnections: int, maxActiveStreamsPerConnection: int, maxIdleConnections: int, waitTime: decimal, never... |}, proxy: nil|{| host: string, password: string, port: int, userName: string, never... |}, responseLimits: {| maxEntityBodySize: int, maxHeaderSize: int, maxStatusLineLength: int, never... |}, secureSocket: nil|{| cert: string, certValidation: nil|{| cacheSize: int, cacheValidityPeriod: int, type: "OCSP_CRL"|"OCSP_STAPLING", never... |}, ciphers: [string...], enable: boolean, handshakeTimeout: decimal, key: {| certFile: string, keyFile: string, keyPassword: string, never... |}, protocol: nil|{| name: "DTLS"|"SSL"|"TLS", versions: [string...], never... |}, serverName: string, sessionTimeout: decimal, shareSession: boolean, verifyHostName: boolean, never... |}, timeout: decimal, never... |}{%90=%94} defaults{timeout=ballerina/http:$desugar$17, followRedirects=ballerina/http:$desugar$18, httpVersion=ballerina/http:$desugar$19, secureSocket=ballerina/http:$desugar$20, poolConfig=ballerina/http:$desugar$21, compression=ballerina/http:$desugar$22, responseLimits=ballerina/http:$desugar$23, proxy=ballerina/http:$desugar$24}
-    %96 = init(%88,%89,%95) -> bb36;
+    %96 = init(%88,%89,%95) -> bb40;
   }
-  bb36 {
+  bb40 {
     %98 = %96 is nil
-    %98 ? bb37 : bb38;
+    %98 ? bb41 : bb42;
   }
-  bb37 {
+  bb41 {
     %97 = %88;
-    GOTO bb39;
+    GOTO bb43;
   }
-  bb38 {
+  bb42 {
     %97 = %96;
-    GOTO bb39;
+    GOTO bb43;
   }
-  bb39 {
+  bb43 {
     negBody = %97;
     %100 = negBody is error
     %101 = %100;
-    %102 = println(%101) -> bb40;
+    %102 = println(%101) -> bb44;
   }
-  bb40 {
+  bb44 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/http-parse-header-v.txt
+++ b/corpus/bir/library/subset2/http-parse-header-v.txt
@@ -1,123 +1,127 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad text/plain;q=0.9, application/json
-    %2 = parseHeader(%1) -> bb1;
+    %2 = ConstantLoad text/plain;q=0.9, application/json
+    %3 = parseHeader(%2) -> bb1;
   }
   bb1 {
-    $desugar$0 = %2;
-    %4 = $desugar$0 is error
+    %4 = %3 is error
     %4 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %3;
     return;
   }
   bb3 {
-    values = $desugar$0;
-    %6 = length(values) -> bb4;
+    %1 = %3;
+    GOTO bb4;
   }
   bb4 {
-    %7 = %6;
-    %8 = println(%7) -> bb5;
+    values = %1;
+    %6 = length(values) -> bb5;
   }
   bb5 {
-    %9 = ConstantLoad multipart/form-data; boundary="----boundary"
-    %10 = parseHeader(%9) -> bb6;
+    %7 = %6;
+    %8 = println(%7) -> bb6;
   }
   bb6 {
-    $desugar$1 = %10;
-    %12 = $desugar$1 is error
-    %12 ? bb7 : bb8;
+    %10 = ConstantLoad multipart/form-data; boundary="----boundary"
+    %11 = parseHeader(%10) -> bb7;
   }
   bb7 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %12 = %11 is error
+    %12 ? bb8 : bb9;
   }
   bb8 {
-    quoted = $desugar$1;
-    %14 = length(quoted) -> bb9;
+    %0 = %11;
+    return;
   }
   bb9 {
-    %15 = %14;
-    %16 = println(%15) -> bb10;
+    %9 = %11;
+    GOTO bb10;
   }
   bb10 {
+    quoted = %9;
+    %14 = length(quoted) -> bb11;
+  }
+  bb11 {
+    %15 = %14;
+    %16 = println(%15) -> bb12;
+  }
+  bb12 {
     %18 = ConstantLoad value
     %20 = ConstantLoad 0
     %19 = quoted[%20];
     %17 = %19[%18];
-    %21 = println(%17) -> bb11;
+    %21 = println(%17) -> bb13;
   }
-  bb11 {
+  bb13 {
     %23 = ConstantLoad boundary
     %25 = ConstantLoad params
     %27 = ConstantLoad 0
     %26 = quoted[%27];
     %24 = %26[%25];
     %22 = %24[%23];
-    %28 = println(%22) -> bb12;
-  }
-  bb12 {
-    %29 = ConstantLoad multipart/form-data; boundary
-    %30 = parseHeader(%29) -> bb13;
-  }
-  bb13 {
-    $desugar$2 = %30;
-    %32 = $desugar$2 is error
-    %32 ? bb14 : bb15;
+    %28 = println(%22) -> bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %30 = ConstantLoad multipart/form-data; boundary
+    %31 = parseHeader(%30) -> bb15;
   }
   bb15 {
-    noVal = $desugar$2;
-    %34 = length(noVal) -> bb16;
+    %32 = %31 is error
+    %32 ? bb16 : bb17;
   }
   bb16 {
-    %35 = %34;
-    %36 = println(%35) -> bb17;
+    %0 = %31;
+    return;
   }
   bb17 {
+    %29 = %31;
+    GOTO bb18;
+  }
+  bb18 {
+    noVal = %29;
+    %34 = length(noVal) -> bb19;
+  }
+  bb19 {
+    %35 = %34;
+    %36 = println(%35) -> bb20;
+  }
+  bb20 {
     %38 = ConstantLoad boundary
     %40 = ConstantLoad params
     %42 = ConstantLoad 0
     %41 = noVal[%42];
     %39 = %41[%40];
     %37 = %39[%38];
-    %43 = println(%37) -> bb18;
-  }
-  bb18 {
-    %44 = ConstantLoad text/html
-    %45 = parseHeader(%44) -> bb19;
-  }
-  bb19 {
-    $desugar$3 = %45;
-    %47 = $desugar$3 is error
-    %47 ? bb20 : bb21;
-  }
-  bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %43 = println(%37) -> bb21;
   }
   bb21 {
-    single = $desugar$3;
-    %49 = length(single) -> bb22;
+    %45 = ConstantLoad text/html
+    %46 = parseHeader(%45) -> bb22;
   }
   bb22 {
-    %50 = %49;
-    %51 = println(%50) -> bb23;
+    %47 = %46 is error
+    %47 ? bb23 : bb24;
   }
   bb23 {
+    %0 = %46;
+    return;
+  }
+  bb24 {
+    %44 = %46;
+    GOTO bb25;
+  }
+  bb25 {
+    single = %44;
+    %49 = length(single) -> bb26;
+  }
+  bb26 {
+    %50 = %49;
+    %51 = println(%50) -> bb27;
+  }
+  bb27 {
     %52 = ConstantLoad <nil>
     %0 = %52;
     return;

--- a/corpus/bir/library/subset2/http-request-response-v.txt
+++ b/corpus/bir/library/subset2/http-request-response-v.txt
@@ -33,494 +33,506 @@ main() -> nil|error{
     %14 = setTextPayload(req,$desugar$0,$desugar$1) -> bb6;
   }
   bb6 {
-    %15 = getTextPayload(req) -> bb7;
+    %16 = getTextPayload(req) -> bb7;
   }
   bb7 {
-    $desugar$2 = %15;
-    %17 = $desugar$2 is error
+    %17 = %16 is error
     %17 ? bb8 : bb9;
   }
   bb8 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %16;
     return;
   }
   bb9 {
-    %18 = println($desugar$2) -> bb10;
+    %15 = %16;
+    GOTO bb10;
   }
   bb10 {
-    %19 = getContentType(req) -> bb11;
+    %18 = println(%15) -> bb11;
   }
   bb11 {
-    %20 = println(%19) -> bb12;
+    %19 = getContentType(req) -> bb12;
   }
   bb12 {
-    %21 = ConstantLoad X-One
-    %22 = ConstantLoad v1
-    %23 = setHeader(req,%21,%22) -> bb13;
+    %20 = println(%19) -> bb13;
   }
   bb13 {
-    %24 = ConstantLoad X-One
-    %25 = ConstantLoad v2
-    %26 = addHeader(req,%24,%25) -> bb14;
+    %21 = ConstantLoad X-One
+    %22 = ConstantLoad v1
+    %23 = setHeader(req,%21,%22) -> bb14;
   }
   bb14 {
-    %27 = ConstantLoad X-One
-    %28 = getHeader(req,%27) -> bb15;
+    %24 = ConstantLoad X-One
+    %25 = ConstantLoad v2
+    %26 = addHeader(req,%24,%25) -> bb15;
   }
   bb15 {
-    $desugar$3 = %28;
-    %30 = $desugar$3 is error
-    %30 ? bb16 : bb17;
+    %28 = ConstantLoad X-One
+    %29 = getHeader(req,%28) -> bb16;
   }
   bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %30 = %29 is error
+    %30 ? bb17 : bb18;
   }
   bb17 {
-    %31 = println($desugar$3) -> bb18;
+    %0 = %29;
+    return;
   }
   bb18 {
-    %32 = ConstantLoad X-One
-    %33 = getHeaders(req,%32) -> bb19;
+    %27 = %29;
+    GOTO bb19;
   }
   bb19 {
-    $desugar$4 = %33;
-    %35 = $desugar$4 is error
-    %35 ? bb20 : bb21;
+    %31 = println(%27) -> bb20;
   }
   bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %33 = ConstantLoad X-One
+    %34 = getHeaders(req,%33) -> bb21;
   }
   bb21 {
-    xs = $desugar$4;
-    %37 = length(xs) -> bb22;
+    %35 = %34 is error
+    %35 ? bb22 : bb23;
   }
   bb22 {
-    %38 = %37;
-    %39 = println(%38) -> bb23;
-  }
-  bb23 {
-    %40 = ConstantLoad X-One
-    %41 = hasHeader(req,%40) -> bb24;
-  }
-  bb24 {
-    %42 = %41;
-    %43 = println(%42) -> bb25;
-  }
-  bb25 {
-    %44 = ConstantLoad X-Absent
-    %45 = hasHeader(req,%44) -> bb26;
-  }
-  bb26 {
-    %46 = %45;
-    %47 = println(%46) -> bb27;
-  }
-  bb27 {
-    %48 = ConstantLoad application/json
-    %49 = setContentType(req,%48) -> bb28;
-  }
-  bb28 {
-    $desugar$5 = %49;
-    %51 = $desugar$5 is error
-    %51 ? bb29 : bb30;
-  }
-  bb29 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %34;
     return;
   }
+  bb23 {
+    %32 = %34;
+    GOTO bb24;
+  }
+  bb24 {
+    xs = %32;
+    %37 = length(xs) -> bb25;
+  }
+  bb25 {
+    %38 = %37;
+    %39 = println(%38) -> bb26;
+  }
+  bb26 {
+    %40 = ConstantLoad X-One
+    %41 = hasHeader(req,%40) -> bb27;
+  }
+  bb27 {
+    %42 = %41;
+    %43 = println(%42) -> bb28;
+  }
+  bb28 {
+    %44 = ConstantLoad X-Absent
+    %45 = hasHeader(req,%44) -> bb29;
+  }
+  bb29 {
+    %46 = %45;
+    %47 = println(%46) -> bb30;
+  }
   bb30 {
-    %52 = getContentType(req) -> bb31;
+    %49 = ConstantLoad application/json
+    %50 = setContentType(req,%49) -> bb31;
   }
   bb31 {
-    %53 = println(%52) -> bb32;
+    %51 = %50 is error
+    %51 ? bb32 : bb33;
   }
   bb32 {
-    %54 = ConstantLoad X-One
-    %55 = removeHeader(req,%54) -> bb33;
+    %0 = %50;
+    return;
   }
   bb33 {
-    %56 = ConstantLoad X-One
-    %57 = hasHeader(req,%56) -> bb34;
+    %48 = %50;
+    GOTO bb34;
   }
   bb34 {
-    %58 = %57;
-    %59 = println(%58) -> bb35;
+    %52 = getContentType(req) -> bb35;
   }
   bb35 {
-    %60 = getQueryParams(req) -> bb36;
+    %53 = println(%52) -> bb36;
   }
   bb36 {
-    %61 = %60;
-    %62 = ConstantLoad q
-    %63 = getQueryParamValue(req,%62) -> bb37;
+    %54 = ConstantLoad X-One
+    %55 = removeHeader(req,%54) -> bb37;
   }
   bb37 {
-    %64 = %63 is nil
-    %65 = %64;
-    %66 = println(%65) -> bb38;
+    %56 = ConstantLoad X-One
+    %57 = hasHeader(req,%56) -> bb38;
   }
   bb38 {
-    %67 = ConstantLoad tag
-    %68 = getQueryParamValues(req,%67) -> bb39;
+    %58 = %57;
+    %59 = println(%58) -> bb39;
   }
   bb39 {
-    %69 = %68 is nil
-    %70 = %69;
-    %71 = println(%70) -> bb40;
+    %60 = getQueryParams(req) -> bb40;
   }
   bb40 {
+    %61 = %60;
+    %62 = ConstantLoad q
+    %63 = getQueryParamValue(req,%62) -> bb41;
+  }
+  bb41 {
+    %64 = %63 is nil
+    %65 = %64;
+    %66 = println(%65) -> bb42;
+  }
+  bb42 {
+    %67 = ConstantLoad tag
+    %68 = getQueryParamValues(req,%67) -> bb43;
+  }
+  bb43 {
+    %69 = %68 is nil
+    %70 = %69;
+    %71 = println(%70) -> bb44;
+  }
+  bb44 {
     %72 = ConstantLoad k
     %73 = ConstantLoad v
     %74 = newMap {| json... |}{%72=%73}
-    $desugar$6 = %74;
-    %76 = $default$11($desugar$6) -> bb41;
-  }
-  bb41 {
-    $desugar$7 = %76;
-    %78 = setJsonPayload(req,$desugar$6,$desugar$7) -> bb42;
-  }
-  bb42 {
-    %79 = getJsonPayload(req) -> bb43;
-  }
-  bb43 {
-    $desugar$8 = %79;
-    %81 = $desugar$8 is error
-    %81 ? bb44 : bb45;
-  }
-  bb44 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    $desugar$2 = %74;
+    %76 = $default$11($desugar$2) -> bb45;
   }
   bb45 {
-    jp = $desugar$8;
-    %83 = println(jp) -> bb46;
+    $desugar$3 = %76;
+    %78 = setJsonPayload(req,$desugar$2,$desugar$3) -> bb46;
   }
   bb46 {
+    %80 = getJsonPayload(req) -> bb47;
+  }
+  bb47 {
+    %81 = %80 is error
+    %81 ? bb48 : bb49;
+  }
+  bb48 {
+    %0 = %80;
+    return;
+  }
+  bb49 {
+    %79 = %80;
+    GOTO bb50;
+  }
+  bb50 {
+    jp = %79;
+    %83 = println(jp) -> bb51;
+  }
+  bb51 {
     %84 = ConstantLoad 1
     %85 = ConstantLoad 2
     %86 = ConstantLoad 3
     %87 = ConstantLoad 3
     %88 = newArray [int:Unsigned8...][%87]{%84, %85, %86}
-    $desugar$9 = %88;
-    %90 = $default$10($desugar$9) -> bb47;
-  }
-  bb47 {
-    $desugar$10 = %90;
-    %92 = setBinaryPayload(req,$desugar$9,$desugar$10) -> bb48;
-  }
-  bb48 {
-    %93 = getBinaryPayload(req) -> bb49;
-  }
-  bb49 {
-    $desugar$11 = %93;
-    %95 = $desugar$11 is error
-    %95 ? bb50 : bb51;
-  }
-  bb50 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
-    return;
-  }
-  bb51 {
-    bp = $desugar$11;
-    %97 = length(bp) -> bb52;
+    $desugar$4 = %88;
+    %90 = $default$10($desugar$4) -> bb52;
   }
   bb52 {
-    %98 = %97;
-    %99 = println(%98) -> bb53;
+    $desugar$5 = %90;
+    %92 = setBinaryPayload(req,$desugar$4,$desugar$5) -> bb53;
   }
   bb53 {
-    %100 = newObject ballerina/http:Response
-    %101 = init(%100) -> bb54;
+    %94 = getBinaryPayload(req) -> bb54;
   }
   bb54 {
-    %103 = %101 is nil
-    %103 ? bb55 : bb56;
+    %95 = %94 is error
+    %95 ? bb55 : bb56;
   }
   bb55 {
-    %102 = %100;
-    GOTO bb57;
+    %0 = %94;
+    return;
   }
   bb56 {
-    %102 = %101;
+    %93 = %94;
     GOTO bb57;
   }
   bb57 {
+    bp = %93;
+    %97 = length(bp) -> bb58;
+  }
+  bb58 {
+    %98 = %97;
+    %99 = println(%98) -> bb59;
+  }
+  bb59 {
+    %100 = newObject ballerina/http:Response
+    %101 = init(%100) -> bb60;
+  }
+  bb60 {
+    %103 = %101 is nil
+    %103 ? bb61 : bb62;
+  }
+  bb61 {
+    %102 = %100;
+    GOTO bb63;
+  }
+  bb62 {
+    %102 = %101;
+    GOTO bb63;
+  }
+  bb63 {
     res = %102;
     %105 = ConstantLoad 201
     %106 = ConstantLoad statusCode
     res[%106] = %105;
     %107 = ConstantLoad X-Resp
     %108 = ConstantLoad r1
-    %109 = setHeader(res,%107,%108) -> bb58;
+    %109 = setHeader(res,%107,%108) -> bb64;
   }
-  bb58 {
+  bb64 {
     %110 = ConstantLoad X-Resp
-    $desugar$12 = %110;
+    $desugar$6 = %110;
     %112 = ConstantLoad r2
-    $desugar$13 = %112;
-    %114 = $default$0($desugar$12,$desugar$13) -> bb59;
+    $desugar$7 = %112;
+    %114 = $default$0($desugar$6,$desugar$7) -> bb65;
   }
-  bb59 {
-    $desugar$14 = %114;
-    %116 = addHeader(res,$desugar$12,$desugar$13,$desugar$14) -> bb60;
+  bb65 {
+    $desugar$8 = %114;
+    %116 = addHeader(res,$desugar$6,$desugar$7,$desugar$8) -> bb66;
   }
-  bb60 {
+  bb66 {
     %118 = ConstantLoad statusCode
     %117 = res[%118];
     %119 = %117;
-    %120 = println(%119) -> bb61;
-  }
-  bb61 {
-    %121 = ConstantLoad X-Resp
-    $desugar$15 = %121;
-    %123 = $default$4($desugar$15) -> bb62;
-  }
-  bb62 {
-    $desugar$16 = %123;
-    %125 = hasHeader(res,$desugar$15,$desugar$16) -> bb63;
-  }
-  bb63 {
-    %126 = %125;
-    %127 = println(%126) -> bb64;
-  }
-  bb64 {
-    %128 = ConstantLoad X-Resp
-    $desugar$17 = %128;
-    %130 = $default$1($desugar$17) -> bb65;
-  }
-  bb65 {
-    $desugar$18 = %130;
-    %132 = getHeader(res,$desugar$17,$desugar$18) -> bb66;
-  }
-  bb66 {
-    $desugar$19 = %132;
-    %134 = $desugar$19 is error
-    %134 ? bb67 : bb68;
+    %120 = println(%119) -> bb67;
   }
   bb67 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$19);
-    PopScopeFrame
-    return;
+    %121 = ConstantLoad X-Resp
+    $desugar$9 = %121;
+    %123 = $default$4($desugar$9) -> bb68;
   }
   bb68 {
-    %135 = println($desugar$19) -> bb69;
+    $desugar$10 = %123;
+    %125 = hasHeader(res,$desugar$9,$desugar$10) -> bb69;
   }
   bb69 {
-    %136 = ConstantLoad X-Resp
-    $desugar$20 = %136;
-    %138 = $default$3($desugar$20) -> bb70;
+    %126 = %125;
+    %127 = println(%126) -> bb70;
   }
   bb70 {
-    $desugar$21 = %138;
-    %140 = getHeaders(res,$desugar$20,$desugar$21) -> bb71;
+    %128 = ConstantLoad X-Resp
+    $desugar$11 = %128;
+    %130 = $default$1($desugar$11) -> bb71;
   }
   bb71 {
-    $desugar$22 = %140;
-    %142 = $desugar$22 is error
-    %142 ? bb72 : bb73;
+    $desugar$12 = %130;
+    %133 = getHeader(res,$desugar$11,$desugar$12) -> bb72;
   }
   bb72 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
-    return;
+    %134 = %133 is error
+    %134 ? bb73 : bb74;
   }
   bb73 {
-    rs = $desugar$22;
-    %144 = length(rs) -> bb74;
+    %0 = %133;
+    return;
   }
   bb74 {
-    %145 = %144;
-    %146 = println(%145) -> bb75;
+    %132 = %133;
+    GOTO bb75;
   }
   bb75 {
-    %147 = $default$2() -> bb76;
+    %135 = println(%132) -> bb76;
   }
   bb76 {
-    $desugar$23 = %147;
-    %150 = getHeaderNames(res,$desugar$23) -> bb77;
+    %136 = ConstantLoad X-Resp
+    $desugar$13 = %136;
+    %138 = $default$3($desugar$13) -> bb77;
   }
   bb77 {
-    %151 = length(%150) -> bb78;
+    $desugar$14 = %138;
+    %141 = getHeaders(res,$desugar$13,$desugar$14) -> bb78;
   }
   bb78 {
+    %142 = %141 is error
+    %142 ? bb79 : bb80;
+  }
+  bb79 {
+    %0 = %141;
+    return;
+  }
+  bb80 {
+    %140 = %141;
+    GOTO bb81;
+  }
+  bb81 {
+    rs = %140;
+    %144 = length(rs) -> bb82;
+  }
+  bb82 {
+    %145 = %144;
+    %146 = println(%145) -> bb83;
+  }
+  bb83 {
+    %147 = $default$2() -> bb84;
+  }
+  bb84 {
+    $desugar$15 = %147;
+    %150 = getHeaderNames(res,$desugar$15) -> bb85;
+  }
+  bb85 {
+    %151 = length(%150) -> bb86;
+  }
+  bb86 {
     %152 = %151;
     %153 = ConstantLoad 1
     %154 = %153;
     %149 = >= %152 %154;
     %155 = %149;
-    %156 = println(%155) -> bb79;
-  }
-  bb79 {
-    %157 = ConstantLoad text/plain
-    %158 = setContentType(res,%157) -> bb80;
-  }
-  bb80 {
-    $desugar$24 = %158;
-    %160 = $desugar$24 is error
-    %160 ? bb81 : bb82;
-  }
-  bb81 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$24);
-    PopScopeFrame
-    return;
-  }
-  bb82 {
-    %161 = getContentType(res) -> bb83;
-  }
-  bb83 {
-    %162 = println(%161) -> bb84;
-  }
-  bb84 {
-    %163 = ConstantLoad resp body
-    $desugar$25 = %163;
-    %165 = $default$9($desugar$25) -> bb85;
-  }
-  bb85 {
-    $desugar$26 = %165;
-    %167 = setTextPayload(res,$desugar$25,$desugar$26) -> bb86;
-  }
-  bb86 {
-    %168 = getTextPayload(res) -> bb87;
+    %156 = println(%155) -> bb87;
   }
   bb87 {
-    $desugar$27 = %168;
-    %170 = $desugar$27 is error
-    %170 ? bb88 : bb89;
+    %158 = ConstantLoad text/plain
+    %159 = setContentType(res,%158) -> bb88;
   }
   bb88 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$27);
-    PopScopeFrame
-    return;
+    %160 = %159 is error
+    %160 ? bb89 : bb90;
   }
   bb89 {
-    %171 = println($desugar$27) -> bb90;
+    %0 = %159;
+    return;
   }
   bb90 {
+    %157 = %159;
+    GOTO bb91;
+  }
+  bb91 {
+    %161 = getContentType(res) -> bb92;
+  }
+  bb92 {
+    %162 = println(%161) -> bb93;
+  }
+  bb93 {
+    %163 = ConstantLoad resp body
+    $desugar$16 = %163;
+    %165 = $default$9($desugar$16) -> bb94;
+  }
+  bb94 {
+    $desugar$17 = %165;
+    %167 = setTextPayload(res,$desugar$16,$desugar$17) -> bb95;
+  }
+  bb95 {
+    %169 = getTextPayload(res) -> bb96;
+  }
+  bb96 {
+    %170 = %169 is error
+    %170 ? bb97 : bb98;
+  }
+  bb97 {
+    %0 = %169;
+    return;
+  }
+  bb98 {
+    %168 = %169;
+    GOTO bb99;
+  }
+  bb99 {
+    %171 = println(%168) -> bb100;
+  }
+  bb100 {
     %172 = ConstantLoad 1
     %173 = ConstantLoad 2
     %174 = ConstantLoad 3
     %175 = ConstantLoad 3
     %176 = newArray [json...][%175]{%172, %173, %174}
-    $desugar$28 = %176;
-    %178 = $default$8($desugar$28) -> bb91;
+    $desugar$18 = %176;
+    %178 = $default$8($desugar$18) -> bb101;
   }
-  bb91 {
-    $desugar$29 = %178;
-    %180 = setJsonPayload(res,$desugar$28,$desugar$29) -> bb92;
+  bb101 {
+    $desugar$19 = %178;
+    %180 = setJsonPayload(res,$desugar$18,$desugar$19) -> bb102;
   }
-  bb92 {
-    %181 = getJsonPayload(res) -> bb93;
+  bb102 {
+    %182 = getJsonPayload(res) -> bb103;
   }
-  bb93 {
-    $desugar$30 = %181;
-    %183 = $desugar$30 is error
-    %183 ? bb94 : bb95;
+  bb103 {
+    %183 = %182 is error
+    %183 ? bb104 : bb105;
   }
-  bb94 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$30);
-    PopScopeFrame
+  bb104 {
+    %0 = %182;
     return;
   }
-  bb95 {
-    rj = $desugar$30;
-    %185 = println(rj) -> bb96;
+  bb105 {
+    %181 = %182;
+    GOTO bb106;
   }
-  bb96 {
+  bb106 {
+    rj = %181;
+    %185 = println(rj) -> bb107;
+  }
+  bb107 {
     %186 = ConstantLoad 10
     %187 = ConstantLoad 20
     %188 = ConstantLoad 30
     %189 = ConstantLoad 3
     %190 = newArray [int:Unsigned8...][%189]{%186, %187, %188}
-    $desugar$31 = %190;
-    %192 = $default$7($desugar$31) -> bb97;
-  }
-  bb97 {
-    $desugar$32 = %192;
-    %194 = setBinaryPayload(res,$desugar$31,$desugar$32) -> bb98;
-  }
-  bb98 {
-    %195 = getBinaryPayload(res) -> bb99;
-  }
-  bb99 {
-    $desugar$33 = %195;
-    %197 = $desugar$33 is error
-    %197 ? bb100 : bb101;
-  }
-  bb100 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$33);
-    PopScopeFrame
-    return;
-  }
-  bb101 {
-    rb = $desugar$33;
-    %199 = length(rb) -> bb102;
-  }
-  bb102 {
-    %200 = %199;
-    %201 = println(%200) -> bb103;
-  }
-  bb103 {
-    %202 = ConstantLoad X-Resp
-    $desugar$34 = %202;
-    %204 = $default$6($desugar$34) -> bb104;
-  }
-  bb104 {
-    $desugar$35 = %204;
-    %206 = removeHeader(res,$desugar$34,$desugar$35) -> bb105;
-  }
-  bb105 {
-    %207 = ConstantLoad X-Resp
-    $desugar$36 = %207;
-    %209 = $default$4($desugar$36) -> bb106;
-  }
-  bb106 {
-    $desugar$37 = %209;
-    %211 = hasHeader(res,$desugar$36,$desugar$37) -> bb107;
-  }
-  bb107 {
-    %212 = %211;
-    %213 = println(%212) -> bb108;
+    $desugar$20 = %190;
+    %192 = $default$7($desugar$20) -> bb108;
   }
   bb108 {
-    %214 = $default$5() -> bb109;
+    $desugar$21 = %192;
+    %194 = setBinaryPayload(res,$desugar$20,$desugar$21) -> bb109;
   }
   bb109 {
-    $desugar$38 = %214;
-    %216 = removeAllHeaders(res,$desugar$38) -> bb110;
+    %196 = getBinaryPayload(res) -> bb110;
   }
   bb110 {
-    %217 = ConstantLoad Content-Type
-    $desugar$39 = %217;
-    %219 = $default$4($desugar$39) -> bb111;
+    %197 = %196 is error
+    %197 ? bb111 : bb112;
   }
   bb111 {
-    $desugar$40 = %219;
-    %221 = hasHeader(res,$desugar$39,$desugar$40) -> bb112;
+    %0 = %196;
+    return;
   }
   bb112 {
-    %222 = %221;
-    %223 = println(%222) -> bb113;
+    %195 = %196;
+    GOTO bb113;
   }
   bb113 {
+    rb = %195;
+    %199 = length(rb) -> bb114;
+  }
+  bb114 {
+    %200 = %199;
+    %201 = println(%200) -> bb115;
+  }
+  bb115 {
+    %202 = ConstantLoad X-Resp
+    $desugar$22 = %202;
+    %204 = $default$6($desugar$22) -> bb116;
+  }
+  bb116 {
+    $desugar$23 = %204;
+    %206 = removeHeader(res,$desugar$22,$desugar$23) -> bb117;
+  }
+  bb117 {
+    %207 = ConstantLoad X-Resp
+    $desugar$24 = %207;
+    %209 = $default$4($desugar$24) -> bb118;
+  }
+  bb118 {
+    $desugar$25 = %209;
+    %211 = hasHeader(res,$desugar$24,$desugar$25) -> bb119;
+  }
+  bb119 {
+    %212 = %211;
+    %213 = println(%212) -> bb120;
+  }
+  bb120 {
+    %214 = $default$5() -> bb121;
+  }
+  bb121 {
+    $desugar$26 = %214;
+    %216 = removeAllHeaders(res,$desugar$26) -> bb122;
+  }
+  bb122 {
+    %217 = ConstantLoad Content-Type
+    $desugar$27 = %217;
+    %219 = $default$4($desugar$27) -> bb123;
+  }
+  bb123 {
+    $desugar$28 = %219;
+    %221 = hasHeader(res,$desugar$27,$desugar$28) -> bb124;
+  }
+  bb124 {
+    %222 = %221;
+    %223 = println(%222) -> bb125;
+  }
+  bb125 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-bytes1-v.txt
+++ b/corpus/bir/library/subset2/io-file-bytes1-v.txt
@@ -17,54 +17,56 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %13;
-    %15 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %16 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %15;
-    %17 = $desugar$3 is error
+    %17 = %16 is error
     %17 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %16;
     return;
   }
   bb4 {
-    %18 = fileReadBytes(path) -> bb5;
+    %15 = %16;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %18;
-    %20 = $desugar$4 is error
-    %20 ? bb6 : bb7;
+    %19 = fileReadBytes(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %20 = %19 is error
+    %20 ? bb7 : bb8;
   }
   bb7 {
-    readBack = $desugar$4;
-    %22 = length(readBack) -> bb8;
+    %0 = %19;
+    return;
   }
   bb8 {
-    %23 = %22;
-    %24 = println(%23) -> bb9;
+    %18 = %19;
+    GOTO bb9;
   }
   bb9 {
+    readBack = %18;
+    %22 = length(readBack) -> bb10;
+  }
+  bb10 {
+    %23 = %22;
+    %24 = println(%23) -> bb11;
+  }
+  bb11 {
     %26 = ConstantLoad 0
     %25 = readBack[%26];
     %27 = %25;
-    %28 = println(%27) -> bb10;
+    %28 = println(%27) -> bb12;
   }
-  bb10 {
+  bb12 {
     %30 = ConstantLoad 4
     %29 = readBack[%30];
     %31 = %29;
-    %32 = println(%31) -> bb11;
+    %32 = println(%31) -> bb13;
   }
-  bb11 {
+  bb13 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-bytes2-v.txt
+++ b/corpus/bir/library/subset2/io-file-bytes2-v.txt
@@ -14,61 +14,64 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %10;
-    %12 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %13 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %12;
-    %14 = $desugar$3 is error
+    %14 = %13 is error
     %14 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %13;
     return;
   }
   bb4 {
-    %15 = ConstantLoad 4
-    %16 = ConstantLoad 5
-    %17 = ConstantLoad 2
-    %18 = newArray [int:Unsigned8...][%17]{%15, %16}
-    %19 = ConstantLoad APPEND
-    %20 = fileWriteBytes(path,%18,%19) -> bb5;
+    %12 = %13;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %20;
-    %22 = $desugar$4 is error
-    %22 ? bb6 : bb7;
+    %16 = ConstantLoad 4
+    %17 = ConstantLoad 5
+    %18 = ConstantLoad 2
+    %19 = newArray [int:Unsigned8...][%18]{%16, %17}
+    %20 = ConstantLoad APPEND
+    %21 = fileWriteBytes(path,%19,%20) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %22 = %21 is error
+    %22 ? bb7 : bb8;
   }
   bb7 {
-    %23 = fileReadBytes(path) -> bb8;
-  }
-  bb8 {
-    $desugar$5 = %23;
-    %25 = $desugar$5 is error
-    %25 ? bb9 : bb10;
-  }
-  bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %21;
     return;
   }
+  bb8 {
+    %15 = %21;
+    GOTO bb9;
+  }
+  bb9 {
+    %24 = fileReadBytes(path) -> bb10;
+  }
   bb10 {
-    readBack = $desugar$5;
-    %27 = length(readBack) -> bb11;
+    %25 = %24 is error
+    %25 ? bb11 : bb12;
   }
   bb11 {
-    %28 = %27;
-    %29 = println(%28) -> bb12;
+    %0 = %24;
+    return;
   }
   bb12 {
+    %23 = %24;
+    GOTO bb13;
+  }
+  bb13 {
+    readBack = %23;
+    %27 = length(readBack) -> bb14;
+  }
+  bb14 {
+    %28 = %27;
+    %29 = println(%28) -> bb15;
+  }
+  bb15 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-errors-v.txt
+++ b/corpus/bir/library/subset2/io-file-errors-v.txt
@@ -52,59 +52,61 @@ main() -> nil|error{
   }
   bb11 {
     $desugar$2 = %28;
-    %30 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb12;
+    %31 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb12;
   }
   bb12 {
-    $desugar$3 = %30;
-    %32 = $desugar$3 is error
+    %32 = %31 is error
     %32 ? bb13 : bb14;
   }
   bb13 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %31;
     return;
   }
   bb14 {
-    %33 = fileReadJson(badJson) -> bb15;
+    %30 = %31;
+    GOTO bb15;
   }
   bb15 {
-    %34 = %33 is error
-    %35 = %34;
-    %36 = println(%35) -> bb16;
+    %33 = fileReadJson(badJson) -> bb16;
   }
   bb16 {
-    %37 = ConstantLoad /tmp/bal_io_trailing_json.json
-    trailingJson = %37;
-    $desugar$4 = trailingJson;
-    %40 = ConstantLoad {"k": 1} extra
-    $desugar$5 = %40;
-    %42 = $default$1($desugar$4,$desugar$5) -> bb17;
+    %34 = %33 is error
+    %35 = %34;
+    %36 = println(%35) -> bb17;
   }
   bb17 {
-    $desugar$6 = %42;
-    %44 = fileWriteString($desugar$4,$desugar$5,$desugar$6) -> bb18;
+    %37 = ConstantLoad /tmp/bal_io_trailing_json.json
+    trailingJson = %37;
+    $desugar$3 = trailingJson;
+    %40 = ConstantLoad {"k": 1} extra
+    $desugar$4 = %40;
+    %42 = $default$1($desugar$3,$desugar$4) -> bb18;
   }
   bb18 {
-    $desugar$7 = %44;
-    %46 = $desugar$7 is error
-    %46 ? bb19 : bb20;
+    $desugar$5 = %42;
+    %45 = fileWriteString($desugar$3,$desugar$4,$desugar$5) -> bb19;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    %46 = %45 is error
+    %46 ? bb20 : bb21;
   }
   bb20 {
-    %47 = fileReadJson(trailingJson) -> bb21;
+    %0 = %45;
+    return;
   }
   bb21 {
-    %48 = %47 is error
-    %49 = %48;
-    %50 = println(%49) -> bb22;
+    %44 = %45;
+    GOTO bb22;
   }
   bb22 {
+    %47 = fileReadJson(trailingJson) -> bb23;
+  }
+  bb23 {
+    %48 = %47 is error
+    %49 = %48;
+    %50 = println(%49) -> bb24;
+  }
+  bb24 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-json-types-v.txt
+++ b/corpus/bir/library/subset2/io-file-json-types-v.txt
@@ -3,112 +3,118 @@ main() -> nil|error{
   bb0 {
     %1 = ConstantLoad /tmp/bal_io_json_float.json
     floatPath = %1;
-    %3 = ConstantLoad 3.14
-    %4 = %3;
-    %5 = fileWriteJson(floatPath,%4) -> bb1;
+    %4 = ConstantLoad 3.14
+    %5 = %4;
+    %6 = fileWriteJson(floatPath,%5) -> bb1;
   }
   bb1 {
-    $desugar$0 = %5;
-    %7 = $desugar$0 is error
+    %7 = %6 is error
     %7 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %6;
     return;
   }
   bb3 {
-    %8 = fileReadJson(floatPath) -> bb4;
+    %3 = %6;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$1 = %8;
-    %10 = $desugar$1 is error
-    %10 ? bb5 : bb6;
+    %9 = fileReadJson(floatPath) -> bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %10 = %9 is error
+    %10 ? bb6 : bb7;
   }
   bb6 {
-    floatBack = $desugar$1;
-    %12 = println(floatBack) -> bb7;
+    %0 = %9;
+    return;
   }
   bb7 {
-    %13 = ConstantLoad /tmp/bal_io_json_decimal.json
-    decimalPath = %13;
-    %15 = ConstantLoad 2.5
-    %16 = %15;
-    %17 = fileWriteJson(decimalPath,%16) -> bb8;
+    %8 = %9;
+    GOTO bb8;
   }
   bb8 {
-    $desugar$2 = %17;
-    %19 = $desugar$2 is error
-    %19 ? bb9 : bb10;
+    floatBack = %8;
+    %12 = println(floatBack) -> bb9;
   }
   bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %13 = ConstantLoad /tmp/bal_io_json_decimal.json
+    decimalPath = %13;
+    %16 = ConstantLoad 2.5
+    %17 = %16;
+    %18 = fileWriteJson(decimalPath,%17) -> bb10;
   }
   bb10 {
-    %20 = fileReadJson(decimalPath) -> bb11;
+    %19 = %18 is error
+    %19 ? bb11 : bb12;
   }
   bb11 {
-    $desugar$3 = %20;
-    %22 = $desugar$3 is error
-    %22 ? bb12 : bb13;
+    %0 = %18;
+    return;
   }
   bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %15 = %18;
+    GOTO bb13;
   }
   bb13 {
-    decimalBack = $desugar$3;
-    %24 = println(decimalBack) -> bb14;
+    %21 = fileReadJson(decimalPath) -> bb14;
   }
   bb14 {
-    %25 = ConstantLoad /tmp/bal_io_json_int.json
-    intPath = %25;
-    %27 = ConstantLoad 42
-    %28 = %27;
-    %29 = fileWriteJson(intPath,%28) -> bb15;
+    %22 = %21 is error
+    %22 ? bb15 : bb16;
   }
   bb15 {
-    $desugar$4 = %29;
-    %31 = $desugar$4 is error
-    %31 ? bb16 : bb17;
+    %0 = %21;
+    return;
   }
   bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %20 = %21;
+    GOTO bb17;
   }
   bb17 {
-    %32 = fileReadJson(intPath) -> bb18;
+    decimalBack = %20;
+    %24 = println(decimalBack) -> bb18;
   }
   bb18 {
-    $desugar$5 = %32;
-    %34 = $desugar$5 is error
-    %34 ? bb19 : bb20;
+    %25 = ConstantLoad /tmp/bal_io_json_int.json
+    intPath = %25;
+    %28 = ConstantLoad 42
+    %29 = %28;
+    %30 = fileWriteJson(intPath,%29) -> bb19;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %31 = %30 is error
+    %31 ? bb20 : bb21;
   }
   bb20 {
-    intBack = $desugar$5;
-    %36 = println(intBack) -> bb21;
+    %0 = %30;
+    return;
   }
   bb21 {
+    %27 = %30;
+    GOTO bb22;
+  }
+  bb22 {
+    %33 = fileReadJson(intPath) -> bb23;
+  }
+  bb23 {
+    %34 = %33 is error
+    %34 ? bb24 : bb25;
+  }
+  bb24 {
+    %0 = %33;
+    return;
+  }
+  bb25 {
+    %32 = %33;
+    GOTO bb26;
+  }
+  bb26 {
+    intBack = %32;
+    %36 = println(intBack) -> bb27;
+  }
+  bb27 {
     %37 = ConstantLoad /tmp/bal_io_json_arr.json
     arrPath = %37;
     %39 = ConstantLoad 1
@@ -119,38 +125,40 @@ main() -> nil|error{
     %44 = ConstantLoad 5
     %45 = newArray [json...][%44]{%39, %40, %41, %42, %43}
     arr = %45;
-    %47 = fileWriteJson(arrPath,arr) -> bb22;
-  }
-  bb22 {
-    $desugar$6 = %47;
-    %49 = $desugar$6 is error
-    %49 ? bb23 : bb24;
-  }
-  bb23 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
-  }
-  bb24 {
-    %50 = fileReadJson(arrPath) -> bb25;
-  }
-  bb25 {
-    $desugar$7 = %50;
-    %52 = $desugar$7 is error
-    %52 ? bb26 : bb27;
-  }
-  bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
-  }
-  bb27 {
-    arrBack = $desugar$7;
-    %54 = println(arrBack) -> bb28;
+    %48 = fileWriteJson(arrPath,arr) -> bb28;
   }
   bb28 {
+    %49 = %48 is error
+    %49 ? bb29 : bb30;
+  }
+  bb29 {
+    %0 = %48;
+    return;
+  }
+  bb30 {
+    %47 = %48;
+    GOTO bb31;
+  }
+  bb31 {
+    %51 = fileReadJson(arrPath) -> bb32;
+  }
+  bb32 {
+    %52 = %51 is error
+    %52 ? bb33 : bb34;
+  }
+  bb33 {
+    %0 = %51;
+    return;
+  }
+  bb34 {
+    %50 = %51;
+    GOTO bb35;
+  }
+  bb35 {
+    arrBack = %50;
+    %54 = println(arrBack) -> bb36;
+  }
+  bb36 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-json1-v.txt
+++ b/corpus/bir/library/subset2/io-file-json1-v.txt
@@ -9,47 +9,49 @@ main() -> nil|error{
     %6 = ConstantLoad 30
     %7 = newMap {| json... |}{%3=%4, %5=%6}
     data = %7;
-    %9 = fileWriteJson(path,data) -> bb1;
+    %10 = fileWriteJson(path,data) -> bb1;
   }
   bb1 {
-    $desugar$0 = %9;
-    %11 = $desugar$0 is error
+    %11 = %10 is error
     %11 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %10;
     return;
   }
   bb3 {
-    %12 = fileReadJson(path) -> bb4;
+    %9 = %10;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$1 = %12;
-    %14 = $desugar$1 is error
-    %14 ? bb5 : bb6;
+    %13 = fileReadJson(path) -> bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %14 = %13 is error
+    %14 ? bb6 : bb7;
   }
   bb6 {
-    result = $desugar$1;
+    %0 = %13;
+    return;
+  }
+  bb7 {
+    %12 = %13;
+    GOTO bb8;
+  }
+  bb8 {
+    result = %12;
     %16 = <{| json... |}>(result)
     m = %16;
     %19 = ConstantLoad name
     %18 = m[%19];
-    %20 = println(%18) -> bb7;
+    %20 = println(%18) -> bb9;
   }
-  bb7 {
+  bb9 {
     %22 = ConstantLoad age
     %21 = m[%22];
-    %23 = println(%21) -> bb8;
+    %23 = println(%21) -> bb10;
   }
-  bb8 {
+  bb10 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-json2-v.txt
+++ b/corpus/bir/library/subset2/io-file-json2-v.txt
@@ -10,49 +10,51 @@ main() -> nil|error{
     %7 = ConstantLoad 4
     %8 = newArray [json...][%7]{%3, %4, %5, %6}
     data = %8;
-    %10 = fileWriteJson(path,data) -> bb1;
+    %11 = fileWriteJson(path,data) -> bb1;
   }
   bb1 {
-    $desugar$0 = %10;
-    %12 = $desugar$0 is error
+    %12 = %11 is error
     %12 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %11;
     return;
   }
   bb3 {
-    %13 = fileReadJson(path) -> bb4;
+    %10 = %11;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$1 = %13;
-    %15 = $desugar$1 is error
-    %15 ? bb5 : bb6;
+    %14 = fileReadJson(path) -> bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %15 = %14 is error
+    %15 ? bb6 : bb7;
   }
   bb6 {
-    result = $desugar$1;
-    %17 = <[json...]>(result)
-    arr = %17;
-    %19 = length(arr) -> bb7;
+    %0 = %14;
+    return;
   }
   bb7 {
-    %20 = %19;
-    %21 = println(%20) -> bb8;
+    %13 = %14;
+    GOTO bb8;
   }
   bb8 {
-    %23 = ConstantLoad 2
-    %22 = arr[%23];
-    %24 = println(%22) -> bb9;
+    result = %13;
+    %17 = <[json...]>(result)
+    arr = %17;
+    %19 = length(arr) -> bb9;
   }
   bb9 {
+    %20 = %19;
+    %21 = println(%20) -> bb10;
+  }
+  bb10 {
+    %23 = ConstantLoad 2
+    %22 = arr[%23];
+    %24 = println(%22) -> bb11;
+  }
+  bb11 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-lines1-v.txt
+++ b/corpus/bir/library/subset2/io-file-lines1-v.txt
@@ -14,66 +14,68 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %10;
-    %12 = fileWriteLines($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %13 = fileWriteLines($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %12;
-    %14 = $desugar$3 is error
+    %14 = %13 is error
     %14 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %13;
     return;
   }
   bb4 {
-    %15 = fileReadLines(path) -> bb5;
+    %12 = %13;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %15;
-    %17 = $desugar$4 is error
-    %17 ? bb6 : bb7;
+    %16 = fileReadLines(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %17 = %16 is error
+    %17 ? bb7 : bb8;
   }
   bb7 {
-    lines = $desugar$4;
-    $desugar$5 = lines;
-    %20 = ConstantLoad 0
-    $desugar$6 = %20;
-    %22 = length($desugar$5) -> bb8;
+    %0 = %16;
+    return;
   }
   bb8 {
-    $desugar$7 = %22;
+    %15 = %16;
     GOTO bb9;
   }
   bb9 {
-    %25 = $desugar$6;
-    %26 = $desugar$7;
-    %24 = < %25 %26;
-    %24 ? bb10 : bb11;
+    lines = %15;
+    $desugar$3 = lines;
+    %20 = ConstantLoad 0
+    $desugar$4 = %20;
+    %22 = length($desugar$3) -> bb10;
   }
   bb10 {
-    PushScopeFrame 7
-    %0 = (1, $desugar$5)[(1, $desugar$6)];
-    line = %0;
-    %2 = println(line) -> bb12;
+    $desugar$5 = %22;
+    GOTO bb11;
   }
   bb11 {
-    return;
+    %25 = $desugar$4;
+    %26 = $desugar$5;
+    %24 = < %25 %26;
+    %24 ? bb12 : bb13;
   }
   bb12 {
-    %4 = (1, $desugar$6);
+    PushScopeFrame 7
+    %0 = (1, $desugar$3)[(1, $desugar$4)];
+    line = %0;
+    %2 = println(line) -> bb14;
+  }
+  bb13 {
+    return;
+  }
+  bb14 {
+    %4 = (1, $desugar$4);
     %5 = ConstantLoad 1
     %6 = %5;
     %3 = + %4 %6;
-    (1, $desugar$6) = %3;
+    (1, $desugar$4) = %3;
     PopScopeFrame
-    GOTO bb9;
+    GOTO bb11;
   }
 }

--- a/corpus/bir/library/subset2/io-file-lines2-v.txt
+++ b/corpus/bir/library/subset2/io-file-lines2-v.txt
@@ -13,65 +13,68 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %9;
-    %11 = fileWriteLines($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %12 = fileWriteLines($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %11;
-    %13 = $desugar$3 is error
+    %13 = %12 is error
     %13 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %12;
     return;
   }
   bb4 {
-    %14 = ConstantLoad Line3
-    %15 = ConstantLoad 1
-    %16 = newArray [string...][%15]{%14}
-    %17 = ConstantLoad APPEND
-    %18 = fileWriteLines(path,%16,%17) -> bb5;
+    %11 = %12;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %18;
-    %20 = $desugar$4 is error
-    %20 ? bb6 : bb7;
+    %15 = ConstantLoad Line3
+    %16 = ConstantLoad 1
+    %17 = newArray [string...][%16]{%15}
+    %18 = ConstantLoad APPEND
+    %19 = fileWriteLines(path,%17,%18) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %20 = %19 is error
+    %20 ? bb7 : bb8;
   }
   bb7 {
-    %21 = fileReadLines(path) -> bb8;
-  }
-  bb8 {
-    $desugar$5 = %21;
-    %23 = $desugar$5 is error
-    %23 ? bb9 : bb10;
-  }
-  bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %19;
     return;
   }
+  bb8 {
+    %14 = %19;
+    GOTO bb9;
+  }
+  bb9 {
+    %22 = fileReadLines(path) -> bb10;
+  }
   bb10 {
-    lines = $desugar$5;
-    %25 = length(lines) -> bb11;
+    %23 = %22 is error
+    %23 ? bb11 : bb12;
   }
   bb11 {
-    %26 = %25;
-    %27 = println(%26) -> bb12;
+    %0 = %22;
+    return;
   }
   bb12 {
-    %29 = ConstantLoad 2
-    %28 = lines[%29];
-    %30 = println(%28) -> bb13;
+    %21 = %22;
+    GOTO bb13;
   }
   bb13 {
+    lines = %21;
+    %25 = length(lines) -> bb14;
+  }
+  bb14 {
+    %26 = %25;
+    %27 = println(%26) -> bb15;
+  }
+  bb15 {
+    %29 = ConstantLoad 2
+    %28 = lines[%29];
+    %30 = println(%28) -> bb16;
+  }
+  bb16 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-mkdir-v.txt
+++ b/corpus/bir/library/subset2/io-file-mkdir-v.txt
@@ -10,257 +10,270 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %6;
-    %8 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %9 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %8;
-    %10 = $desugar$3 is error
+    %10 = %9 is error
     %10 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %9;
     return;
   }
   bb4 {
-    %11 = fileReadString(stringPath) -> bb5;
+    %8 = %9;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %11;
-    %13 = $desugar$4 is error
-    %13 ? bb6 : bb7;
+    %12 = fileReadString(stringPath) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %13 = %12 is error
+    %13 ? bb7 : bb8;
   }
   bb7 {
-    %14 = println($desugar$4) -> bb8;
+    %0 = %12;
+    return;
   }
   bb8 {
+    %11 = %12;
+    GOTO bb9;
+  }
+  bb9 {
+    %14 = println(%11) -> bb10;
+  }
+  bb10 {
     %15 = ConstantLoad /tmp/bal_io_mkdir_xyz/lines/a/b/lines.txt
     linesPath = %15;
-    $desugar$5 = linesPath;
+    $desugar$3 = linesPath;
     %18 = ConstantLoad one
     %19 = ConstantLoad two
     %20 = ConstantLoad 2
     %21 = newArray [string...][%20]{%18, %19}
-    $desugar$6 = %21;
-    %23 = $default$2($desugar$5,$desugar$6) -> bb9;
-  }
-  bb9 {
-    $desugar$7 = %23;
-    %25 = fileWriteLines($desugar$5,$desugar$6,$desugar$7) -> bb10;
-  }
-  bb10 {
-    $desugar$8 = %25;
-    %27 = $desugar$8 is error
-    %27 ? bb11 : bb12;
+    $desugar$4 = %21;
+    %23 = $default$2($desugar$3,$desugar$4) -> bb11;
   }
   bb11 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    $desugar$5 = %23;
+    %26 = fileWriteLines($desugar$3,$desugar$4,$desugar$5) -> bb12;
   }
   bb12 {
-    %28 = fileReadLines(linesPath) -> bb13;
+    %27 = %26 is error
+    %27 ? bb13 : bb14;
   }
   bb13 {
-    $desugar$9 = %28;
-    %30 = $desugar$9 is error
-    %30 ? bb14 : bb15;
-  }
-  bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %26;
     return;
   }
+  bb14 {
+    %25 = %26;
+    GOTO bb15;
+  }
   bb15 {
-    %31 = println($desugar$9) -> bb16;
+    %29 = fileReadLines(linesPath) -> bb16;
   }
   bb16 {
+    %30 = %29 is error
+    %30 ? bb17 : bb18;
+  }
+  bb17 {
+    %0 = %29;
+    return;
+  }
+  bb18 {
+    %28 = %29;
+    GOTO bb19;
+  }
+  bb19 {
+    %31 = println(%28) -> bb20;
+  }
+  bb20 {
     %32 = ConstantLoad /tmp/bal_io_mkdir_xyz/bytes/a/b/bytes.dat
     bytesPath = %32;
-    $desugar$10 = bytesPath;
+    $desugar$6 = bytesPath;
     %35 = ConstantLoad 1
     %36 = ConstantLoad 2
     %37 = ConstantLoad 3
     %38 = ConstantLoad 3
     %39 = newArray [int:Unsigned8...][%38]{%35, %36, %37}
-    $desugar$11 = %39;
-    %41 = $default$4($desugar$10,$desugar$11) -> bb17;
-  }
-  bb17 {
-    $desugar$12 = %41;
-    %43 = fileWriteBytes($desugar$10,$desugar$11,$desugar$12) -> bb18;
-  }
-  bb18 {
-    $desugar$13 = %43;
-    %45 = $desugar$13 is error
-    %45 ? bb19 : bb20;
-  }
-  bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
-    return;
-  }
-  bb20 {
-    %46 = fileReadBytes(bytesPath) -> bb21;
+    $desugar$7 = %39;
+    %41 = $default$4($desugar$6,$desugar$7) -> bb21;
   }
   bb21 {
-    $desugar$14 = %46;
-    %48 = $desugar$14 is error
-    %48 ? bb22 : bb23;
+    $desugar$8 = %41;
+    %44 = fileWriteBytes($desugar$6,$desugar$7,$desugar$8) -> bb22;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
-    return;
+    %45 = %44 is error
+    %45 ? bb23 : bb24;
   }
   bb23 {
-    %49 = println($desugar$14) -> bb24;
+    %0 = %44;
+    return;
   }
   bb24 {
-    %50 = ConstantLoad /tmp/bal_io_mkdir_xyz/json/a/b/data.json
-    jsonPath = %50;
-    %52 = ConstantLoad k
-    %53 = ConstantLoad v
-    %54 = newMap {| json... |}{%52=%53}
-    %55 = fileWriteJson(jsonPath,%54) -> bb25;
+    %43 = %44;
+    GOTO bb25;
   }
   bb25 {
-    $desugar$15 = %55;
-    %57 = $desugar$15 is error
-    %57 ? bb26 : bb27;
+    %47 = fileReadBytes(bytesPath) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$15);
-    PopScopeFrame
-    return;
+    %48 = %47 is error
+    %48 ? bb27 : bb28;
   }
   bb27 {
-    %58 = fileReadJson(jsonPath) -> bb28;
+    %0 = %47;
+    return;
   }
   bb28 {
-    $desugar$16 = %58;
-    %60 = $desugar$16 is error
-    %60 ? bb29 : bb30;
+    %46 = %47;
+    GOTO bb29;
   }
   bb29 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$16);
-    PopScopeFrame
-    return;
+    %49 = println(%46) -> bb30;
   }
   bb30 {
-    %61 = println($desugar$16) -> bb31;
+    %50 = ConstantLoad /tmp/bal_io_mkdir_xyz/json/a/b/data.json
+    jsonPath = %50;
+    %53 = ConstantLoad k
+    %54 = ConstantLoad v
+    %55 = newMap {| json... |}{%53=%54}
+    %56 = fileWriteJson(jsonPath,%55) -> bb31;
   }
   bb31 {
-    %62 = ConstantLoad /tmp/bal_io_mkdir_xyz/xml/a/b/data.xml
-    xmlPath = %62;
-    $desugar$17 = xmlPath;
-    %65 = ConstantLoad a
-    %66 = newXMLElement(%65, ())
-    $desugar$18 = %66;
-    %68 = $default$6($desugar$17,$desugar$18) -> bb32;
+    %57 = %56 is error
+    %57 ? bb32 : bb33;
   }
   bb32 {
-    $desugar$19 = %68;
-    %70 = fileWriteXml($desugar$17,$desugar$18,$desugar$19) -> bb33;
+    %0 = %56;
+    return;
   }
   bb33 {
-    $desugar$20 = %70;
-    %72 = $desugar$20 is error
-    %72 ? bb34 : bb35;
+    %52 = %56;
+    GOTO bb34;
   }
   bb34 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
+    %59 = fileReadJson(jsonPath) -> bb35;
   }
   bb35 {
-    %73 = fileReadXml(xmlPath) -> bb36;
+    %60 = %59 is error
+    %60 ? bb36 : bb37;
   }
   bb36 {
-    $desugar$21 = %73;
-    %75 = $desugar$21 is error
-    %75 ? bb37 : bb38;
-  }
-  bb37 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$21);
-    PopScopeFrame
+    %0 = %59;
     return;
   }
+  bb37 {
+    %58 = %59;
+    GOTO bb38;
+  }
   bb38 {
-    %76 = println($desugar$21) -> bb39;
+    %61 = println(%58) -> bb39;
   }
   bb39 {
-    %77 = ConstantLoad /tmp/bal_io_mkdir_xyz/append/c/d/append.txt
-    appendPath = %77;
-    $desugar$22 = appendPath;
-    %80 = ConstantLoad First
-    $desugar$23 = %80;
-    %82 = $default$1($desugar$22,$desugar$23) -> bb40;
+    %62 = ConstantLoad /tmp/bal_io_mkdir_xyz/xml/a/b/data.xml
+    xmlPath = %62;
+    $desugar$9 = xmlPath;
+    %65 = ConstantLoad a
+    %66 = newXMLElement(%65, ())
+    $desugar$10 = %66;
+    %68 = $default$6($desugar$9,$desugar$10) -> bb40;
   }
   bb40 {
-    $desugar$24 = %82;
-    %84 = fileWriteString($desugar$22,$desugar$23,$desugar$24) -> bb41;
+    $desugar$11 = %68;
+    %71 = fileWriteXml($desugar$9,$desugar$10,$desugar$11) -> bb41;
   }
   bb41 {
-    $desugar$25 = %84;
-    %86 = $desugar$25 is error
-    %86 ? bb42 : bb43;
+    %72 = %71 is error
+    %72 ? bb42 : bb43;
   }
   bb42 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$25);
-    PopScopeFrame
+    %0 = %71;
     return;
   }
   bb43 {
-    %87 = ConstantLoad Second
-    %88 = ConstantLoad APPEND
-    %89 = fileWriteString(appendPath,%87,%88) -> bb44;
+    %70 = %71;
+    GOTO bb44;
   }
   bb44 {
-    $desugar$26 = %89;
-    %91 = $desugar$26 is error
-    %91 ? bb45 : bb46;
+    %74 = fileReadXml(xmlPath) -> bb45;
   }
   bb45 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$26);
-    PopScopeFrame
-    return;
+    %75 = %74 is error
+    %75 ? bb46 : bb47;
   }
   bb46 {
-    %92 = fileReadString(appendPath) -> bb47;
-  }
-  bb47 {
-    $desugar$27 = %92;
-    %94 = $desugar$27 is error
-    %94 ? bb48 : bb49;
-  }
-  bb48 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$27);
-    PopScopeFrame
+    %0 = %74;
     return;
   }
+  bb47 {
+    %73 = %74;
+    GOTO bb48;
+  }
+  bb48 {
+    %76 = println(%73) -> bb49;
+  }
   bb49 {
-    %95 = println($desugar$27) -> bb50;
+    %77 = ConstantLoad /tmp/bal_io_mkdir_xyz/append/c/d/append.txt
+    appendPath = %77;
+    $desugar$12 = appendPath;
+    %80 = ConstantLoad First
+    $desugar$13 = %80;
+    %82 = $default$1($desugar$12,$desugar$13) -> bb50;
   }
   bb50 {
+    $desugar$14 = %82;
+    %85 = fileWriteString($desugar$12,$desugar$13,$desugar$14) -> bb51;
+  }
+  bb51 {
+    %86 = %85 is error
+    %86 ? bb52 : bb53;
+  }
+  bb52 {
+    %0 = %85;
+    return;
+  }
+  bb53 {
+    %84 = %85;
+    GOTO bb54;
+  }
+  bb54 {
+    %88 = ConstantLoad Second
+    %89 = ConstantLoad APPEND
+    %90 = fileWriteString(appendPath,%88,%89) -> bb55;
+  }
+  bb55 {
+    %91 = %90 is error
+    %91 ? bb56 : bb57;
+  }
+  bb56 {
+    %0 = %90;
+    return;
+  }
+  bb57 {
+    %87 = %90;
+    GOTO bb58;
+  }
+  bb58 {
+    %93 = fileReadString(appendPath) -> bb59;
+  }
+  bb59 {
+    %94 = %93 is error
+    %94 ? bb60 : bb61;
+  }
+  bb60 {
+    %0 = %93;
+    return;
+  }
+  bb61 {
+    %92 = %93;
+    GOTO bb62;
+  }
+  bb62 {
+    %95 = println(%92) -> bb63;
+  }
+  bb63 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-string1-v.txt
+++ b/corpus/bir/library/subset2/io-file-string1-v.txt
@@ -11,38 +11,40 @@ World
   }
   bb1 {
     $desugar$2 = %6;
-    %8 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %9 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %8;
-    %10 = $desugar$3 is error
+    %10 = %9 is error
     %10 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %9;
     return;
   }
   bb4 {
-    %11 = fileReadString(path) -> bb5;
+    %8 = %9;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %11;
-    %13 = $desugar$4 is error
-    %13 ? bb6 : bb7;
+    %12 = fileReadString(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %13 = %12 is error
+    %13 ? bb7 : bb8;
   }
   bb7 {
-    content = $desugar$4;
-    %15 = println(content) -> bb8;
+    %0 = %12;
+    return;
   }
   bb8 {
+    %11 = %12;
+    GOTO bb9;
+  }
+  bb9 {
+    content = %11;
+    %15 = println(content) -> bb10;
+  }
+  bb10 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-string2-v.txt
+++ b/corpus/bir/library/subset2/io-file-string2-v.txt
@@ -10,54 +10,57 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %6;
-    %8 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %9 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %8;
-    %10 = $desugar$3 is error
+    %10 = %9 is error
     %10 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %9;
     return;
   }
   bb4 {
-    %11 = ConstantLoad Second
-    %12 = ConstantLoad APPEND
-    %13 = fileWriteString(path,%11,%12) -> bb5;
+    %8 = %9;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %13;
-    %15 = $desugar$4 is error
-    %15 ? bb6 : bb7;
+    %12 = ConstantLoad Second
+    %13 = ConstantLoad APPEND
+    %14 = fileWriteString(path,%12,%13) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %15 = %14 is error
+    %15 ? bb7 : bb8;
   }
   bb7 {
-    %16 = fileReadString(path) -> bb8;
-  }
-  bb8 {
-    $desugar$5 = %16;
-    %18 = $desugar$5 is error
-    %18 ? bb9 : bb10;
-  }
-  bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %14;
     return;
   }
+  bb8 {
+    %11 = %14;
+    GOTO bb9;
+  }
+  bb9 {
+    %17 = fileReadString(path) -> bb10;
+  }
   bb10 {
-    content = $desugar$5;
-    %20 = println(content) -> bb11;
+    %18 = %17 is error
+    %18 ? bb11 : bb12;
   }
   bb11 {
+    %0 = %17;
+    return;
+  }
+  bb12 {
+    %16 = %17;
+    GOTO bb13;
+  }
+  bb13 {
+    content = %16;
+    %20 = println(content) -> bb14;
+  }
+  bb14 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-xml-extra-v.txt
+++ b/corpus/bir/library/subset2/io-file-xml-extra-v.txt
@@ -13,189 +13,197 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %9;
-    %11 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %12 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %11;
-    %13 = $desugar$3 is error
+    %13 = %12 is error
     %13 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %12;
     return;
   }
   bb4 {
-    %14 = fileReadXml(nsPath) -> bb5;
+    %11 = %12;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %14;
-    %16 = $desugar$4 is error
-    %16 ? bb6 : bb7;
+    %15 = fileReadXml(nsPath) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %16 = %15 is error
+    %16 ? bb7 : bb8;
   }
   bb7 {
-    nsResult = $desugar$4;
-    %18 = println(nsResult) -> bb8;
+    %0 = %15;
+    return;
   }
   bb8 {
+    %14 = %15;
+    GOTO bb9;
+  }
+  bb9 {
+    nsResult = %14;
+    %18 = println(nsResult) -> bb10;
+  }
+  bb10 {
     %19 = ConstantLoad /tmp/bal_io_xml_multi.xml
     multiPath = %19;
     %21 = ConstantLoad <!DOCTYPE note><!-- a comment --><?target data?><a/><b/>
     multiContent = %21;
-    $desugar$5 = multiPath;
-    $desugar$6 = multiContent;
-    %25 = $default$1($desugar$5,$desugar$6) -> bb9;
-  }
-  bb9 {
-    $desugar$7 = %25;
-    %27 = fileWriteString($desugar$5,$desugar$6,$desugar$7) -> bb10;
-  }
-  bb10 {
-    $desugar$8 = %27;
-    %29 = $desugar$8 is error
-    %29 ? bb11 : bb12;
+    $desugar$3 = multiPath;
+    $desugar$4 = multiContent;
+    %25 = $default$1($desugar$3,$desugar$4) -> bb11;
   }
   bb11 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    $desugar$5 = %25;
+    %28 = fileWriteString($desugar$3,$desugar$4,$desugar$5) -> bb12;
   }
   bb12 {
-    %30 = fileReadXml(multiPath) -> bb13;
+    %29 = %28 is error
+    %29 ? bb13 : bb14;
   }
   bb13 {
-    $desugar$9 = %30;
-    %32 = $desugar$9 is error
-    %32 ? bb14 : bb15;
+    %0 = %28;
+    return;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
-    return;
+    %27 = %28;
+    GOTO bb15;
   }
   bb15 {
-    multiResult = $desugar$9;
-    %34 = println(multiResult) -> bb16;
+    %31 = fileReadXml(multiPath) -> bb16;
   }
   bb16 {
-    %35 = ConstantLoad /tmp/bal_io_xml_empty.xml
-    emptyPath = %35;
-    $desugar$10 = emptyPath;
-    %38 = ConstantLoad    
-  
-    $desugar$11 = %38;
-    %40 = $default$1($desugar$10,$desugar$11) -> bb17;
+    %32 = %31 is error
+    %32 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$12 = %40;
-    %42 = fileWriteString($desugar$10,$desugar$11,$desugar$12) -> bb18;
+    %0 = %31;
+    return;
   }
   bb18 {
-    $desugar$13 = %42;
-    %44 = $desugar$13 is error
-    %44 ? bb19 : bb20;
+    %30 = %31;
+    GOTO bb19;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
-    return;
+    multiResult = %30;
+    %34 = println(multiResult) -> bb20;
   }
   bb20 {
-    %45 = fileReadXml(emptyPath) -> bb21;
+    %35 = ConstantLoad /tmp/bal_io_xml_empty.xml
+    emptyPath = %35;
+    $desugar$6 = emptyPath;
+    %38 = ConstantLoad    
+  
+    $desugar$7 = %38;
+    %40 = $default$1($desugar$6,$desugar$7) -> bb21;
   }
   bb21 {
-    $desugar$14 = %45;
-    %47 = $desugar$14 is error
-    %47 ? bb22 : bb23;
+    $desugar$8 = %40;
+    %43 = fileWriteString($desugar$6,$desugar$7,$desugar$8) -> bb22;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
-    return;
+    %44 = %43 is error
+    %44 ? bb23 : bb24;
   }
   bb23 {
-    emptyResult = $desugar$14;
-    %50 = newXMLSequence{}
-    %49 = unknown emptyResult %50;
-    %51 = %49;
-    %52 = println(%51) -> bb24;
+    %0 = %43;
+    return;
   }
   bb24 {
-    %53 = ConstantLoad /tmp/bal_io_xml_bad.xml
-    badPath = %53;
-    $desugar$15 = badPath;
-    %56 = ConstantLoad <root><unclosed></root>
-    $desugar$16 = %56;
-    %58 = $default$1($desugar$15,$desugar$16) -> bb25;
+    %42 = %43;
+    GOTO bb25;
   }
   bb25 {
-    $desugar$17 = %58;
-    %60 = fileWriteString($desugar$15,$desugar$16,$desugar$17) -> bb26;
+    %46 = fileReadXml(emptyPath) -> bb26;
   }
   bb26 {
-    $desugar$18 = %60;
-    %62 = $desugar$18 is error
-    %62 ? bb27 : bb28;
+    %47 = %46 is error
+    %47 ? bb27 : bb28;
   }
   bb27 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
+    %0 = %46;
     return;
   }
   bb28 {
-    %63 = fileReadXml(badPath) -> bb29;
+    %45 = %46;
+    GOTO bb29;
   }
   bb29 {
-    badResult = %63;
-    %65 = badResult is error
-    %66 = %65;
-    %67 = println(%66) -> bb30;
+    emptyResult = %45;
+    %50 = newXMLSequence{}
+    %49 = unknown emptyResult %50;
+    %51 = %49;
+    %52 = println(%51) -> bb30;
   }
   bb30 {
-    %68 = ConstantLoad /tmp/bal_io_xml_stray.xml
-    strayPath = %68;
-    $desugar$19 = strayPath;
-    %71 = ConstantLoad </root>
-    $desugar$20 = %71;
-    %73 = $default$1($desugar$19,$desugar$20) -> bb31;
+    %53 = ConstantLoad /tmp/bal_io_xml_bad.xml
+    badPath = %53;
+    $desugar$9 = badPath;
+    %56 = ConstantLoad <root><unclosed></root>
+    $desugar$10 = %56;
+    %58 = $default$1($desugar$9,$desugar$10) -> bb31;
   }
   bb31 {
-    $desugar$21 = %73;
-    %75 = fileWriteString($desugar$19,$desugar$20,$desugar$21) -> bb32;
+    $desugar$11 = %58;
+    %61 = fileWriteString($desugar$9,$desugar$10,$desugar$11) -> bb32;
   }
   bb32 {
-    $desugar$22 = %75;
-    %77 = $desugar$22 is error
-    %77 ? bb33 : bb34;
+    %62 = %61 is error
+    %62 ? bb33 : bb34;
   }
   bb33 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
+    %0 = %61;
     return;
   }
   bb34 {
-    %78 = fileReadXml(strayPath) -> bb35;
+    %60 = %61;
+    GOTO bb35;
   }
   bb35 {
+    %63 = fileReadXml(badPath) -> bb36;
+  }
+  bb36 {
+    badResult = %63;
+    %65 = badResult is error
+    %66 = %65;
+    %67 = println(%66) -> bb37;
+  }
+  bb37 {
+    %68 = ConstantLoad /tmp/bal_io_xml_stray.xml
+    strayPath = %68;
+    $desugar$12 = strayPath;
+    %71 = ConstantLoad </root>
+    $desugar$13 = %71;
+    %73 = $default$1($desugar$12,$desugar$13) -> bb38;
+  }
+  bb38 {
+    $desugar$14 = %73;
+    %76 = fileWriteString($desugar$12,$desugar$13,$desugar$14) -> bb39;
+  }
+  bb39 {
+    %77 = %76 is error
+    %77 ? bb40 : bb41;
+  }
+  bb40 {
+    %0 = %76;
+    return;
+  }
+  bb41 {
+    %75 = %76;
+    GOTO bb42;
+  }
+  bb42 {
+    %78 = fileReadXml(strayPath) -> bb43;
+  }
+  bb43 {
     strayResult = %78;
     %80 = strayResult is error
     %81 = %80;
-    %82 = println(%81) -> bb36;
+    %82 = println(%81) -> bb44;
   }
-  bb36 {
+  bb44 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-xml1-v.txt
+++ b/corpus/bir/library/subset2/io-file-xml1-v.txt
@@ -21,38 +21,40 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %17;
-    %19 = fileWriteXml($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %20 = fileWriteXml($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %19;
-    %21 = $desugar$3 is error
+    %21 = %20 is error
     %21 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %20;
     return;
   }
   bb4 {
-    %22 = fileReadXml(path) -> bb5;
+    %19 = %20;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %22;
-    %24 = $desugar$4 is error
-    %24 ? bb6 : bb7;
+    %23 = fileReadXml(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %24 = %23 is error
+    %24 ? bb7 : bb8;
   }
   bb7 {
-    result = $desugar$4;
-    %26 = println(result) -> bb8;
+    %0 = %23;
+    return;
   }
   bb8 {
+    %22 = %23;
+    GOTO bb9;
+  }
+  bb9 {
+    result = %22;
+    %26 = println(result) -> bb10;
+  }
+  bb10 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/io-file-xml2-v.txt
+++ b/corpus/bir/library/subset2/io-file-xml2-v.txt
@@ -17,79 +17,83 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %13;
-    %15 = fileWriteXml($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %16 = fileWriteXml($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %15;
-    %17 = $desugar$3 is error
+    %17 = %16 is error
     %17 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %16;
     return;
   }
   bb4 {
-    %18 = fileReadXml(path) -> bb5;
+    %15 = %16;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %18;
-    %20 = $desugar$4 is error
-    %20 ? bb6 : bb7;
+    %19 = fileReadXml(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %20 = %19 is error
+    %20 ? bb7 : bb8;
   }
   bb7 {
-    result = $desugar$4;
-    %22 = println(result) -> bb8;
+    %0 = %19;
+    return;
   }
   bb8 {
+    %18 = %19;
+    GOTO bb9;
+  }
+  bb9 {
+    result = %18;
+    %22 = println(result) -> bb10;
+  }
+  bb10 {
     %23 = ConstantLoad updated
     %24 = newXMLElement(%23, ())
     data2 = %24;
-    $desugar$5 = path;
-    $desugar$6 = data2;
-    %28 = $default$6($desugar$5,$desugar$6) -> bb9;
-  }
-  bb9 {
-    $desugar$7 = %28;
-    %30 = fileWriteXml($desugar$5,$desugar$6,$desugar$7) -> bb10;
-  }
-  bb10 {
-    $desugar$8 = %30;
-    %32 = $desugar$8 is error
-    %32 ? bb11 : bb12;
+    $desugar$3 = path;
+    $desugar$4 = data2;
+    %28 = $default$6($desugar$3,$desugar$4) -> bb11;
   }
   bb11 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    $desugar$5 = %28;
+    %31 = fileWriteXml($desugar$3,$desugar$4,$desugar$5) -> bb12;
   }
   bb12 {
-    %33 = fileReadXml(path) -> bb13;
+    %32 = %31 is error
+    %32 ? bb13 : bb14;
   }
   bb13 {
-    $desugar$9 = %33;
-    %35 = $desugar$9 is error
-    %35 ? bb14 : bb15;
-  }
-  bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %31;
     return;
   }
+  bb14 {
+    %30 = %31;
+    GOTO bb15;
+  }
   bb15 {
-    result2 = $desugar$9;
-    %37 = println(result2) -> bb16;
+    %34 = fileReadXml(path) -> bb16;
   }
   bb16 {
+    %35 = %34 is error
+    %35 ? bb17 : bb18;
+  }
+  bb17 {
+    %0 = %34;
+    return;
+  }
+  bb18 {
+    %33 = %34;
+    GOTO bb19;
+  }
+  bb19 {
+    result2 = %33;
+    %37 = println(result2) -> bb20;
+  }
+  bb20 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/os-env2-v.txt
+++ b/corpus/bir/library/subset2/os-env2-v.txt
@@ -15,47 +15,49 @@ main() -> nil|error{
     %8 = println(%7) -> bb3;
   }
   bb3 {
-    %9 = ConstantLoad BAL_TEST_LISTENV
-    %10 = ConstantLoad present
-    %11 = setEnv(%9,%10) -> bb4;
+    %10 = ConstantLoad BAL_TEST_LISTENV
+    %11 = ConstantLoad present
+    %12 = setEnv(%10,%11) -> bb4;
   }
   bb4 {
-    $desugar$0 = %11;
-    %13 = $desugar$0 is error
+    %13 = %12 is error
     %13 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %12;
     return;
   }
   bb6 {
-    %14 = listEnv() -> bb7;
+    %9 = %12;
+    GOTO bb7;
   }
   bb7 {
+    %14 = listEnv() -> bb8;
+  }
+  bb8 {
     envs = %14;
     %17 = ConstantLoad BAL_TEST_LISTENV
     %16 = envs[%17];
     v = %16;
-    %19 = println(v) -> bb8;
-  }
-  bb8 {
-    %20 = ConstantLoad BAL_TEST_LISTENV
-    %21 = unsetEnv(%20) -> bb9;
+    %19 = println(v) -> bb9;
   }
   bb9 {
-    $desugar$1 = %21;
-    %23 = $desugar$1 is error
-    %23 ? bb10 : bb11;
+    %21 = ConstantLoad BAL_TEST_LISTENV
+    %22 = unsetEnv(%21) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %23 = %22 is error
+    %23 ? bb11 : bb12;
   }
   bb11 {
+    %0 = %22;
+    return;
+  }
+  bb12 {
+    %20 = %22;
+    GOTO bb13;
+  }
+  bb13 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/os-exec-v.txt
+++ b/corpus/bir/library/subset2/os-exec-v.txt
@@ -1,304 +1,319 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad value
-    %2 = ConstantLoad echo
-    %3 = ConstantLoad arguments
-    %4 = ConstantLoad hello
-    %5 = ConstantLoad 1
-    %6 = newArray [string...][%5]{%4}
-    %7 = newMap {| arguments: [string...], value: string, never... |}{%1=%2, %3=%6} defaults{arguments=ballerina/os:$desugar$0}
-    %8 = newMap {| command: never, anydata... |}{}
-    %9 = exec(%7,%8) -> bb1;
+    %2 = ConstantLoad value
+    %3 = ConstantLoad echo
+    %4 = ConstantLoad arguments
+    %5 = ConstantLoad hello
+    %6 = ConstantLoad 1
+    %7 = newArray [string...][%6]{%5}
+    %8 = newMap {| arguments: [string...], value: string, never... |}{%2=%3, %4=%7} defaults{arguments=ballerina/os:$desugar$0}
+    %9 = newMap {| command: never, anydata... |}{}
+    %10 = exec(%8,%9) -> bb1;
   }
   bb1 {
-    $desugar$0 = %9;
-    %11 = $desugar$0 is error
+    %11 = %10 is error
     %11 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %10;
     return;
   }
   bb3 {
-    p = $desugar$0;
-    %13 = waitForExit(p) -> bb4;
+    %1 = %10;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$1 = %13;
-    %15 = $desugar$1 is error
-    %15 ? bb5 : bb6;
+    p = %1;
+    %14 = waitForExit(p) -> bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %15 = %14 is error
+    %15 ? bb6 : bb7;
   }
   bb6 {
-    code = $desugar$1;
-    %17 = code;
-    %18 = println(%17) -> bb7;
-  }
-  bb7 {
-    %19 = $default$0() -> bb8;
-  }
-  bb8 {
-    $desugar$2 = %19;
-    %21 = $desugar$2;
-    %22 = output(p,%21) -> bb9;
-  }
-  bb9 {
-    $desugar$3 = %22;
-    %24 = $desugar$3 is error
-    %24 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %14;
     return;
   }
+  bb7 {
+    %13 = %14;
+    GOTO bb8;
+  }
+  bb8 {
+    code = %13;
+    %17 = code;
+    %18 = println(%17) -> bb9;
+  }
+  bb9 {
+    %19 = $default$0() -> bb10;
+  }
+  bb10 {
+    $desugar$0 = %19;
+    %22 = $desugar$0;
+    %23 = output(p,%22) -> bb11;
+  }
   bb11 {
-    out = $desugar$3;
-    %27 = length(out) -> bb12;
+    %24 = %23 is error
+    %24 ? bb12 : bb13;
   }
   bb12 {
+    %0 = %23;
+    return;
+  }
+  bb13 {
+    %21 = %23;
+    GOTO bb14;
+  }
+  bb14 {
+    out = %21;
+    %27 = length(out) -> bb15;
+  }
+  bb15 {
     %28 = %27;
     %29 = ConstantLoad 0
     %30 = %29;
     %26 = > %28 %30;
     %31 = %26;
-    %32 = println(%31) -> bb13;
-  }
-  bb13 {
-    %33 = ConstantLoad value
-    %34 = ConstantLoad echo
-    %35 = ConstantLoad arguments
-    %36 = ConstantLoad world
-    %37 = ConstantLoad 1
-    %38 = newArray [string...][%37]{%36}
-    %39 = newMap {| arguments: [string...], value: string, never... |}{%33=%34, %35=%38} defaults{arguments=ballerina/os:$desugar$0}
-    %40 = newMap {| command: never, anydata... |}{}
-    %41 = exec(%39,%40) -> bb14;
-  }
-  bb14 {
-    $desugar$4 = %41;
-    %43 = $desugar$4 is error
-    %43 ? bb15 : bb16;
-  }
-  bb15 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %32 = println(%31) -> bb16;
   }
   bb16 {
-    p2 = $desugar$4;
-    %45 = waitForExit(p2) -> bb17;
+    %34 = ConstantLoad value
+    %35 = ConstantLoad echo
+    %36 = ConstantLoad arguments
+    %37 = ConstantLoad world
+    %38 = ConstantLoad 1
+    %39 = newArray [string...][%38]{%37}
+    %40 = newMap {| arguments: [string...], value: string, never... |}{%34=%35, %36=%39} defaults{arguments=ballerina/os:$desugar$0}
+    %41 = newMap {| command: never, anydata... |}{}
+    %42 = exec(%40,%41) -> bb17;
   }
   bb17 {
-    $desugar$5 = %45;
-    %47 = $desugar$5 is error
-    %47 ? bb18 : bb19;
+    %43 = %42 is error
+    %43 ? bb18 : bb19;
   }
   bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %42;
     return;
   }
   bb19 {
-    _ = $desugar$5;
-    %49 = ConstantLoad 2
-    %50 = %49;
-    %51 = output(p2,%50) -> bb20;
+    %33 = %42;
+    GOTO bb20;
   }
   bb20 {
-    $desugar$6 = %51;
-    %53 = $desugar$6 is error
-    %53 ? bb21 : bb22;
+    p2 = %33;
+    %46 = waitForExit(p2) -> bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    %47 = %46 is error
+    %47 ? bb22 : bb23;
   }
   bb22 {
-    err = $desugar$6;
-    %55 = length(err) -> bb23;
+    %0 = %46;
+    return;
   }
   bb23 {
-    %56 = %55;
-    %57 = println(%56) -> bb24;
+    %45 = %46;
+    GOTO bb24;
   }
   bb24 {
-    %58 = ConstantLoad /tmp/bal_exec_space_test/foo bar
-    dirWithSpace = %58;
-    %60 = ConstantLoad value
-    %61 = ConstantLoad mkdir
-    %62 = ConstantLoad arguments
-    %63 = ConstantLoad -p
-    %64 = ConstantLoad 2
-    %65 = newArray [string...][%64]{%63, dirWithSpace}
-    %66 = newMap {| arguments: [string...], value: string, never... |}{%60=%61, %62=%65} defaults{arguments=ballerina/os:$desugar$0}
-    %67 = newMap {| command: never, anydata... |}{}
-    %68 = exec(%66,%67) -> bb25;
+    _ = %45;
+    %50 = ConstantLoad 2
+    %51 = %50;
+    %52 = output(p2,%51) -> bb25;
   }
   bb25 {
-    $desugar$7 = %68;
-    %70 = $desugar$7 is error
-    %70 ? bb26 : bb27;
+    %53 = %52 is error
+    %53 ? bb26 : bb27;
   }
   bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
+    %0 = %52;
     return;
   }
   bb27 {
-    mk = $desugar$7;
-    %72 = waitForExit(mk) -> bb28;
+    %49 = %52;
+    GOTO bb28;
   }
   bb28 {
-    $desugar$8 = %72;
-    %74 = $desugar$8 is error
-    %74 ? bb29 : bb30;
+    err = %49;
+    %55 = length(err) -> bb29;
   }
   bb29 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    %56 = %55;
+    %57 = println(%56) -> bb30;
   }
   bb30 {
-    %75 = println($desugar$8) -> bb31;
+    %58 = ConstantLoad /tmp/bal_exec_space_test/foo bar
+    dirWithSpace = %58;
+    %61 = ConstantLoad value
+    %62 = ConstantLoad mkdir
+    %63 = ConstantLoad arguments
+    %64 = ConstantLoad -p
+    %65 = ConstantLoad 2
+    %66 = newArray [string...][%65]{%64, dirWithSpace}
+    %67 = newMap {| arguments: [string...], value: string, never... |}{%61=%62, %63=%66} defaults{arguments=ballerina/os:$desugar$0}
+    %68 = newMap {| command: never, anydata... |}{}
+    %69 = exec(%67,%68) -> bb31;
   }
   bb31 {
-    %76 = ConstantLoad value
-    %77 = ConstantLoad ls
-    %78 = ConstantLoad arguments
-    %79 = ConstantLoad 1
-    %80 = newArray [string...][%79]{dirWithSpace}
-    %81 = newMap {| arguments: [string...], value: string, never... |}{%76=%77, %78=%80} defaults{arguments=ballerina/os:$desugar$0}
-    %82 = newMap {| command: never, anydata... |}{}
-    %83 = exec(%81,%82) -> bb32;
+    %70 = %69 is error
+    %70 ? bb32 : bb33;
   }
   bb32 {
-    $desugar$9 = %83;
-    %85 = $desugar$9 is error
-    %85 ? bb33 : bb34;
-  }
-  bb33 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %69;
     return;
   }
+  bb33 {
+    %60 = %69;
+    GOTO bb34;
+  }
   bb34 {
-    lsProc = $desugar$9;
-    %87 = waitForExit(lsProc) -> bb35;
+    mk = %60;
+    %73 = waitForExit(mk) -> bb35;
   }
   bb35 {
-    $desugar$10 = %87;
-    %89 = $desugar$10 is error
-    %89 ? bb36 : bb37;
+    %74 = %73 is error
+    %74 ? bb36 : bb37;
   }
   bb36 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
+    %0 = %73;
     return;
   }
   bb37 {
-    %90 = println($desugar$10) -> bb38;
+    %72 = %73;
+    GOTO bb38;
   }
   bb38 {
-    %91 = ConstantLoad value
-    %92 = ConstantLoad rm
-    %93 = ConstantLoad arguments
-    %94 = ConstantLoad -rf
-    %95 = ConstantLoad /tmp/bal_exec_space_test
-    %96 = ConstantLoad 2
-    %97 = newArray [string...][%96]{%94, %95}
-    %98 = newMap {| arguments: [string...], value: string, never... |}{%91=%92, %93=%97} defaults{arguments=ballerina/os:$desugar$0}
-    %99 = newMap {| command: never, anydata... |}{}
-    %100 = exec(%98,%99) -> bb39;
+    %75 = %72;
+    %76 = println(%75) -> bb39;
   }
   bb39 {
-    $desugar$11 = %100;
-    %102 = $desugar$11 is error
-    %102 ? bb40 : bb41;
+    %78 = ConstantLoad value
+    %79 = ConstantLoad ls
+    %80 = ConstantLoad arguments
+    %81 = ConstantLoad 1
+    %82 = newArray [string...][%81]{dirWithSpace}
+    %83 = newMap {| arguments: [string...], value: string, never... |}{%78=%79, %80=%82} defaults{arguments=ballerina/os:$desugar$0}
+    %84 = newMap {| command: never, anydata... |}{}
+    %85 = exec(%83,%84) -> bb40;
   }
   bb40 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
-    return;
+    %86 = %85 is error
+    %86 ? bb41 : bb42;
   }
   bb41 {
-    rm = $desugar$11;
-    %104 = waitForExit(rm) -> bb42;
+    %0 = %85;
+    return;
   }
   bb42 {
-    $desugar$12 = %104;
-    %106 = $desugar$12 is error
-    %106 ? bb43 : bb44;
+    %77 = %85;
+    GOTO bb43;
   }
   bb43 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$12);
-    PopScopeFrame
-    return;
+    lsProc = %77;
+    %89 = waitForExit(lsProc) -> bb44;
   }
   bb44 {
-    _ = $desugar$12;
-    %108 = ConstantLoad value
-    %109 = ConstantLoad no_such_command_xyz_123
-    %110 = newMap {| arguments: [string...], value: string, never... |}{%108=%109} defaults{arguments=ballerina/os:$desugar$0}
-    %111 = newMap {| command: never, anydata... |}{}
-    %112 = exec(%110,%111) -> bb45;
+    %90 = %89 is error
+    %90 ? bb45 : bb46;
   }
   bb45 {
-    bad = %112;
-    %114 = bad is error
-    %115 = %114;
-    %116 = println(%115) -> bb46;
-  }
-  bb46 {
-    %117 = ConstantLoad value
-    %118 = ConstantLoad echo
-    %119 = ConstantLoad arguments
-    %120 = ConstantLoad bye
-    %121 = ConstantLoad 1
-    %122 = newArray [string...][%121]{%120}
-    %123 = newMap {| arguments: [string...], value: string, never... |}{%117=%118, %119=%122} defaults{arguments=ballerina/os:$desugar$0}
-    %124 = newMap {| command: never, anydata... |}{}
-    %125 = exec(%123,%124) -> bb47;
-  }
-  bb47 {
-    $desugar$13 = %125;
-    %127 = $desugar$13 is error
-    %127 ? bb48 : bb49;
-  }
-  bb48 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
+    %0 = %89;
     return;
   }
+  bb46 {
+    %88 = %89;
+    GOTO bb47;
+  }
+  bb47 {
+    %91 = %88;
+    %92 = println(%91) -> bb48;
+  }
+  bb48 {
+    %94 = ConstantLoad value
+    %95 = ConstantLoad rm
+    %96 = ConstantLoad arguments
+    %97 = ConstantLoad -rf
+    %98 = ConstantLoad /tmp/bal_exec_space_test
+    %99 = ConstantLoad 2
+    %100 = newArray [string...][%99]{%97, %98}
+    %101 = newMap {| arguments: [string...], value: string, never... |}{%94=%95, %96=%100} defaults{arguments=ballerina/os:$desugar$0}
+    %102 = newMap {| command: never, anydata... |}{}
+    %103 = exec(%101,%102) -> bb49;
+  }
   bb49 {
-    p3 = $desugar$13;
-    %129 = exit(p3) -> bb50;
+    %104 = %103 is error
+    %104 ? bb50 : bb51;
   }
   bb50 {
-    %130 = ConstantLoad exited
-    %131 = println(%130) -> bb51;
+    %0 = %103;
+    return;
   }
   bb51 {
+    %93 = %103;
+    GOTO bb52;
+  }
+  bb52 {
+    rm = %93;
+    %107 = waitForExit(rm) -> bb53;
+  }
+  bb53 {
+    %108 = %107 is error
+    %108 ? bb54 : bb55;
+  }
+  bb54 {
+    %0 = %107;
+    return;
+  }
+  bb55 {
+    %106 = %107;
+    GOTO bb56;
+  }
+  bb56 {
+    _ = %106;
+    %110 = ConstantLoad value
+    %111 = ConstantLoad no_such_command_xyz_123
+    %112 = newMap {| arguments: [string...], value: string, never... |}{%110=%111} defaults{arguments=ballerina/os:$desugar$0}
+    %113 = newMap {| command: never, anydata... |}{}
+    %114 = exec(%112,%113) -> bb57;
+  }
+  bb57 {
+    bad = %114;
+    %116 = bad is error
+    %117 = %116;
+    %118 = println(%117) -> bb58;
+  }
+  bb58 {
+    %120 = ConstantLoad value
+    %121 = ConstantLoad echo
+    %122 = ConstantLoad arguments
+    %123 = ConstantLoad bye
+    %124 = ConstantLoad 1
+    %125 = newArray [string...][%124]{%123}
+    %126 = newMap {| arguments: [string...], value: string, never... |}{%120=%121, %122=%125} defaults{arguments=ballerina/os:$desugar$0}
+    %127 = newMap {| command: never, anydata... |}{}
+    %128 = exec(%126,%127) -> bb59;
+  }
+  bb59 {
+    %129 = %128 is error
+    %129 ? bb60 : bb61;
+  }
+  bb60 {
+    %0 = %128;
+    return;
+  }
+  bb61 {
+    %119 = %128;
+    GOTO bb62;
+  }
+  bb62 {
+    p3 = %119;
+    %131 = exit(p3) -> bb63;
+  }
+  bb63 {
+    %132 = ConstantLoad exited
+    %133 = println(%132) -> bb64;
+  }
+  bb64 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/os-setenv1-v.txt
+++ b/corpus/bir/library/subset2/os-setenv1-v.txt
@@ -1,45 +1,47 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad BAL_TEST_VAR
-    %2 = ConstantLoad hello
-    %3 = setEnv(%1,%2) -> bb1;
+    %2 = ConstantLoad BAL_TEST_VAR
+    %3 = ConstantLoad hello
+    %4 = setEnv(%2,%3) -> bb1;
   }
   bb1 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
+    %5 = %4 is error
     %5 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %4;
     return;
   }
   bb3 {
-    %6 = ConstantLoad BAL_TEST_VAR
-    %7 = getEnv(%6) -> bb4;
+    %1 = %4;
+    GOTO bb4;
   }
   bb4 {
-    v = %7;
-    %9 = println(v) -> bb5;
+    %6 = ConstantLoad BAL_TEST_VAR
+    %7 = getEnv(%6) -> bb5;
   }
   bb5 {
-    %10 = ConstantLoad BAL_TEST_VAR
-    %11 = unsetEnv(%10) -> bb6;
+    v = %7;
+    %9 = println(v) -> bb6;
   }
   bb6 {
-    $desugar$1 = %11;
-    %13 = $desugar$1 is error
-    %13 ? bb7 : bb8;
+    %11 = ConstantLoad BAL_TEST_VAR
+    %12 = unsetEnv(%11) -> bb7;
   }
   bb7 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %13 = %12 is error
+    %13 ? bb8 : bb9;
   }
   bb8 {
+    %0 = %12;
+    return;
+  }
+  bb9 {
+    %10 = %12;
+    GOTO bb10;
+  }
+  bb10 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/random-range1-v.txt
+++ b/corpus/bir/library/subset2/random-range1-v.txt
@@ -1,45 +1,46 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 10
-    %2 = %1;
-    %3 = ConstantLoad 20
-    %4 = %3;
-    %5 = createIntInRange(%2,%4) -> bb1;
+    %2 = ConstantLoad 10
+    %3 = %2;
+    %4 = ConstantLoad 20
+    %5 = %4;
+    %6 = createIntInRange(%3,%5) -> bb1;
   }
   bb1 {
-    $desugar$0 = %5;
-    %7 = $desugar$0 is error
+    %7 = %6 is error
     %7 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %6;
     return;
   }
   bb3 {
-    n = $desugar$0;
+    %1 = %6;
+    GOTO bb4;
+  }
+  bb4 {
+    n = %1;
     %11 = n;
     %12 = ConstantLoad 10
     %13 = %12;
     %10 = >= %11 %13;
     %9 = %10;
-    %10 ? bb4 : bb5;
+    %10 ? bb5 : bb6;
   }
-  bb4 {
+  bb5 {
     %15 = n;
     %16 = ConstantLoad 20
     %17 = %16;
     %14 = < %15 %17;
     %9 = %14;
-    GOTO bb5;
-  }
-  bb5 {
-    %18 = %9;
-    %19 = println(%18) -> bb6;
+    GOTO bb6;
   }
   bb6 {
+    %18 = %9;
+    %19 = println(%18) -> bb7;
+  }
+  bb7 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/time-error-cases-v.txt
+++ b/corpus/bir/library/subset2/time-error-cases-v.txt
@@ -57,82 +57,84 @@ main() -> nil|error{
     %36 = println(%35) -> bb10;
   }
   bb10 {
-    %37 = ConstantLoad year
-    %38 = ConstantLoad 2021
-    %39 = ConstantLoad month
-    %40 = ConstantLoad 4
-    %41 = ConstantLoad day
-    %42 = ConstantLoad 12
-    %43 = ConstantLoad hour
-    %44 = ConstantLoad 23
-    %45 = ConstantLoad minute
-    %46 = ConstantLoad 20
-    %47 = ConstantLoad second
-    %48 = ConstantLoad 50
-    %49 = ConstantLoad utcOffset
-    %50 = ConstantLoad hours
-    %51 = ConstantLoad 5
-    %52 = ConstantLoad minutes
-    %53 = ConstantLoad 30
-    %54 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%50=%51, %52=%53} defaults{minutes=ballerina/time:$desugar$0}
-    %55 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%37=%38, %39=%40, %41=%42, %43=%44, %45=%46, %47=%48, %49=%54}
-    %56 = utcFromCivil(%55) -> bb11;
+    %38 = ConstantLoad year
+    %39 = ConstantLoad 2021
+    %40 = ConstantLoad month
+    %41 = ConstantLoad 4
+    %42 = ConstantLoad day
+    %43 = ConstantLoad 12
+    %44 = ConstantLoad hour
+    %45 = ConstantLoad 23
+    %46 = ConstantLoad minute
+    %47 = ConstantLoad 20
+    %48 = ConstantLoad second
+    %49 = ConstantLoad 50
+    %50 = ConstantLoad utcOffset
+    %51 = ConstantLoad hours
+    %52 = ConstantLoad 5
+    %53 = ConstantLoad minutes
+    %54 = ConstantLoad 30
+    %55 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%51=%52, %53=%54} defaults{minutes=ballerina/time:$desugar$0}
+    %56 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%38=%39, %40=%41, %42=%43, %44=%45, %46=%47, %48=%49, %50=%55}
+    %57 = utcFromCivil(%56) -> bb11;
   }
   bb11 {
-    $desugar$1 = %56;
-    %58 = $desugar$1 is error
+    %58 = %57 is error
     %58 ? bb12 : bb13;
   }
   bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
+    %0 = %57;
     return;
   }
   bb13 {
-    fromOffset = $desugar$1;
-    %60 = utcToString(fromOffset) -> bb14;
+    %37 = %57;
+    GOTO bb14;
   }
   bb14 {
-    %61 = println(%60) -> bb15;
+    fromOffset = %37;
+    %60 = utcToString(fromOffset) -> bb15;
   }
   bb15 {
-    %62 = ConstantLoad year
-    %63 = ConstantLoad 2021
-    %64 = ConstantLoad month
-    %65 = ConstantLoad 4
-    %66 = ConstantLoad day
-    %67 = ConstantLoad 12
-    %68 = ConstantLoad hour
-    %69 = ConstantLoad 17
-    %70 = ConstantLoad minute
-    %71 = ConstantLoad 50
-    %72 = ConstantLoad second
-    %73 = ConstantLoad 50
-    %74 = ConstantLoad timeAbbrev
-    %75 = ConstantLoad Z
-    %76 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%62=%63, %64=%65, %66=%67, %68=%69, %70=%71, %72=%73, %74=%75}
-    %77 = utcFromCivil(%76) -> bb16;
+    %61 = println(%60) -> bb16;
   }
   bb16 {
-    $desugar$2 = %77;
-    %79 = $desugar$2 is error
-    %79 ? bb17 : bb18;
+    %63 = ConstantLoad year
+    %64 = ConstantLoad 2021
+    %65 = ConstantLoad month
+    %66 = ConstantLoad 4
+    %67 = ConstantLoad day
+    %68 = ConstantLoad 12
+    %69 = ConstantLoad hour
+    %70 = ConstantLoad 17
+    %71 = ConstantLoad minute
+    %72 = ConstantLoad 50
+    %73 = ConstantLoad second
+    %74 = ConstantLoad 50
+    %75 = ConstantLoad timeAbbrev
+    %76 = ConstantLoad Z
+    %77 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%63=%64, %65=%66, %67=%68, %69=%70, %71=%72, %73=%74, %75=%76}
+    %78 = utcFromCivil(%77) -> bb17;
   }
   bb17 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %79 = %78 is error
+    %79 ? bb18 : bb19;
   }
   bb18 {
-    fromZ = $desugar$2;
-    %81 = utcToString(fromZ) -> bb19;
+    %0 = %78;
+    return;
   }
   bb19 {
-    %82 = println(%81) -> bb20;
+    %62 = %78;
+    GOTO bb20;
   }
   bb20 {
+    fromZ = %62;
+    %81 = utcToString(fromZ) -> bb21;
+  }
+  bb21 {
+    %82 = println(%81) -> bb22;
+  }
+  bb22 {
     %83 = ConstantLoad year
     %84 = ConstantLoad 2021
     %85 = ConstantLoad month
@@ -144,15 +146,15 @@ main() -> nil|error{
     %91 = ConstantLoad minute
     %92 = ConstantLoad 50
     %93 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%83=%84, %85=%86, %87=%88, %89=%90, %91=%92}
-    %94 = utcFromCivil(%93) -> bb21;
+    %94 = utcFromCivil(%93) -> bb23;
   }
-  bb21 {
+  bb23 {
     noZone = %94;
     %96 = noZone is error
     %97 = %96;
-    %98 = println(%97) -> bb22;
+    %98 = println(%97) -> bb24;
   }
-  bb22 {
+  bb24 {
     %99 = ConstantLoad year
     %100 = ConstantLoad 2021
     %101 = ConstantLoad month
@@ -167,15 +169,15 @@ main() -> nil|error{
     %110 = ConstantLoad hours
     %111 = ConstantLoad 1
     %112 = newMap {| days: int, hours: int, minutes: int, months: int, seconds: decimal, weeks: int, years: int, never... |}{%110=%111} defaults{years=ballerina/time:$desugar$2, months=ballerina/time:$desugar$3, weeks=ballerina/time:$desugar$4, days=ballerina/time:$desugar$5, hours=ballerina/time:$desugar$6, minutes=ballerina/time:$desugar$7, seconds=ballerina/time:$desugar$8}
-    %113 = civilAddDuration(%109,%112) -> bb23;
+    %113 = civilAddDuration(%109,%112) -> bb25;
   }
-  bb23 {
+  bb25 {
     addErr = %113;
     %115 = addErr is error
     %116 = %115;
-    %117 = println(%116) -> bb24;
+    %117 = println(%116) -> bb26;
   }
-  bb24 {
+  bb26 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/time-offset-parsing-v.txt
+++ b/corpus/bir/library/subset2/time-offset-parsing-v.txt
@@ -1,226 +1,228 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = newObject ballerina/time:TimeZone
-    %2 = ConstantLoad +0530
-    %3 = init(%1,%2) -> bb1;
+    %2 = newObject ballerina/time:TimeZone
+    %3 = ConstantLoad +0530
+    %4 = init(%2,%3) -> bb1;
   }
   bb1 {
-    %5 = %3 is nil
-    %5 ? bb2 : bb3;
+    %6 = %4 is nil
+    %6 ? bb2 : bb3;
   }
   bb2 {
-    %4 = %1;
+    %5 = %2;
     GOTO bb4;
   }
   bb3 {
-    %4 = %3;
+    %5 = %4;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %4;
-    %7 = $desugar$0 is error
+    %7 = %5 is error
     %7 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb6 {
-    east = $desugar$0;
-    %9 = fixedOffset(east) -> bb7;
+    %1 = %5;
+    GOTO bb7;
   }
   bb7 {
-    eastOffset = %9;
-    %11 = eastOffset !is nil
-    %11 ? bb8 : bb11;
+    east = %1;
+    %9 = fixedOffset(east) -> bb8;
   }
   bb8 {
+    eastOffset = %9;
+    %11 = eastOffset !is nil
+    %11 ? bb9 : bb12;
+  }
+  bb9 {
     PushScopeFrame 8
     %1 = ConstantLoad hours
     %0 = (1, eastOffset)[%1];
     %2 = %0;
-    %3 = println(%2) -> bb9;
+    %3 = println(%2) -> bb10;
   }
-  bb9 {
+  bb10 {
     %5 = ConstantLoad minutes
     %4 = (1, eastOffset)[%5];
     %6 = %4;
-    %7 = println(%6) -> bb10;
-  }
-  bb10 {
-    PopScopeFrame
-    GOTO bb11;
+    %7 = println(%6) -> bb11;
   }
   bb11 {
-    PushScopeFrame 11
-    %0 = newObject ballerina/time:TimeZone
-    %1 = ConstantLoad -0800
-    %2 = init(%0,%1) -> bb12;
+    PopScopeFrame
+    GOTO bb12;
   }
   bb12 {
-    %4 = %2 is nil
-    %4 ? bb13 : bb14;
+    PushScopeFrame 11
+    %1 = newObject ballerina/time:TimeZone
+    %2 = ConstantLoad -0800
+    %3 = init(%1,%2) -> bb13;
   }
   bb13 {
-    %3 = %0;
-    GOTO bb15;
+    %5 = %3 is nil
+    %5 ? bb14 : bb15;
   }
   bb14 {
-    %3 = %2;
-    GOTO bb15;
+    %4 = %1;
+    GOTO bb16;
   }
   bb15 {
-    $desugar$1 = %3;
-    %6 = $desugar$1 is error
-    %6 ? bb16 : bb17;
+    %4 = %3;
+    GOTO bb16;
   }
   bb16 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$1);
-    PopScopeFrame
+    %6 = %4 is error
+    %6 ? bb17 : bb18;
+  }
+  bb17 {
+    (1, %0) = %4;
     PopScopeFrame
     return;
   }
-  bb17 {
-    west = $desugar$1;
-    %8 = fixedOffset(west) -> bb18;
-  }
   bb18 {
-    westOffset = %8;
-    %10 = westOffset !is nil
-    %10 ? bb19 : bb21;
+    %0 = %4;
+    GOTO bb19;
   }
   bb19 {
+    west = %0;
+    %8 = fixedOffset(west) -> bb20;
+  }
+  bb20 {
+    westOffset = %8;
+    %10 = westOffset !is nil
+    %10 ? bb21 : bb23;
+  }
+  bb21 {
     PushScopeFrame 4
     %1 = ConstantLoad hours
     %0 = (1, westOffset)[%1];
     %2 = %0;
-    %3 = println(%2) -> bb20;
+    %3 = println(%2) -> bb22;
   }
-  bb20 {
+  bb22 {
     PopScopeFrame
-    GOTO bb21;
+    GOTO bb23;
   }
-  bb21 {
+  bb23 {
     PushScopeFrame 127
     %0 = newObject ballerina/time:TimeZone
     %1 = ConstantLoad +12:99
-    %2 = init(%0,%1) -> bb22;
-  }
-  bb22 {
-    %4 = %2 is nil
-    %4 ? bb23 : bb24;
-  }
-  bb23 {
-    %3 = %0;
-    GOTO bb25;
+    %2 = init(%0,%1) -> bb24;
   }
   bb24 {
-    %3 = %2;
-    GOTO bb25;
+    %4 = %2 is nil
+    %4 ? bb25 : bb26;
   }
   bb25 {
+    %3 = %0;
+    GOTO bb27;
+  }
+  bb26 {
+    %3 = %2;
+    GOTO bb27;
+  }
+  bb27 {
     badMin = %3;
     %6 = badMin is error
     %7 = %6;
-    %8 = println(%7) -> bb26;
-  }
-  bb26 {
-    %9 = newObject ballerina/time:TimeZone
-    %10 = ConstantLoad +2400
-    %11 = init(%9,%10) -> bb27;
-  }
-  bb27 {
-    %13 = %11 is nil
-    %13 ? bb28 : bb29;
+    %8 = println(%7) -> bb28;
   }
   bb28 {
-    %12 = %9;
-    GOTO bb30;
+    %9 = newObject ballerina/time:TimeZone
+    %10 = ConstantLoad +2400
+    %11 = init(%9,%10) -> bb29;
   }
   bb29 {
-    %12 = %11;
-    GOTO bb30;
+    %13 = %11 is nil
+    %13 ? bb30 : bb31;
   }
   bb30 {
+    %12 = %9;
+    GOTO bb32;
+  }
+  bb31 {
+    %12 = %11;
+    GOTO bb32;
+  }
+  bb32 {
     badHour = %12;
     %15 = badHour is error
     %16 = %15;
-    %17 = println(%16) -> bb31;
-  }
-  bb31 {
-    %18 = newObject ballerina/time:TimeZone
-    %19 = ConstantLoad +1a:30
-    %20 = init(%18,%19) -> bb32;
-  }
-  bb32 {
-    %22 = %20 is nil
-    %22 ? bb33 : bb34;
+    %17 = println(%16) -> bb33;
   }
   bb33 {
-    %21 = %18;
-    GOTO bb35;
+    %18 = newObject ballerina/time:TimeZone
+    %19 = ConstantLoad +1a:30
+    %20 = init(%18,%19) -> bb34;
   }
   bb34 {
-    %21 = %20;
-    GOTO bb35;
+    %22 = %20 is nil
+    %22 ? bb35 : bb36;
   }
   bb35 {
+    %21 = %18;
+    GOTO bb37;
+  }
+  bb36 {
+    %21 = %20;
+    GOTO bb37;
+  }
+  bb37 {
     bad1 = %21;
     %24 = bad1 is error
     %25 = %24;
-    %26 = println(%25) -> bb36;
-  }
-  bb36 {
-    %27 = newObject ballerina/time:TimeZone
-    %28 = ConstantLoad +12:a0
-    %29 = init(%27,%28) -> bb37;
-  }
-  bb37 {
-    %31 = %29 is nil
-    %31 ? bb38 : bb39;
+    %26 = println(%25) -> bb38;
   }
   bb38 {
-    %30 = %27;
-    GOTO bb40;
+    %27 = newObject ballerina/time:TimeZone
+    %28 = ConstantLoad +12:a0
+    %29 = init(%27,%28) -> bb39;
   }
   bb39 {
-    %30 = %29;
-    GOTO bb40;
+    %31 = %29 is nil
+    %31 ? bb40 : bb41;
   }
   bb40 {
+    %30 = %27;
+    GOTO bb42;
+  }
+  bb41 {
+    %30 = %29;
+    GOTO bb42;
+  }
+  bb42 {
     bad2 = %30;
     %33 = bad2 is error
     %34 = %33;
-    %35 = println(%34) -> bb41;
-  }
-  bb41 {
-    %36 = newObject ballerina/time:TimeZone
-    %37 = ConstantLoad +12a0
-    %38 = init(%36,%37) -> bb42;
-  }
-  bb42 {
-    %40 = %38 is nil
-    %40 ? bb43 : bb44;
+    %35 = println(%34) -> bb43;
   }
   bb43 {
-    %39 = %36;
-    GOTO bb45;
+    %36 = newObject ballerina/time:TimeZone
+    %37 = ConstantLoad +12a0
+    %38 = init(%36,%37) -> bb44;
   }
   bb44 {
-    %39 = %38;
-    GOTO bb45;
+    %40 = %38 is nil
+    %40 ? bb45 : bb46;
   }
   bb45 {
+    %39 = %36;
+    GOTO bb47;
+  }
+  bb46 {
+    %39 = %38;
+    GOTO bb47;
+  }
+  bb47 {
     bad3 = %39;
     %42 = bad3 is error
     %43 = %42;
-    %44 = println(%43) -> bb46;
+    %44 = println(%43) -> bb48;
   }
-  bb46 {
+  bb48 {
     %45 = ConstantLoad year
     %46 = ConstantLoad 2021
     %47 = ConstantLoad month
@@ -236,15 +238,15 @@ main() -> nil|error{
     %57 = ConstantLoad timeAbbrev
     %58 = ConstantLoad +12:99
     %59 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%45=%46, %47=%48, %49=%50, %51=%52, %53=%54, %55=%56, %57=%58}
-    %60 = civilToString(%59) -> bb47;
+    %60 = civilToString(%59) -> bb49;
   }
-  bb47 {
+  bb49 {
     badAbbrev = %60;
     %62 = badAbbrev is error
     %63 = %62;
-    %64 = println(%63) -> bb48;
+    %64 = println(%63) -> bb50;
   }
-  bb48 {
+  bb50 {
     %65 = ConstantLoad year
     %66 = ConstantLoad 2021
     %67 = ConstantLoad month
@@ -260,15 +262,15 @@ main() -> nil|error{
     %77 = ConstantLoad timeAbbrev
     %78 = ConstantLoad Bogus/Zone
     %79 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%65=%66, %67=%68, %69=%70, %71=%72, %73=%74, %75=%76, %77=%78}
-    %80 = civilToString(%79) -> bb49;
+    %80 = civilToString(%79) -> bb51;
   }
-  bb49 {
+  bb51 {
     unknownZone = %80;
     %82 = unknownZone is error
     %83 = %82;
-    %84 = println(%83) -> bb50;
+    %84 = println(%83) -> bb52;
   }
-  bb50 {
+  bb52 {
     %85 = ConstantLoad year
     %86 = ConstantLoad 2021
     %87 = ConstantLoad month
@@ -288,48 +290,49 @@ main() -> nil|error{
     %101 = ConstantLoad 30
     %102 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%98=%99, %100=%101} defaults{minutes=ballerina/time:$desugar$0}
     %103 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%85=%86, %87=%88, %89=%90, %91=%92, %93=%94, %95=%96, %97=%102}
-    %104 = utcFromCivil(%103) -> bb51;
+    %104 = utcFromCivil(%103) -> bb53;
   }
-  bb51 {
+  bb53 {
     badDate = %104;
     %106 = badDate is error
     %107 = %106;
-    %108 = println(%107) -> bb52;
-  }
-  bb52 {
-    %109 = ConstantLoad year
-    %110 = ConstantLoad 2021
-    %111 = ConstantLoad month
-    %112 = ConstantLoad 4
-    %113 = ConstantLoad day
-    %114 = ConstantLoad 12
-    %115 = ConstantLoad hour
-    %116 = ConstantLoad 23
-    %117 = ConstantLoad minute
-    %118 = ConstantLoad 20
-    %119 = ConstantLoad timeAbbrev
-    %120 = ConstantLoad +05:30
-    %121 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%109=%110, %111=%112, %113=%114, %115=%116, %117=%118, %119=%120}
-    %122 = civilToString(%121) -> bb53;
-  }
-  bb53 {
-    $desugar$2 = %122;
-    %124 = $desugar$2 is error
-    %124 ? bb54 : bb55;
+    %108 = println(%107) -> bb54;
   }
   bb54 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %110 = ConstantLoad year
+    %111 = ConstantLoad 2021
+    %112 = ConstantLoad month
+    %113 = ConstantLoad 4
+    %114 = ConstantLoad day
+    %115 = ConstantLoad 12
+    %116 = ConstantLoad hour
+    %117 = ConstantLoad 23
+    %118 = ConstantLoad minute
+    %119 = ConstantLoad 20
+    %120 = ConstantLoad timeAbbrev
+    %121 = ConstantLoad +05:30
+    %122 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%110=%111, %112=%113, %114=%115, %116=%117, %118=%119, %120=%121}
+    %123 = civilToString(%122) -> bb55;
+  }
+  bb55 {
+    %124 = %123 is error
+    %124 ? bb56 : bb57;
+  }
+  bb56 {
+    (2, %0) = %123;
     PopScopeFrame
     PopScopeFrame
     return;
   }
-  bb55 {
-    noSec = $desugar$2;
-    %126 = println(noSec) -> bb56;
+  bb57 {
+    %109 = %123;
+    GOTO bb58;
   }
-  bb56 {
+  bb58 {
+    noSec = %109;
+    %126 = println(noSec) -> bb59;
+  }
+  bb59 {
     PopScopeFrame
     PopScopeFrame
     return;

--- a/corpus/bir/library/subset2/time-subsecond-v.txt
+++ b/corpus/bir/library/subset2/time-subsecond-v.txt
@@ -1,168 +1,174 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 2024-06-15T10:30:45.123Z
-    %2 = utcFromString(%1) -> bb1;
+    %2 = ConstantLoad 2024-06-15T10:30:45.123Z
+    %3 = utcFromString(%2) -> bb1;
   }
   bb1 {
-    $desugar$0 = %2;
-    %4 = $desugar$0 is error
+    %4 = %3 is error
     %4 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %3;
     return;
   }
   bb3 {
-    ms = $desugar$0;
-    %6 = utcToString(ms) -> bb4;
+    %1 = %3;
+    GOTO bb4;
   }
   bb4 {
-    %7 = println(%6) -> bb5;
+    ms = %1;
+    %6 = utcToString(ms) -> bb5;
   }
   bb5 {
-    %8 = ConstantLoad 2024-06-15T10:30:45.123456Z
-    %9 = utcFromString(%8) -> bb6;
+    %7 = println(%6) -> bb6;
   }
   bb6 {
-    $desugar$1 = %9;
-    %11 = $desugar$1 is error
-    %11 ? bb7 : bb8;
+    %9 = ConstantLoad 2024-06-15T10:30:45.123456Z
+    %10 = utcFromString(%9) -> bb7;
   }
   bb7 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %11 = %10 is error
+    %11 ? bb8 : bb9;
   }
   bb8 {
-    us = $desugar$1;
-    %13 = utcToString(us) -> bb9;
+    %0 = %10;
+    return;
   }
   bb9 {
-    %14 = println(%13) -> bb10;
+    %8 = %10;
+    GOTO bb10;
   }
   bb10 {
-    %15 = ConstantLoad 2024-06-15T10:30:45.123456789Z
-    %16 = utcFromString(%15) -> bb11;
+    us = %8;
+    %13 = utcToString(us) -> bb11;
   }
   bb11 {
-    $desugar$2 = %16;
-    %18 = $desugar$2 is error
-    %18 ? bb12 : bb13;
+    %14 = println(%13) -> bb12;
   }
   bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %16 = ConstantLoad 2024-06-15T10:30:45.123456789Z
+    %17 = utcFromString(%16) -> bb13;
   }
   bb13 {
-    ns = $desugar$2;
-    %20 = utcToString(ns) -> bb14;
+    %18 = %17 is error
+    %18 ? bb14 : bb15;
   }
   bb14 {
-    %21 = println(%20) -> bb15;
+    %0 = %17;
+    return;
   }
   bb15 {
-    %22 = ConstantLoad 2024-06-15T10:30:45.5Z
-    %23 = utcFromString(%22) -> bb16;
+    %15 = %17;
+    GOTO bb16;
   }
   bb16 {
-    $desugar$3 = %23;
-    %25 = $desugar$3 is error
-    %25 ? bb17 : bb18;
+    ns = %15;
+    %20 = utcToString(ns) -> bb17;
   }
   bb17 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %21 = println(%20) -> bb18;
   }
   bb18 {
-    half = $desugar$3;
-    %27 = utcToString(half) -> bb19;
+    %23 = ConstantLoad 2024-06-15T10:30:45.5Z
+    %24 = utcFromString(%23) -> bb19;
   }
   bb19 {
-    %28 = println(%27) -> bb20;
+    %25 = %24 is error
+    %25 ? bb20 : bb21;
   }
   bb20 {
-    %29 = ConstantLoad year
-    %30 = ConstantLoad 2024
-    %31 = ConstantLoad month
-    %32 = ConstantLoad 6
-    %33 = ConstantLoad day
-    %34 = ConstantLoad 15
-    %35 = ConstantLoad hour
-    %36 = ConstantLoad 10
-    %37 = ConstantLoad minute
-    %38 = ConstantLoad 30
-    %39 = ConstantLoad second
-    %40 = ConstantLoad 45.5
-    %41 = ConstantLoad timeAbbrev
-    %42 = ConstantLoad -08:00
-    %43 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%29=%30, %31=%32, %33=%34, %35=%36, %37=%38, %39=%40, %41=%42}
-    %44 = civilToString(%43) -> bb21;
-  }
-  bb21 {
-    $desugar$4 = %44;
-    %46 = $desugar$4 is error
-    %46 ? bb22 : bb23;
-  }
-  bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %24;
     return;
   }
+  bb21 {
+    %22 = %24;
+    GOTO bb22;
+  }
+  bb22 {
+    half = %22;
+    %27 = utcToString(half) -> bb23;
+  }
   bb23 {
-    neg = $desugar$4;
-    %48 = println(neg) -> bb24;
+    %28 = println(%27) -> bb24;
   }
   bb24 {
-    %49 = ConstantLoad year
-    %50 = ConstantLoad 2024
-    %51 = ConstantLoad month
-    %52 = ConstantLoad 6
-    %53 = ConstantLoad day
-    %54 = ConstantLoad 15
-    %55 = ConstantLoad hour
-    %56 = ConstantLoad 2
-    %57 = ConstantLoad minute
-    %58 = ConstantLoad 30
-    %59 = ConstantLoad second
-    %60 = ConstantLoad 45
-    %61 = ConstantLoad utcOffset
-    %62 = ConstantLoad hours
-    %63 = ConstantLoad 8
-    %64 = unknown %63;
-    %65 = ConstantLoad minutes
-    %66 = ConstantLoad 0
-    %67 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%62=%64, %65=%66} defaults{minutes=ballerina/time:$desugar$0}
-    %68 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%49=%50, %51=%52, %53=%54, %55=%56, %57=%58, %59=%60, %61=%67}
-    %69 = utcFromCivil(%68) -> bb25;
+    %30 = ConstantLoad year
+    %31 = ConstantLoad 2024
+    %32 = ConstantLoad month
+    %33 = ConstantLoad 6
+    %34 = ConstantLoad day
+    %35 = ConstantLoad 15
+    %36 = ConstantLoad hour
+    %37 = ConstantLoad 10
+    %38 = ConstantLoad minute
+    %39 = ConstantLoad 30
+    %40 = ConstantLoad second
+    %41 = ConstantLoad 45.5
+    %42 = ConstantLoad timeAbbrev
+    %43 = ConstantLoad -08:00
+    %44 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%30=%31, %32=%33, %34=%35, %36=%37, %38=%39, %40=%41, %42=%43}
+    %45 = civilToString(%44) -> bb25;
   }
   bb25 {
-    $desugar$5 = %69;
-    %71 = $desugar$5 is error
-    %71 ? bb26 : bb27;
+    %46 = %45 is error
+    %46 ? bb26 : bb27;
   }
   bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %45;
     return;
   }
   bb27 {
-    fromNeg = $desugar$5;
-    %73 = utcToString(fromNeg) -> bb28;
+    %29 = %45;
+    GOTO bb28;
   }
   bb28 {
-    %74 = println(%73) -> bb29;
+    neg = %29;
+    %48 = println(neg) -> bb29;
   }
   bb29 {
+    %50 = ConstantLoad year
+    %51 = ConstantLoad 2024
+    %52 = ConstantLoad month
+    %53 = ConstantLoad 6
+    %54 = ConstantLoad day
+    %55 = ConstantLoad 15
+    %56 = ConstantLoad hour
+    %57 = ConstantLoad 2
+    %58 = ConstantLoad minute
+    %59 = ConstantLoad 30
+    %60 = ConstantLoad second
+    %61 = ConstantLoad 45
+    %62 = ConstantLoad utcOffset
+    %63 = ConstantLoad hours
+    %64 = ConstantLoad 8
+    %65 = unknown %64;
+    %66 = ConstantLoad minutes
+    %67 = ConstantLoad 0
+    %68 = newMap {| hours: int, minutes: int, seconds: decimal, never... |}{%63=%65, %66=%67} defaults{minutes=ballerina/time:$desugar$0}
+    %69 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%50=%51, %52=%53, %54=%55, %56=%57, %58=%59, %60=%61, %62=%68}
+    %70 = utcFromCivil(%69) -> bb30;
+  }
+  bb30 {
+    %71 = %70 is error
+    %71 ? bb31 : bb32;
+  }
+  bb31 {
+    %0 = %70;
+    return;
+  }
+  bb32 {
+    %49 = %70;
+    GOTO bb33;
+  }
+  bb33 {
+    fromNeg = %49;
+    %73 = utcToString(fromNeg) -> bb34;
+  }
+  bb34 {
+    %74 = println(%73) -> bb35;
+  }
+  bb35 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/timezone-fixed-offset-v.txt
+++ b/corpus/bir/library/subset2/timezone-fixed-offset-v.txt
@@ -1,165 +1,169 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = newObject ballerina/time:TimeZone
-    %2 = ConstantLoad +05:30
-    %3 = init(%1,%2) -> bb1;
+    %2 = newObject ballerina/time:TimeZone
+    %3 = ConstantLoad +05:30
+    %4 = init(%2,%3) -> bb1;
   }
   bb1 {
-    %5 = %3 is nil
-    %5 ? bb2 : bb3;
+    %6 = %4 is nil
+    %6 ? bb2 : bb3;
   }
   bb2 {
-    %4 = %1;
+    %5 = %2;
     GOTO bb4;
   }
   bb3 {
-    %4 = %3;
+    %5 = %4;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %4;
-    %7 = $desugar$0 is error
+    %7 = %5 is error
     %7 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb6 {
-    tz = $desugar$0;
-    %9 = fixedOffset(tz) -> bb7;
+    %1 = %5;
+    GOTO bb7;
   }
   bb7 {
+    tz = %1;
+    %9 = fixedOffset(tz) -> bb8;
+  }
+  bb8 {
     offset = %9;
     %11 = offset is nil
     %12 = ! %11;
-    %12 ? bb8 : bb11;
+    %12 ? bb9 : bb12;
   }
-  bb8 {
+  bb9 {
     PushScopeFrame 8
     %1 = ConstantLoad hours
     %0 = (1, offset)[%1];
     %2 = %0;
-    %3 = println(%2) -> bb9;
+    %3 = println(%2) -> bb10;
   }
-  bb9 {
+  bb10 {
     %5 = ConstantLoad minutes
     %4 = (1, offset)[%5];
     %6 = %4;
-    %7 = println(%6) -> bb10;
-  }
-  bb10 {
-    PopScopeFrame
-    GOTO bb11;
+    %7 = println(%6) -> bb11;
   }
   bb11 {
-    PushScopeFrame 47
-    %0 = ConstantLoad 2007-12-03T10:15:30.00Z
-    %1 = utcFromString(%0) -> bb12;
+    PopScopeFrame
+    GOTO bb12;
   }
   bb12 {
-    $desugar$1 = %1;
-    %3 = $desugar$1 is error
-    %3 ? bb13 : bb14;
+    PushScopeFrame 47
+    %1 = ConstantLoad 2007-12-03T10:15:30.00Z
+    %2 = utcFromString(%1) -> bb13;
   }
   bb13 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$1);
-    PopScopeFrame
+    %3 = %2 is error
+    %3 ? bb14 : bb15;
+  }
+  bb14 {
+    (1, %0) = %2;
     PopScopeFrame
     return;
   }
-  bb14 {
-    utc = $desugar$1;
-    %5 = utcToCivil((1, tz),utc) -> bb15;
-  }
   bb15 {
+    %0 = %2;
+    GOTO bb16;
+  }
+  bb16 {
+    utc = %0;
+    %5 = utcToCivil((1, tz),utc) -> bb17;
+  }
+  bb17 {
     civil = %5;
     %8 = ConstantLoad year
     %7 = civil[%8];
     %9 = %7;
-    %10 = println(%9) -> bb16;
+    %10 = println(%9) -> bb18;
   }
-  bb16 {
+  bb18 {
     %12 = ConstantLoad month
     %11 = civil[%12];
     %13 = %11;
-    %14 = println(%13) -> bb17;
+    %14 = println(%13) -> bb19;
   }
-  bb17 {
+  bb19 {
     %16 = ConstantLoad day
     %15 = civil[%16];
     %17 = %15;
-    %18 = println(%17) -> bb18;
+    %18 = println(%17) -> bb20;
   }
-  bb18 {
+  bb20 {
     %20 = ConstantLoad hour
     %19 = civil[%20];
     %21 = %19;
-    %22 = println(%21) -> bb19;
+    %22 = println(%21) -> bb21;
   }
-  bb19 {
+  bb21 {
     %24 = ConstantLoad minute
     %23 = civil[%24];
     %25 = %23;
-    %26 = println(%25) -> bb20;
-  }
-  bb20 {
-    %27 = utcFromCivil((1, tz),civil) -> bb21;
-  }
-  bb21 {
-    $desugar$2 = %27;
-    %29 = $desugar$2 is error
-    %29 ? bb22 : bb23;
+    %26 = println(%25) -> bb22;
   }
   bb22 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$2);
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %28 = utcFromCivil((1, tz),civil) -> bb23;
   }
   bb23 {
-    utc2 = $desugar$2;
-    %31 = utcToString(utc2) -> bb24;
+    %29 = %28 is error
+    %29 ? bb24 : bb25;
   }
   bb24 {
-    %32 = println(%31) -> bb25;
-  }
-  bb25 {
-    %33 = ConstantLoad hours
-    %34 = ConstantLoad 2
-    %35 = newMap {| days: int, hours: int, minutes: int, months: int, seconds: decimal, weeks: int, years: int, never... |}{%33=%34} defaults{years=ballerina/time:$desugar$2, months=ballerina/time:$desugar$3, weeks=ballerina/time:$desugar$4, days=ballerina/time:$desugar$5, hours=ballerina/time:$desugar$6, minutes=ballerina/time:$desugar$7, seconds=ballerina/time:$desugar$8}
-    %36 = civilAddDuration((1, tz),civil,%35) -> bb26;
-  }
-  bb26 {
-    $desugar$3 = %36;
-    %38 = $desugar$3 is error
-    %38 ? bb27 : bb28;
-  }
-  bb27 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %28;
     PopScopeFrame
     return;
   }
+  bb25 {
+    %27 = %28;
+    GOTO bb26;
+  }
+  bb26 {
+    utc2 = %27;
+    %31 = utcToString(utc2) -> bb27;
+  }
+  bb27 {
+    %32 = println(%31) -> bb28;
+  }
   bb28 {
-    civil2 = $desugar$3;
+    %34 = ConstantLoad hours
+    %35 = ConstantLoad 2
+    %36 = newMap {| days: int, hours: int, minutes: int, months: int, seconds: decimal, weeks: int, years: int, never... |}{%34=%35} defaults{years=ballerina/time:$desugar$2, months=ballerina/time:$desugar$3, weeks=ballerina/time:$desugar$4, days=ballerina/time:$desugar$5, hours=ballerina/time:$desugar$6, minutes=ballerina/time:$desugar$7, seconds=ballerina/time:$desugar$8}
+    %37 = civilAddDuration((1, tz),civil,%36) -> bb29;
+  }
+  bb29 {
+    %38 = %37 is error
+    %38 ? bb30 : bb31;
+  }
+  bb30 {
+    (1, %0) = %37;
+    PopScopeFrame
+    return;
+  }
+  bb31 {
+    %33 = %37;
+    GOTO bb32;
+  }
+  bb32 {
+    civil2 = %33;
     %41 = ConstantLoad hour
     %40 = civil2[%41];
     %42 = %40;
-    %43 = println(%42) -> bb29;
+    %43 = println(%42) -> bb33;
   }
-  bb29 {
+  bb33 {
     %45 = ConstantLoad timeAbbrev
     %44 = civil2[%45];
-    %46 = println(%44) -> bb30;
+    %46 = println(%44) -> bb34;
   }
-  bb30 {
+  bb34 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset2/timezone-invalid-v.txt
+++ b/corpus/bir/library/subset2/timezone-invalid-v.txt
@@ -24,35 +24,36 @@ main() -> nil|error{
     %9 = println(%8) -> bb5;
   }
   bb5 {
-    %10 = newObject ballerina/time:TimeZone
-    %11 = ConstantLoad UTC
-    %12 = init(%10,%11) -> bb6;
+    %11 = newObject ballerina/time:TimeZone
+    %12 = ConstantLoad UTC
+    %13 = init(%11,%12) -> bb6;
   }
   bb6 {
-    %14 = %12 is nil
-    %14 ? bb7 : bb8;
+    %15 = %13 is nil
+    %15 ? bb7 : bb8;
   }
   bb7 {
-    %13 = %10;
+    %14 = %11;
     GOTO bb9;
   }
   bb8 {
-    %13 = %12;
+    %14 = %13;
     GOTO bb9;
   }
   bb9 {
-    $desugar$0 = %13;
-    %16 = $desugar$0 is error
+    %16 = %14 is error
     %16 ? bb10 : bb11;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %14;
     return;
   }
   bb11 {
-    utcZone = $desugar$0;
+    %10 = %14;
+    GOTO bb12;
+  }
+  bb12 {
+    utcZone = %10;
     %18 = ConstantLoad year
     %19 = ConstantLoad 2021
     %20 = ConstantLoad month
@@ -65,15 +66,15 @@ main() -> nil|error{
     %27 = ConstantLoad 0
     %28 = newMap {| day: int, dayOfWeek: 0|1|2|3|4|5|6, hour: int, minute: int, month: int, second: decimal, timeAbbrev: string, utcOffset: {| hours: int, minutes: int, seconds: decimal, never... |}, which: 0|1, year: int, anydata... |}{%18=%19, %20=%21, %22=%23, %24=%25, %26=%27}
     civil = %28;
-    %30 = utcFromCivil(utcZone,civil) -> bb12;
+    %30 = utcFromCivil(utcZone,civil) -> bb13;
   }
-  bb12 {
+  bb13 {
     result = %30;
     %32 = result is error
     %33 = %32;
-    %34 = println(%33) -> bb13;
+    %34 = println(%33) -> bb14;
   }
-  bb13 {
+  bb14 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/timezone-named-v.txt
+++ b/corpus/bir/library/subset2/timezone-named-v.txt
@@ -1,155 +1,159 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = newObject ballerina/time:TimeZone
-    %2 = ConstantLoad Asia/Colombo
-    %3 = init(%1,%2) -> bb1;
+    %2 = newObject ballerina/time:TimeZone
+    %3 = ConstantLoad Asia/Colombo
+    %4 = init(%2,%3) -> bb1;
   }
   bb1 {
-    %5 = %3 is nil
-    %5 ? bb2 : bb3;
+    %6 = %4 is nil
+    %6 ? bb2 : bb3;
   }
   bb2 {
-    %4 = %1;
+    %5 = %2;
     GOTO bb4;
   }
   bb3 {
-    %4 = %3;
+    %5 = %4;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %4;
-    %7 = $desugar$0 is error
+    %7 = %5 is error
     %7 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb6 {
-    tz = $desugar$0;
-    %9 = fixedOffset(tz) -> bb7;
+    %1 = %5;
+    GOTO bb7;
   }
   bb7 {
+    tz = %1;
+    %9 = fixedOffset(tz) -> bb8;
+  }
+  bb8 {
     offset = %9;
     %11 = offset is nil
     %12 = %11;
-    %13 = println(%12) -> bb8;
-  }
-  bb8 {
-    %14 = ConstantLoad 2007-12-03T10:15:30.00Z
-    %15 = utcFromString(%14) -> bb9;
+    %13 = println(%12) -> bb9;
   }
   bb9 {
-    $desugar$1 = %15;
-    %17 = $desugar$1 is error
-    %17 ? bb10 : bb11;
+    %15 = ConstantLoad 2007-12-03T10:15:30.00Z
+    %16 = utcFromString(%15) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %17 = %16 is error
+    %17 ? bb11 : bb12;
   }
   bb11 {
-    utc = $desugar$1;
-    %19 = utcToCivil(tz,utc) -> bb12;
+    %0 = %16;
+    return;
   }
   bb12 {
+    %14 = %16;
+    GOTO bb13;
+  }
+  bb13 {
+    utc = %14;
+    %19 = utcToCivil(tz,utc) -> bb14;
+  }
+  bb14 {
     civil = %19;
     %22 = ConstantLoad year
     %21 = civil[%22];
     %23 = %21;
-    %24 = println(%23) -> bb13;
+    %24 = println(%23) -> bb15;
   }
-  bb13 {
+  bb15 {
     %26 = ConstantLoad month
     %25 = civil[%26];
     %27 = %25;
-    %28 = println(%27) -> bb14;
+    %28 = println(%27) -> bb16;
   }
-  bb14 {
+  bb16 {
     %30 = ConstantLoad day
     %29 = civil[%30];
     %31 = %29;
-    %32 = println(%31) -> bb15;
+    %32 = println(%31) -> bb17;
   }
-  bb15 {
+  bb17 {
     %34 = ConstantLoad hour
     %33 = civil[%34];
     %35 = %33;
-    %36 = println(%35) -> bb16;
+    %36 = println(%35) -> bb18;
   }
-  bb16 {
+  bb18 {
     %38 = ConstantLoad minute
     %37 = civil[%38];
     %39 = %37;
-    %40 = println(%39) -> bb17;
-  }
-  bb17 {
-    %42 = ConstantLoad timeAbbrev
-    %41 = civil[%42];
-    %43 = println(%41) -> bb18;
-  }
-  bb18 {
-    %44 = utcFromCivil(tz,civil) -> bb19;
+    %40 = println(%39) -> bb19;
   }
   bb19 {
-    $desugar$2 = %44;
-    %46 = $desugar$2 is error
-    %46 ? bb20 : bb21;
+    %42 = ConstantLoad timeAbbrev
+    %41 = civil[%42];
+    %43 = println(%41) -> bb20;
   }
   bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %45 = utcFromCivil(tz,civil) -> bb21;
   }
   bb21 {
-    utc2 = $desugar$2;
-    %48 = utcToString(utc2) -> bb22;
+    %46 = %45 is error
+    %46 ? bb22 : bb23;
   }
   bb22 {
-    %49 = println(%48) -> bb23;
-  }
-  bb23 {
-    %50 = ConstantLoad months
-    %51 = ConstantLoad 1
-    %52 = newMap {| days: int, hours: int, minutes: int, months: int, seconds: decimal, weeks: int, years: int, never... |}{%50=%51} defaults{years=ballerina/time:$desugar$2, months=ballerina/time:$desugar$3, weeks=ballerina/time:$desugar$4, days=ballerina/time:$desugar$5, hours=ballerina/time:$desugar$6, minutes=ballerina/time:$desugar$7, seconds=ballerina/time:$desugar$8}
-    %53 = civilAddDuration(tz,civil,%52) -> bb24;
-  }
-  bb24 {
-    $desugar$3 = %53;
-    %55 = $desugar$3 is error
-    %55 ? bb25 : bb26;
-  }
-  bb25 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %45;
     return;
   }
+  bb23 {
+    %44 = %45;
+    GOTO bb24;
+  }
+  bb24 {
+    utc2 = %44;
+    %48 = utcToString(utc2) -> bb25;
+  }
+  bb25 {
+    %49 = println(%48) -> bb26;
+  }
   bb26 {
-    civil2 = $desugar$3;
+    %51 = ConstantLoad months
+    %52 = ConstantLoad 1
+    %53 = newMap {| days: int, hours: int, minutes: int, months: int, seconds: decimal, weeks: int, years: int, never... |}{%51=%52} defaults{years=ballerina/time:$desugar$2, months=ballerina/time:$desugar$3, weeks=ballerina/time:$desugar$4, days=ballerina/time:$desugar$5, hours=ballerina/time:$desugar$6, minutes=ballerina/time:$desugar$7, seconds=ballerina/time:$desugar$8}
+    %54 = civilAddDuration(tz,civil,%53) -> bb27;
+  }
+  bb27 {
+    %55 = %54 is error
+    %55 ? bb28 : bb29;
+  }
+  bb28 {
+    %0 = %54;
+    return;
+  }
+  bb29 {
+    %50 = %54;
+    GOTO bb30;
+  }
+  bb30 {
+    civil2 = %50;
     %58 = ConstantLoad month
     %57 = civil2[%58];
     %59 = %57;
-    %60 = println(%59) -> bb27;
+    %60 = println(%59) -> bb31;
   }
-  bb27 {
+  bb31 {
     %62 = ConstantLoad year
     %61 = civil2[%62];
     %63 = %61;
-    %64 = println(%63) -> bb28;
+    %64 = println(%63) -> bb32;
   }
-  bb28 {
+  bb32 {
     %66 = ConstantLoad timeAbbrev
     %65 = civil2[%66];
-    %67 = println(%65) -> bb29;
+    %67 = println(%65) -> bb33;
   }
-  bb29 {
+  bb33 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/timezone-utc-v.txt
+++ b/corpus/bir/library/subset2/timezone-utc-v.txt
@@ -1,160 +1,164 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = newObject ballerina/time:TimeZone
-    %2 = ConstantLoad UTC
-    %3 = init(%1,%2) -> bb1;
+    %2 = newObject ballerina/time:TimeZone
+    %3 = ConstantLoad UTC
+    %4 = init(%2,%3) -> bb1;
   }
   bb1 {
-    %5 = %3 is nil
-    %5 ? bb2 : bb3;
+    %6 = %4 is nil
+    %6 ? bb2 : bb3;
   }
   bb2 {
-    %4 = %1;
+    %5 = %2;
     GOTO bb4;
   }
   bb3 {
-    %4 = %3;
+    %5 = %4;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %4;
-    %7 = $desugar$0 is error
+    %7 = %5 is error
     %7 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb6 {
-    utcZone = $desugar$0;
-    %9 = fixedOffset(utcZone) -> bb7;
+    %1 = %5;
+    GOTO bb7;
   }
   bb7 {
+    utcZone = %1;
+    %9 = fixedOffset(utcZone) -> bb8;
+  }
+  bb8 {
     offset = %9;
     %11 = offset is nil
     %12 = ! %11;
-    %12 ? bb8 : bb11;
+    %12 ? bb9 : bb12;
   }
-  bb8 {
+  bb9 {
     PushScopeFrame 8
     %1 = ConstantLoad hours
     %0 = (1, offset)[%1];
     %2 = %0;
-    %3 = println(%2) -> bb9;
+    %3 = println(%2) -> bb10;
   }
-  bb9 {
+  bb10 {
     %5 = ConstantLoad minutes
     %4 = (1, offset)[%5];
     %6 = %4;
-    %7 = println(%6) -> bb10;
-  }
-  bb10 {
-    PopScopeFrame
-    GOTO bb11;
+    %7 = println(%6) -> bb11;
   }
   bb11 {
-    PushScopeFrame 44
-    %0 = ConstantLoad 2007-12-03T10:15:30.00Z
-    %1 = utcFromString(%0) -> bb12;
+    PopScopeFrame
+    GOTO bb12;
   }
   bb12 {
-    $desugar$1 = %1;
-    %3 = $desugar$1 is error
-    %3 ? bb13 : bb14;
+    PushScopeFrame 44
+    %1 = ConstantLoad 2007-12-03T10:15:30.00Z
+    %2 = utcFromString(%1) -> bb13;
   }
   bb13 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$1);
-    PopScopeFrame
+    %3 = %2 is error
+    %3 ? bb14 : bb15;
+  }
+  bb14 {
+    (1, %0) = %2;
     PopScopeFrame
     return;
   }
-  bb14 {
-    utc = $desugar$1;
-    %5 = utcToCivil((1, utcZone),utc) -> bb15;
-  }
   bb15 {
+    %0 = %2;
+    GOTO bb16;
+  }
+  bb16 {
+    utc = %0;
+    %5 = utcToCivil((1, utcZone),utc) -> bb17;
+  }
+  bb17 {
     civil = %5;
     %8 = ConstantLoad year
     %7 = civil[%8];
     %9 = %7;
-    %10 = println(%9) -> bb16;
+    %10 = println(%9) -> bb18;
   }
-  bb16 {
+  bb18 {
     %12 = ConstantLoad month
     %11 = civil[%12];
     %13 = %11;
-    %14 = println(%13) -> bb17;
+    %14 = println(%13) -> bb19;
   }
-  bb17 {
+  bb19 {
     %16 = ConstantLoad day
     %15 = civil[%16];
     %17 = %15;
-    %18 = println(%17) -> bb18;
+    %18 = println(%17) -> bb20;
   }
-  bb18 {
+  bb20 {
     %20 = ConstantLoad hour
     %19 = civil[%20];
     %21 = %19;
-    %22 = println(%21) -> bb19;
+    %22 = println(%21) -> bb21;
   }
-  bb19 {
+  bb21 {
     %24 = ConstantLoad minute
     %23 = civil[%24];
     %25 = %23;
-    %26 = println(%25) -> bb20;
-  }
-  bb20 {
-    %27 = utcFromCivil((1, utcZone),civil) -> bb21;
-  }
-  bb21 {
-    $desugar$2 = %27;
-    %29 = $desugar$2 is error
-    %29 ? bb22 : bb23;
+    %26 = println(%25) -> bb22;
   }
   bb22 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$2);
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %28 = utcFromCivil((1, utcZone),civil) -> bb23;
   }
   bb23 {
-    utc2 = $desugar$2;
-    %31 = utcToString(utc2) -> bb24;
+    %29 = %28 is error
+    %29 ? bb24 : bb25;
   }
   bb24 {
-    %32 = println(%31) -> bb25;
-  }
-  bb25 {
-    %33 = ConstantLoad days
-    %34 = ConstantLoad 1
-    %35 = newMap {| days: int, hours: int, minutes: int, months: int, seconds: decimal, weeks: int, years: int, never... |}{%33=%34} defaults{years=ballerina/time:$desugar$2, months=ballerina/time:$desugar$3, weeks=ballerina/time:$desugar$4, days=ballerina/time:$desugar$5, hours=ballerina/time:$desugar$6, minutes=ballerina/time:$desugar$7, seconds=ballerina/time:$desugar$8}
-    %36 = civilAddDuration((1, utcZone),civil,%35) -> bb26;
-  }
-  bb26 {
-    $desugar$3 = %36;
-    %38 = $desugar$3 is error
-    %38 ? bb27 : bb28;
-  }
-  bb27 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %28;
     PopScopeFrame
     return;
   }
+  bb25 {
+    %27 = %28;
+    GOTO bb26;
+  }
+  bb26 {
+    utc2 = %27;
+    %31 = utcToString(utc2) -> bb27;
+  }
+  bb27 {
+    %32 = println(%31) -> bb28;
+  }
   bb28 {
-    civil2 = $desugar$3;
+    %34 = ConstantLoad days
+    %35 = ConstantLoad 1
+    %36 = newMap {| days: int, hours: int, minutes: int, months: int, seconds: decimal, weeks: int, years: int, never... |}{%34=%35} defaults{years=ballerina/time:$desugar$2, months=ballerina/time:$desugar$3, weeks=ballerina/time:$desugar$4, days=ballerina/time:$desugar$5, hours=ballerina/time:$desugar$6, minutes=ballerina/time:$desugar$7, seconds=ballerina/time:$desugar$8}
+    %37 = civilAddDuration((1, utcZone),civil,%36) -> bb29;
+  }
+  bb29 {
+    %38 = %37 is error
+    %38 ? bb30 : bb31;
+  }
+  bb30 {
+    (1, %0) = %37;
+    PopScopeFrame
+    return;
+  }
+  bb31 {
+    %33 = %37;
+    GOTO bb32;
+  }
+  bb32 {
+    civil2 = %33;
     %41 = ConstantLoad day
     %40 = civil2[%41];
     %42 = %40;
-    %43 = println(%42) -> bb29;
+    %43 = println(%42) -> bb33;
   }
-  bb29 {
+  bb33 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset2/url-charset-ascii-v.txt
+++ b/corpus/bir/library/subset2/url-charset-ascii-v.txt
@@ -1,197 +1,206 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad hello world
-    %2 = ConstantLoad US-ASCII
-    %3 = encode(%1,%2) -> bb1;
+    %2 = ConstantLoad hello world
+    %3 = ConstantLoad US-ASCII
+    %4 = encode(%2,%3) -> bb1;
   }
   bb1 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
+    %5 = %4 is error
     %5 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %4;
     return;
   }
   bb3 {
-    %6 = println($desugar$0) -> bb4;
+    %1 = %4;
+    GOTO bb4;
   }
   bb4 {
-    %7 = ConstantLoad hello%20world
-    %8 = ConstantLoad US-ASCII
-    %9 = decode(%7,%8) -> bb5;
+    %6 = println(%1) -> bb5;
   }
   bb5 {
-    $desugar$1 = %9;
-    %11 = $desugar$1 is error
-    %11 ? bb6 : bb7;
+    %8 = ConstantLoad hello%20world
+    %9 = ConstantLoad US-ASCII
+    %10 = decode(%8,%9) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %11 = %10 is error
+    %11 ? bb7 : bb8;
   }
   bb7 {
-    %12 = println($desugar$1) -> bb8;
-  }
-  bb8 {
-    %13 = ConstantLoad a=b
-    %14 = ConstantLoad ASCII
-    %15 = encode(%13,%14) -> bb9;
-  }
-  bb9 {
-    $desugar$2 = %15;
-    %17 = $desugar$2 is error
-    %17 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %10;
     return;
   }
+  bb8 {
+    %7 = %10;
+    GOTO bb9;
+  }
+  bb9 {
+    %12 = println(%7) -> bb10;
+  }
+  bb10 {
+    %14 = ConstantLoad a=b
+    %15 = ConstantLoad ASCII
+    %16 = encode(%14,%15) -> bb11;
+  }
   bb11 {
-    %18 = println($desugar$2) -> bb12;
+    %17 = %16 is error
+    %17 ? bb12 : bb13;
   }
   bb12 {
-    %19 = ConstantLoad café
-    %20 = ConstantLoad US-ASCII
-    %21 = encode(%19,%20) -> bb13;
+    %0 = %16;
+    return;
   }
   bb13 {
+    %13 = %16;
+    GOTO bb14;
+  }
+  bb14 {
+    %18 = println(%13) -> bb15;
+  }
+  bb15 {
+    %19 = ConstantLoad café
+    %20 = ConstantLoad US-ASCII
+    %21 = encode(%19,%20) -> bb16;
+  }
+  bb16 {
     enc = %21;
     %23 = enc is error
     %24 = %23;
-    %25 = println(%24) -> bb14;
+    %25 = println(%24) -> bb17;
   }
-  bb14 {
+  bb17 {
     %26 = ConstantLoad %FF
     %27 = ConstantLoad US-ASCII
-    %28 = decode(%26,%27) -> bb15;
+    %28 = decode(%26,%27) -> bb18;
   }
-  bb15 {
+  bb18 {
     dec = %28;
     %30 = dec is error
     %31 = %30;
-    %32 = println(%31) -> bb16;
-  }
-  bb16 {
-    %33 = ConstantLoad a b
-    %34 = ConstantLoad UTF8
-    %35 = encode(%33,%34) -> bb17;
-  }
-  bb17 {
-    $desugar$3 = %35;
-    %37 = $desugar$3 is error
-    %37 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %32 = println(%31) -> bb19;
   }
   bb19 {
-    %38 = println($desugar$3) -> bb20;
+    %34 = ConstantLoad a b
+    %35 = ConstantLoad UTF8
+    %36 = encode(%34,%35) -> bb20;
   }
   bb20 {
-    %39 = ConstantLoad café
-    %40 = ConstantLoad LATIN-1
-    %41 = encode(%39,%40) -> bb21;
+    %37 = %36 is error
+    %37 ? bb21 : bb22;
   }
   bb21 {
-    $desugar$4 = %41;
-    %43 = $desugar$4 is error
-    %43 ? bb22 : bb23;
-  }
-  bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %36;
     return;
   }
+  bb22 {
+    %33 = %36;
+    GOTO bb23;
+  }
   bb23 {
-    %44 = println($desugar$4) -> bb24;
+    %38 = println(%33) -> bb24;
   }
   bb24 {
-    %45 = ConstantLoad Hi
-    original = %45;
-    %47 = ConstantLoad UTF-16
-    %48 = encode(original,%47) -> bb25;
+    %40 = ConstantLoad café
+    %41 = ConstantLoad LATIN-1
+    %42 = encode(%40,%41) -> bb25;
   }
   bb25 {
-    $desugar$5 = %48;
-    %50 = $desugar$5 is error
-    %50 ? bb26 : bb27;
+    %43 = %42 is error
+    %43 ? bb26 : bb27;
   }
   bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %42;
     return;
   }
   bb27 {
-    utf16 = $desugar$5;
-    %52 = ConstantLoad UTF-16
-    %53 = decode(utf16,%52) -> bb28;
+    %39 = %42;
+    GOTO bb28;
   }
   bb28 {
-    $desugar$6 = %53;
-    %55 = $desugar$6 is error
-    %55 ? bb29 : bb30;
+    %44 = println(%39) -> bb29;
   }
   bb29 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    %45 = ConstantLoad Hi
+    original = %45;
+    %48 = ConstantLoad UTF-16
+    %49 = encode(original,%48) -> bb30;
   }
   bb30 {
-    %56 = == $desugar$6 original;
-    %57 = %56;
-    %58 = println(%57) -> bb31;
+    %50 = %49 is error
+    %50 ? bb31 : bb32;
   }
   bb31 {
-    %59 = ConstantLoad UTF-16LE
-    %60 = encode(original,%59) -> bb32;
+    %0 = %49;
+    return;
   }
   bb32 {
-    $desugar$7 = %60;
-    %62 = $desugar$7 is error
-    %62 ? bb33 : bb34;
+    %47 = %49;
+    GOTO bb33;
   }
   bb33 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    utf16 = %47;
+    %54 = ConstantLoad UTF-16
+    %55 = decode(utf16,%54) -> bb34;
   }
   bb34 {
-    utf16le = $desugar$7;
-    %64 = ConstantLoad UTF-16LE
-    %65 = decode(utf16le,%64) -> bb35;
+    %56 = %55 is error
+    %56 ? bb35 : bb36;
   }
   bb35 {
-    $desugar$8 = %65;
-    %67 = $desugar$8 is error
-    %67 ? bb36 : bb37;
-  }
-  bb36 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
+    %0 = %55;
     return;
   }
+  bb36 {
+    %53 = %55;
+    GOTO bb37;
+  }
   bb37 {
-    %68 = == $desugar$8 original;
-    %69 = %68;
-    %70 = println(%69) -> bb38;
+    %52 = == %53 original;
+    %57 = %52;
+    %58 = println(%57) -> bb38;
   }
   bb38 {
+    %60 = ConstantLoad UTF-16LE
+    %61 = encode(original,%60) -> bb39;
+  }
+  bb39 {
+    %62 = %61 is error
+    %62 ? bb40 : bb41;
+  }
+  bb40 {
+    %0 = %61;
+    return;
+  }
+  bb41 {
+    %59 = %61;
+    GOTO bb42;
+  }
+  bb42 {
+    utf16le = %59;
+    %66 = ConstantLoad UTF-16LE
+    %67 = decode(utf16le,%66) -> bb43;
+  }
+  bb43 {
+    %68 = %67 is error
+    %68 ? bb44 : bb45;
+  }
+  bb44 {
+    %0 = %67;
+    return;
+  }
+  bb45 {
+    %65 = %67;
+    GOTO bb46;
+  }
+  bb46 {
+    %64 = == %65 original;
+    %69 = %64;
+    %70 = println(%69) -> bb47;
+  }
+  bb47 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/url-charset-iso8859-v.txt
+++ b/corpus/bir/library/subset2/url-charset-iso8859-v.txt
@@ -1,178 +1,187 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad hello
-    %2 = ConstantLoad ISO-8859-1
-    %3 = encode(%1,%2) -> bb1;
+    %2 = ConstantLoad hello
+    %3 = ConstantLoad ISO-8859-1
+    %4 = encode(%2,%3) -> bb1;
   }
   bb1 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
+    %5 = %4 is error
     %5 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %4;
     return;
   }
   bb3 {
-    %6 = println($desugar$0) -> bb4;
+    %1 = %4;
+    GOTO bb4;
   }
   bb4 {
-    %7 = ConstantLoad hello world
-    %8 = ConstantLoad ISO-8859-1
-    %9 = encode(%7,%8) -> bb5;
+    %6 = println(%1) -> bb5;
   }
   bb5 {
-    $desugar$1 = %9;
-    %11 = $desugar$1 is error
-    %11 ? bb6 : bb7;
+    %8 = ConstantLoad hello world
+    %9 = ConstantLoad ISO-8859-1
+    %10 = encode(%8,%9) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %11 = %10 is error
+    %11 ? bb7 : bb8;
   }
   bb7 {
-    %12 = println($desugar$1) -> bb8;
+    %0 = %10;
+    return;
   }
   bb8 {
-    %13 = ConstantLoad café
-    %14 = ConstantLoad ISO-8859-1
-    %15 = encode(%13,%14) -> bb9;
+    %7 = %10;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$2 = %15;
-    %17 = $desugar$2 is error
-    %17 ? bb10 : bb11;
+    %12 = println(%7) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %14 = ConstantLoad café
+    %15 = ConstantLoad ISO-8859-1
+    %16 = encode(%14,%15) -> bb11;
   }
   bb11 {
-    %18 = println($desugar$2) -> bb12;
+    %17 = %16 is error
+    %17 ? bb12 : bb13;
   }
   bb12 {
-    %19 = ConstantLoad résumé
-    %20 = ConstantLoad ISO-8859-1
-    %21 = encode(%19,%20) -> bb13;
+    %0 = %16;
+    return;
   }
   bb13 {
-    $desugar$3 = %21;
-    %23 = $desugar$3 is error
-    %23 ? bb14 : bb15;
+    %13 = %16;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %18 = println(%13) -> bb15;
   }
   bb15 {
-    %24 = println($desugar$3) -> bb16;
+    %20 = ConstantLoad résumé
+    %21 = ConstantLoad ISO-8859-1
+    %22 = encode(%20,%21) -> bb16;
   }
   bb16 {
-    %25 = ConstantLoad caf%E9
-    %26 = ConstantLoad ISO-8859-1
-    %27 = decode(%25,%26) -> bb17;
+    %23 = %22 is error
+    %23 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %27;
-    %29 = $desugar$4 is error
-    %29 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %22;
     return;
   }
+  bb18 {
+    %19 = %22;
+    GOTO bb19;
+  }
   bb19 {
-    %30 = println($desugar$4) -> bb20;
+    %24 = println(%19) -> bb20;
   }
   bb20 {
-    %31 = ConstantLoad r%E9sum%E9
-    %32 = ConstantLoad ISO-8859-1
-    %33 = decode(%31,%32) -> bb21;
+    %26 = ConstantLoad caf%E9
+    %27 = ConstantLoad ISO-8859-1
+    %28 = decode(%26,%27) -> bb21;
   }
   bb21 {
-    $desugar$5 = %33;
-    %35 = $desugar$5 is error
-    %35 ? bb22 : bb23;
+    %29 = %28 is error
+    %29 ? bb22 : bb23;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %28;
     return;
   }
   bb23 {
-    %36 = println($desugar$5) -> bb24;
+    %25 = %28;
+    GOTO bb24;
   }
   bb24 {
-    %37 = ConstantLoad hello%20world
-    %38 = ConstantLoad ISO-8859-1
-    %39 = decode(%37,%38) -> bb25;
+    %30 = println(%25) -> bb25;
   }
   bb25 {
-    $desugar$6 = %39;
-    %41 = $desugar$6 is error
-    %41 ? bb26 : bb27;
+    %32 = ConstantLoad r%E9sum%E9
+    %33 = ConstantLoad ISO-8859-1
+    %34 = decode(%32,%33) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    %35 = %34 is error
+    %35 ? bb27 : bb28;
   }
   bb27 {
-    %42 = println($desugar$6) -> bb28;
+    %0 = %34;
+    return;
   }
   bb28 {
-    %43 = ConstantLoad naïve
-    original = %43;
-    %45 = ConstantLoad ISO-8859-1
-    %46 = encode(original,%45) -> bb29;
+    %31 = %34;
+    GOTO bb29;
   }
   bb29 {
-    $desugar$7 = %46;
-    %48 = $desugar$7 is error
-    %48 ? bb30 : bb31;
+    %36 = println(%31) -> bb30;
   }
   bb30 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    %38 = ConstantLoad hello%20world
+    %39 = ConstantLoad ISO-8859-1
+    %40 = decode(%38,%39) -> bb31;
   }
   bb31 {
-    encoded = $desugar$7;
-    %50 = ConstantLoad ISO-8859-1
-    %51 = decode(encoded,%50) -> bb32;
+    %41 = %40 is error
+    %41 ? bb32 : bb33;
   }
   bb32 {
-    $desugar$8 = %51;
-    %53 = $desugar$8 is error
-    %53 ? bb33 : bb34;
-  }
-  bb33 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
+    %0 = %40;
     return;
   }
+  bb33 {
+    %37 = %40;
+    GOTO bb34;
+  }
   bb34 {
-    decoded = $desugar$8;
-    %55 = == decoded original;
-    %56 = %55;
-    %57 = println(%56) -> bb35;
+    %42 = println(%37) -> bb35;
   }
   bb35 {
+    %43 = ConstantLoad naïve
+    original = %43;
+    %46 = ConstantLoad ISO-8859-1
+    %47 = encode(original,%46) -> bb36;
+  }
+  bb36 {
+    %48 = %47 is error
+    %48 ? bb37 : bb38;
+  }
+  bb37 {
+    %0 = %47;
+    return;
+  }
+  bb38 {
+    %45 = %47;
+    GOTO bb39;
+  }
+  bb39 {
+    encoded = %45;
+    %51 = ConstantLoad ISO-8859-1
+    %52 = decode(encoded,%51) -> bb40;
+  }
+  bb40 {
+    %53 = %52 is error
+    %53 ? bb41 : bb42;
+  }
+  bb41 {
+    %0 = %52;
+    return;
+  }
+  bb42 {
+    %50 = %52;
+    GOTO bb43;
+  }
+  bb43 {
+    decoded = %50;
+    %55 = == decoded original;
+    %56 = %55;
+    %57 = println(%56) -> bb44;
+  }
+  bb44 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/url-charset-utf16be-v.txt
+++ b/corpus/bir/library/subset2/url-charset-utf16be-v.txt
@@ -1,121 +1,127 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad AB
-    %2 = ConstantLoad UTF-16BE
-    %3 = encode(%1,%2) -> bb1;
+    %2 = ConstantLoad AB
+    %3 = ConstantLoad UTF-16BE
+    %4 = encode(%2,%3) -> bb1;
   }
   bb1 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
+    %5 = %4 is error
     %5 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %4;
     return;
   }
   bb3 {
-    %6 = println($desugar$0) -> bb4;
+    %1 = %4;
+    GOTO bb4;
   }
   bb4 {
-    %7 = ConstantLoad hi
-    %8 = ConstantLoad UTF-16BE
-    %9 = encode(%7,%8) -> bb5;
+    %6 = println(%1) -> bb5;
   }
   bb5 {
-    $desugar$1 = %9;
-    %11 = $desugar$1 is error
-    %11 ? bb6 : bb7;
+    %8 = ConstantLoad hi
+    %9 = ConstantLoad UTF-16BE
+    %10 = encode(%8,%9) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %11 = %10 is error
+    %11 ? bb7 : bb8;
   }
   bb7 {
-    %12 = println($desugar$1) -> bb8;
+    %0 = %10;
+    return;
   }
   bb8 {
-    %13 = ConstantLoad %00A%00B
-    %14 = ConstantLoad UTF-16BE
-    %15 = decode(%13,%14) -> bb9;
+    %7 = %10;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$2 = %15;
-    %17 = $desugar$2 is error
-    %17 ? bb10 : bb11;
+    %12 = println(%7) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %14 = ConstantLoad %00A%00B
+    %15 = ConstantLoad UTF-16BE
+    %16 = decode(%14,%15) -> bb11;
   }
   bb11 {
-    %18 = println($desugar$2) -> bb12;
+    %17 = %16 is error
+    %17 ? bb12 : bb13;
   }
   bb12 {
-    %19 = ConstantLoad %00h%00i
-    %20 = ConstantLoad UTF-16BE
-    %21 = decode(%19,%20) -> bb13;
+    %0 = %16;
+    return;
   }
   bb13 {
-    $desugar$3 = %21;
-    %23 = $desugar$3 is error
-    %23 ? bb14 : bb15;
+    %13 = %16;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %18 = println(%13) -> bb15;
   }
   bb15 {
-    %24 = println($desugar$3) -> bb16;
+    %20 = ConstantLoad %00h%00i
+    %21 = ConstantLoad UTF-16BE
+    %22 = decode(%20,%21) -> bb16;
   }
   bb16 {
-    %25 = ConstantLoad Go
-    original = %25;
-    %27 = ConstantLoad UTF-16BE
-    %28 = encode(original,%27) -> bb17;
+    %23 = %22 is error
+    %23 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %28;
-    %30 = $desugar$4 is error
-    %30 ? bb18 : bb19;
+    %0 = %22;
+    return;
   }
   bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %19 = %22;
+    GOTO bb19;
   }
   bb19 {
-    encoded = $desugar$4;
-    %32 = ConstantLoad UTF-16BE
-    %33 = decode(encoded,%32) -> bb20;
+    %24 = println(%19) -> bb20;
   }
   bb20 {
-    $desugar$5 = %33;
-    %35 = $desugar$5 is error
-    %35 ? bb21 : bb22;
+    %25 = ConstantLoad Go
+    original = %25;
+    %28 = ConstantLoad UTF-16BE
+    %29 = encode(original,%28) -> bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %30 = %29 is error
+    %30 ? bb22 : bb23;
   }
   bb22 {
-    decoded = $desugar$5;
-    %37 = == decoded original;
-    %38 = %37;
-    %39 = println(%38) -> bb23;
+    %0 = %29;
+    return;
   }
   bb23 {
+    %27 = %29;
+    GOTO bb24;
+  }
+  bb24 {
+    encoded = %27;
+    %33 = ConstantLoad UTF-16BE
+    %34 = decode(encoded,%33) -> bb25;
+  }
+  bb25 {
+    %35 = %34 is error
+    %35 ? bb26 : bb27;
+  }
+  bb26 {
+    %0 = %34;
+    return;
+  }
+  bb27 {
+    %32 = %34;
+    GOTO bb28;
+  }
+  bb28 {
+    decoded = %32;
+    %37 = == decoded original;
+    %38 = %37;
+    %39 = println(%38) -> bb29;
+  }
+  bb29 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/url-decode-errors-v.txt
+++ b/corpus/bir/library/subset2/url-decode-errors-v.txt
@@ -23,74 +23,77 @@ main() -> nil|error{
     %14 = println(%13) -> bb4;
   }
   bb4 {
-    %15 = ConstantLoad a%
-    %16 = ConstantLoad UTF-8
-    %17 = decode(%15,%16) -> bb5;
+    %16 = ConstantLoad a%
+    %17 = ConstantLoad UTF-8
+    %18 = decode(%16,%17) -> bb5;
   }
   bb5 {
-    $desugar$0 = %17;
-    %19 = $desugar$0 is error
+    %19 = %18 is error
     %19 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %18;
     return;
   }
   bb7 {
-    %20 = println($desugar$0) -> bb8;
+    %15 = %18;
+    GOTO bb8;
   }
   bb8 {
-    %21 = ConstantLoad %2a%2b
-    %22 = ConstantLoad UTF-8
-    %23 = decode(%21,%22) -> bb9;
+    %20 = println(%15) -> bb9;
   }
   bb9 {
-    $desugar$1 = %23;
-    %25 = $desugar$1 is error
-    %25 ? bb10 : bb11;
+    %22 = ConstantLoad %2a%2b
+    %23 = ConstantLoad UTF-8
+    %24 = decode(%22,%23) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %25 = %24 is error
+    %25 ? bb11 : bb12;
   }
   bb11 {
-    %26 = println($desugar$1) -> bb12;
-  }
-  bb12 {
-    %27 = ConstantLoad café
-    %28 = ConstantLoad ISO-8859-1
-    %29 = decode(%27,%28) -> bb13;
-  }
-  bb13 {
-    $desugar$2 = %29;
-    %31 = $desugar$2 is error
-    %31 ? bb14 : bb15;
-  }
-  bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %24;
     return;
   }
+  bb12 {
+    %21 = %24;
+    GOTO bb13;
+  }
+  bb13 {
+    %26 = println(%21) -> bb14;
+  }
+  bb14 {
+    %28 = ConstantLoad café
+    %29 = ConstantLoad ISO-8859-1
+    %30 = decode(%28,%29) -> bb15;
+  }
   bb15 {
-    %32 = println($desugar$2) -> bb16;
+    %31 = %30 is error
+    %31 ? bb16 : bb17;
   }
   bb16 {
-    %33 = ConstantLoad %FFé
-    %34 = ConstantLoad US-ASCII
-    %35 = decode(%33,%34) -> bb17;
+    %0 = %30;
+    return;
   }
   bb17 {
+    %27 = %30;
+    GOTO bb18;
+  }
+  bb18 {
+    %32 = println(%27) -> bb19;
+  }
+  bb19 {
+    %33 = ConstantLoad %FFé
+    %34 = ConstantLoad US-ASCII
+    %35 = decode(%33,%34) -> bb20;
+  }
+  bb20 {
     flushErr = %35;
     %37 = flushErr is error
     %38 = %37;
-    %39 = println(%38) -> bb18;
+    %39 = println(%38) -> bb21;
   }
-  bb18 {
+  bb21 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/url-decode-v.txt
+++ b/corpus/bir/library/subset2/url-decode-v.txt
@@ -1,102 +1,107 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad param1%3Dhttp%3A%2F%2Fxyz.com%2F%3Fa%3D12%26b%3D55
-    %2 = ConstantLoad UTF-8
-    %3 = decode(%1,%2) -> bb1;
+    %2 = ConstantLoad param1%3Dhttp%3A%2F%2Fxyz.com%2F%3Fa%3D12%26b%3D55
+    %3 = ConstantLoad UTF-8
+    %4 = decode(%2,%3) -> bb1;
   }
   bb1 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
+    %5 = %4 is error
     %5 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %4;
     return;
   }
   bb3 {
-    decoded = $desugar$0;
-    %7 = println(decoded) -> bb4;
+    %1 = %4;
+    GOTO bb4;
   }
   bb4 {
-    %8 = ConstantLoad hello%20world
-    %9 = ConstantLoad UTF-8
-    %10 = decode(%8,%9) -> bb5;
+    decoded = %1;
+    %7 = println(decoded) -> bb5;
   }
   bb5 {
-    $desugar$1 = %10;
-    %12 = $desugar$1 is error
-    %12 ? bb6 : bb7;
+    %9 = ConstantLoad hello%20world
+    %10 = ConstantLoad UTF-8
+    %11 = decode(%9,%10) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %12 = %11 is error
+    %12 ? bb7 : bb8;
   }
   bb7 {
-    %13 = println($desugar$1) -> bb8;
+    %0 = %11;
+    return;
   }
   bb8 {
-    %14 = ConstantLoad hello+world
-    %15 = ConstantLoad UTF-8
-    %16 = decode(%14,%15) -> bb9;
+    %8 = %11;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$2 = %16;
-    %18 = $desugar$2 is error
-    %18 ? bb10 : bb11;
+    %13 = println(%8) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %15 = ConstantLoad hello+world
+    %16 = ConstantLoad UTF-8
+    %17 = decode(%15,%16) -> bb11;
   }
   bb11 {
-    %19 = println($desugar$2) -> bb12;
+    %18 = %17 is error
+    %18 ? bb12 : bb13;
   }
   bb12 {
-    %20 = ConstantLoad a%2Ab
-    %21 = ConstantLoad UTF-8
-    %22 = decode(%20,%21) -> bb13;
+    %0 = %17;
+    return;
   }
   bb13 {
-    $desugar$3 = %22;
-    %24 = $desugar$3 is error
-    %24 ? bb14 : bb15;
+    %14 = %17;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %19 = println(%14) -> bb15;
   }
   bb15 {
-    %25 = println($desugar$3) -> bb16;
+    %21 = ConstantLoad a%2Ab
+    %22 = ConstantLoad UTF-8
+    %23 = decode(%21,%22) -> bb16;
   }
   bb16 {
-    %26 = ConstantLoad a%7Eb
-    %27 = ConstantLoad UTF-8
-    %28 = decode(%26,%27) -> bb17;
+    %24 = %23 is error
+    %24 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %28;
-    %30 = $desugar$4 is error
-    %30 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %23;
     return;
   }
+  bb18 {
+    %20 = %23;
+    GOTO bb19;
+  }
   bb19 {
-    %31 = println($desugar$4) -> bb20;
+    %25 = println(%20) -> bb20;
   }
   bb20 {
+    %27 = ConstantLoad a%7Eb
+    %28 = ConstantLoad UTF-8
+    %29 = decode(%27,%28) -> bb21;
+  }
+  bb21 {
+    %30 = %29 is error
+    %30 ? bb22 : bb23;
+  }
+  bb22 {
+    %0 = %29;
+    return;
+  }
+  bb23 {
+    %26 = %29;
+    GOTO bb24;
+  }
+  bb24 {
+    %31 = println(%26) -> bb25;
+  }
+  bb25 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/url-encode-v.txt
+++ b/corpus/bir/library/subset2/url-encode-v.txt
@@ -1,102 +1,107 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad param1=http://xyz.com/?a=12&b=55
-    %2 = ConstantLoad UTF-8
-    %3 = encode(%1,%2) -> bb1;
+    %2 = ConstantLoad param1=http://xyz.com/?a=12&b=55
+    %3 = ConstantLoad UTF-8
+    %4 = encode(%2,%3) -> bb1;
   }
   bb1 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
+    %5 = %4 is error
     %5 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %4;
     return;
   }
   bb3 {
-    encoded = $desugar$0;
-    %7 = println(encoded) -> bb4;
+    %1 = %4;
+    GOTO bb4;
   }
   bb4 {
-    %8 = ConstantLoad hello world
-    %9 = ConstantLoad UTF-8
-    %10 = encode(%8,%9) -> bb5;
+    encoded = %1;
+    %7 = println(encoded) -> bb5;
   }
   bb5 {
-    $desugar$1 = %10;
-    %12 = $desugar$1 is error
-    %12 ? bb6 : bb7;
+    %9 = ConstantLoad hello world
+    %10 = ConstantLoad UTF-8
+    %11 = encode(%9,%10) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %12 = %11 is error
+    %12 ? bb7 : bb8;
   }
   bb7 {
-    %13 = println($desugar$1) -> bb8;
+    %0 = %11;
+    return;
   }
   bb8 {
-    %14 = ConstantLoad a*b
-    %15 = ConstantLoad UTF-8
-    %16 = encode(%14,%15) -> bb9;
+    %8 = %11;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$2 = %16;
-    %18 = $desugar$2 is error
-    %18 ? bb10 : bb11;
+    %13 = println(%8) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %15 = ConstantLoad a*b
+    %16 = ConstantLoad UTF-8
+    %17 = encode(%15,%16) -> bb11;
   }
   bb11 {
-    %19 = println($desugar$2) -> bb12;
+    %18 = %17 is error
+    %18 ? bb12 : bb13;
   }
   bb12 {
-    %20 = ConstantLoad a~b
-    %21 = ConstantLoad UTF-8
-    %22 = encode(%20,%21) -> bb13;
+    %0 = %17;
+    return;
   }
   bb13 {
-    $desugar$3 = %22;
-    %24 = $desugar$3 is error
-    %24 ? bb14 : bb15;
+    %14 = %17;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %19 = println(%14) -> bb15;
   }
   bb15 {
-    %25 = println($desugar$3) -> bb16;
+    %21 = ConstantLoad a~b
+    %22 = ConstantLoad UTF-8
+    %23 = encode(%21,%22) -> bb16;
   }
   bb16 {
-    %26 = ConstantLoad a.b-c_d
-    %27 = ConstantLoad UTF-8
-    %28 = encode(%26,%27) -> bb17;
+    %24 = %23 is error
+    %24 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %28;
-    %30 = $desugar$4 is error
-    %30 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %23;
     return;
   }
+  bb18 {
+    %20 = %23;
+    GOTO bb19;
+  }
   bb19 {
-    %31 = println($desugar$4) -> bb20;
+    %25 = println(%20) -> bb20;
   }
   bb20 {
+    %27 = ConstantLoad a.b-c_d
+    %28 = ConstantLoad UTF-8
+    %29 = encode(%27,%28) -> bb21;
+  }
+  bb21 {
+    %30 = %29 is error
+    %30 ? bb22 : bb23;
+  }
+  bb22 {
+    %0 = %29;
+    return;
+  }
+  bb23 {
+    %26 = %29;
+    GOTO bb24;
+  }
+  bb24 {
+    %31 = println(%26) -> bb25;
+  }
+  bb25 {
     return;
   }
 }

--- a/corpus/bir/library/subset2/url-roundtrip-v.txt
+++ b/corpus/bir/library/subset2/url-roundtrip-v.txt
@@ -3,43 +3,45 @@ main() -> nil|error{
   bb0 {
     %1 = ConstantLoad param1=http://xyz.com/?a=12&b=55&param2=99
     original = %1;
-    %3 = ConstantLoad UTF-8
-    %4 = encode(original,%3) -> bb1;
+    %4 = ConstantLoad UTF-8
+    %5 = encode(original,%4) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
+    %6 = %5 is error
     %6 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb3 {
-    encoded = $desugar$0;
-    %8 = ConstantLoad UTF-8
-    %9 = decode(encoded,%8) -> bb4;
+    %3 = %5;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$1 = %9;
-    %11 = $desugar$1 is error
-    %11 ? bb5 : bb6;
+    encoded = %3;
+    %9 = ConstantLoad UTF-8
+    %10 = decode(encoded,%9) -> bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %11 = %10 is error
+    %11 ? bb6 : bb7;
   }
   bb6 {
-    decoded = $desugar$1;
-    %13 = == decoded original;
-    %14 = %13;
-    %15 = println(%14) -> bb7;
+    %0 = %10;
+    return;
   }
   bb7 {
+    %8 = %10;
+    GOTO bb8;
+  }
+  bb8 {
+    decoded = %8;
+    %13 = == decoded original;
+    %14 = %13;
+    %15 = println(%14) -> bb9;
+  }
+  bb9 {
     return;
   }
 }

--- a/corpus/bir/library/subset3/http-client-databind-methods-v.txt
+++ b/corpus/bir/library/subset3/http-client-databind-methods-v.txt
@@ -7,326 +7,336 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newObject ballerina/http:Client
-    %6 = init(%5,$desugar$0,$desugar$1) -> bb2;
+    %6 = newObject ballerina/http:Client
+    %7 = init(%6,$desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    %8 = %6 is nil
-    %8 ? bb3 : bb4;
+    %9 = %7 is nil
+    %9 ? bb3 : bb4;
   }
   bb3 {
-    %7 = %5;
+    %8 = %6;
     GOTO bb5;
   }
   bb4 {
-    %7 = %6;
+    %8 = %7;
     GOTO bb5;
   }
   bb5 {
-    $desugar$2 = %7;
-    %10 = $desugar$2 is error
+    %10 = %8 is error
     %10 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb7 {
-    c = $desugar$2;
-    %12 = ConstantLoad /path
-    $desugar$3 = %12;
-    %14 = ConstantLoad req
-    $desugar$4 = %14;
-    %16 = $default$26($desugar$3,$desugar$4) -> bb8;
+    %5 = %8;
+    GOTO bb8;
   }
   bb8 {
-    $desugar$5 = %16;
-    %18 = $default$27($desugar$3,$desugar$4,$desugar$5) -> bb9;
+    c = %5;
+    %12 = ConstantLoad /path
+    $desugar$2 = %12;
+    %14 = ConstantLoad req
+    $desugar$3 = %14;
+    %16 = $default$26($desugar$2,$desugar$3) -> bb9;
   }
   bb9 {
-    $desugar$6 = %18;
-    %20 = ConstantLoad typedesc
-    $desugar$7 = %20;
-    %22 = $remote$post(c,$desugar$3,$desugar$4,$desugar$5,$desugar$6,$desugar$7) -> bb10;
+    $desugar$4 = %16;
+    %18 = $default$27($desugar$2,$desugar$3,$desugar$4) -> bb10;
   }
   bb10 {
-    $desugar$8 = %22;
-    %24 = $desugar$8 is error
-    %24 ? bb11 : bb12;
+    $desugar$5 = %18;
+    %20 = ConstantLoad typedesc
+    $desugar$6 = %20;
+    %23 = $remote$post(c,$desugar$2,$desugar$3,$desugar$4,$desugar$5,$desugar$6) -> bb11;
   }
   bb11 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    %24 = %23 is error
+    %24 ? bb12 : bb13;
   }
   bb12 {
-    postBody = $desugar$8;
-    %26 = println(postBody) -> bb13;
+    %0 = %23;
+    return;
   }
   bb13 {
-    %27 = ConstantLoad /path
-    $desugar$9 = %27;
-    %29 = ConstantLoad req
-    $desugar$10 = %29;
-    %31 = $default$28($desugar$9,$desugar$10) -> bb14;
+    %22 = %23;
+    GOTO bb14;
   }
   bb14 {
-    $desugar$11 = %31;
-    %33 = $default$29($desugar$9,$desugar$10,$desugar$11) -> bb15;
+    postBody = %22;
+    %26 = println(postBody) -> bb15;
   }
   bb15 {
-    $desugar$12 = %33;
-    %35 = ConstantLoad typedesc
-    $desugar$13 = %35;
-    %37 = $remote$put(c,$desugar$9,$desugar$10,$desugar$11,$desugar$12,$desugar$13) -> bb16;
+    %27 = ConstantLoad /path
+    $desugar$7 = %27;
+    %29 = ConstantLoad req
+    $desugar$8 = %29;
+    %31 = $default$28($desugar$7,$desugar$8) -> bb16;
   }
   bb16 {
-    $desugar$14 = %37;
-    %39 = $desugar$14 is error
-    %39 ? bb17 : bb18;
+    $desugar$9 = %31;
+    %33 = $default$29($desugar$7,$desugar$8,$desugar$9) -> bb17;
   }
   bb17 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
-    return;
+    $desugar$10 = %33;
+    %35 = ConstantLoad typedesc
+    $desugar$11 = %35;
+    %38 = $remote$put(c,$desugar$7,$desugar$8,$desugar$9,$desugar$10,$desugar$11) -> bb18;
   }
   bb18 {
-    putBody = $desugar$14;
-    %41 = println(putBody) -> bb19;
+    %39 = %38 is error
+    %39 ? bb19 : bb20;
   }
   bb19 {
-    %42 = ConstantLoad /path
-    $desugar$15 = %42;
-    %44 = ConstantLoad req
-    $desugar$16 = %44;
-    %46 = $default$24($desugar$15,$desugar$16) -> bb20;
+    %0 = %38;
+    return;
   }
   bb20 {
-    $desugar$17 = %46;
-    %48 = $default$25($desugar$15,$desugar$16,$desugar$17) -> bb21;
+    %37 = %38;
+    GOTO bb21;
   }
   bb21 {
-    $desugar$18 = %48;
-    %50 = ConstantLoad typedesc
-    $desugar$19 = %50;
-    %52 = $remote$patch(c,$desugar$15,$desugar$16,$desugar$17,$desugar$18,$desugar$19) -> bb22;
+    putBody = %37;
+    %41 = println(putBody) -> bb22;
   }
   bb22 {
-    $desugar$20 = %52;
-    %54 = $desugar$20 is error
-    %54 ? bb23 : bb24;
+    %42 = ConstantLoad /path
+    $desugar$12 = %42;
+    %44 = ConstantLoad req
+    $desugar$13 = %44;
+    %46 = $default$24($desugar$12,$desugar$13) -> bb23;
   }
   bb23 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
+    $desugar$14 = %46;
+    %48 = $default$25($desugar$12,$desugar$13,$desugar$14) -> bb24;
   }
   bb24 {
-    patchBody = $desugar$20;
-    %56 = println(patchBody) -> bb25;
+    $desugar$15 = %48;
+    %50 = ConstantLoad typedesc
+    $desugar$16 = %50;
+    %53 = $remote$patch(c,$desugar$12,$desugar$13,$desugar$14,$desugar$15,$desugar$16) -> bb25;
   }
   bb25 {
-    %57 = ConstantLoad /path
-    $desugar$21 = %57;
-    %59 = $default$16($desugar$21) -> bb26;
+    %54 = %53 is error
+    %54 ? bb26 : bb27;
   }
   bb26 {
-    $desugar$22 = %59;
-    %61 = $default$17($desugar$21,$desugar$22) -> bb27;
+    %0 = %53;
+    return;
   }
   bb27 {
-    $desugar$23 = %61;
-    %63 = $default$18($desugar$21,$desugar$22,$desugar$23) -> bb28;
+    %52 = %53;
+    GOTO bb28;
   }
   bb28 {
-    $desugar$24 = %63;
-    %65 = ConstantLoad typedesc
-    $desugar$25 = %65;
-    %67 = $remote$delete(c,$desugar$21,$desugar$22,$desugar$23,$desugar$24,$desugar$25) -> bb29;
+    patchBody = %52;
+    %56 = println(patchBody) -> bb29;
   }
   bb29 {
-    $desugar$26 = %67;
-    %69 = $desugar$26 is error
-    %69 ? bb30 : bb31;
+    %57 = ConstantLoad /path
+    $desugar$17 = %57;
+    %59 = $default$16($desugar$17) -> bb30;
   }
   bb30 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$26);
-    PopScopeFrame
-    return;
+    $desugar$18 = %59;
+    %61 = $default$17($desugar$17,$desugar$18) -> bb31;
   }
   bb31 {
-    deleteBody = $desugar$26;
-    %71 = println(deleteBody) -> bb32;
+    $desugar$19 = %61;
+    %63 = $default$18($desugar$17,$desugar$18,$desugar$19) -> bb32;
   }
   bb32 {
-    %72 = ConstantLoad /path
-    $desugar$27 = %72;
-    %74 = $default$23($desugar$27) -> bb33;
+    $desugar$20 = %63;
+    %65 = ConstantLoad typedesc
+    $desugar$21 = %65;
+    %68 = $remote$delete(c,$desugar$17,$desugar$18,$desugar$19,$desugar$20,$desugar$21) -> bb33;
   }
   bb33 {
-    $desugar$28 = %74;
-    %76 = ConstantLoad typedesc
-    $desugar$29 = %76;
-    %78 = $remote$options(c,$desugar$27,$desugar$28,$desugar$29) -> bb34;
+    %69 = %68 is error
+    %69 ? bb34 : bb35;
   }
   bb34 {
-    $desugar$30 = %78;
-    %80 = $desugar$30 is error
-    %80 ? bb35 : bb36;
+    %0 = %68;
+    return;
   }
   bb35 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$30);
-    PopScopeFrame
-    return;
+    %67 = %68;
+    GOTO bb36;
   }
   bb36 {
-    optionsBody = $desugar$30;
-    %82 = println(optionsBody) -> bb37;
+    deleteBody = %67;
+    %71 = println(deleteBody) -> bb37;
   }
   bb37 {
-    %83 = ConstantLoad PATCH
-    $desugar$31 = %83;
-    %85 = ConstantLoad /path
-    $desugar$32 = %85;
-    %87 = ConstantLoad req
-    $desugar$33 = %87;
-    %89 = $default$19($desugar$31,$desugar$32,$desugar$33) -> bb38;
+    %72 = ConstantLoad /path
+    $desugar$22 = %72;
+    %74 = $default$23($desugar$22) -> bb38;
   }
   bb38 {
-    $desugar$34 = %89;
-    %91 = $default$20($desugar$31,$desugar$32,$desugar$33,$desugar$34) -> bb39;
+    $desugar$23 = %74;
+    %76 = ConstantLoad typedesc
+    $desugar$24 = %76;
+    %79 = $remote$options(c,$desugar$22,$desugar$23,$desugar$24) -> bb39;
   }
   bb39 {
-    $desugar$35 = %91;
-    %93 = ConstantLoad typedesc
-    $desugar$36 = %93;
-    %95 = $remote$execute(c,$desugar$31,$desugar$32,$desugar$33,$desugar$34,$desugar$35,$desugar$36) -> bb40;
+    %80 = %79 is error
+    %80 ? bb40 : bb41;
   }
   bb40 {
-    $desugar$37 = %95;
-    %97 = $desugar$37 is error
-    %97 ? bb41 : bb42;
+    %0 = %79;
+    return;
   }
   bb41 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$37);
-    PopScopeFrame
-    return;
+    %78 = %79;
+    GOTO bb42;
   }
   bb42 {
-    execBody = $desugar$37;
-    %99 = println(execBody) -> bb43;
+    optionsBody = %78;
+    %82 = println(optionsBody) -> bb43;
   }
   bb43 {
-    %100 = newObject ballerina/http:Request
-    %101 = init(%100) -> bb44;
+    %83 = ConstantLoad PATCH
+    $desugar$25 = %83;
+    %85 = ConstantLoad /path
+    $desugar$26 = %85;
+    %87 = ConstantLoad req
+    $desugar$27 = %87;
+    %89 = $default$19($desugar$25,$desugar$26,$desugar$27) -> bb44;
   }
   bb44 {
-    %103 = %101 is nil
-    %103 ? bb45 : bb46;
+    $desugar$28 = %89;
+    %91 = $default$20($desugar$25,$desugar$26,$desugar$27,$desugar$28) -> bb45;
   }
   bb45 {
-    %102 = %100;
-    GOTO bb47;
+    $desugar$29 = %91;
+    %93 = ConstantLoad typedesc
+    $desugar$30 = %93;
+    %96 = $remote$execute(c,$desugar$25,$desugar$26,$desugar$27,$desugar$28,$desugar$29,$desugar$30) -> bb46;
   }
   bb46 {
-    %102 = %101;
-    GOTO bb47;
+    %97 = %96 is error
+    %97 ? bb47 : bb48;
   }
   bb47 {
-    req = %102;
-    %105 = ConstantLoad fwd
-    $desugar$38 = %105;
-    %107 = $default$12($desugar$38) -> bb48;
+    %0 = %96;
+    return;
   }
   bb48 {
-    $desugar$39 = %107;
-    %109 = setTextPayload(req,$desugar$38,$desugar$39) -> bb49;
+    %95 = %96;
+    GOTO bb49;
   }
   bb49 {
-    %110 = ConstantLoad /path
-    %111 = ConstantLoad typedesc
-    %112 = $remote$forward(c,%110,req,%111) -> bb50;
+    execBody = %95;
+    %99 = println(execBody) -> bb50;
   }
   bb50 {
-    $desugar$40 = %112;
-    %114 = $desugar$40 is error
-    %114 ? bb51 : bb52;
+    %100 = newObject ballerina/http:Request
+    %101 = init(%100) -> bb51;
   }
   bb51 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$40);
-    PopScopeFrame
-    return;
+    %103 = %101 is nil
+    %103 ? bb52 : bb53;
   }
   bb52 {
-    forwardBody = $desugar$40;
-    %116 = println(forwardBody) -> bb53;
+    %102 = %100;
+    GOTO bb54;
   }
   bb53 {
-    %117 = ConstantLoad /path
-    $desugar$41 = %117;
-    %119 = $default$22($desugar$41) -> bb54;
+    %102 = %101;
+    GOTO bb54;
   }
   bb54 {
-    $desugar$42 = %119;
-    %121 = $remote$head(c,$desugar$41,$desugar$42) -> bb55;
+    req = %102;
+    %105 = ConstantLoad fwd
+    $desugar$31 = %105;
+    %107 = $default$12($desugar$31) -> bb55;
   }
   bb55 {
-    $desugar$43 = %121;
-    %123 = $desugar$43 is error
-    %123 ? bb56 : bb57;
+    $desugar$32 = %107;
+    %109 = setTextPayload(req,$desugar$31,$desugar$32) -> bb56;
   }
   bb56 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$43);
-    PopScopeFrame
-    return;
+    %111 = ConstantLoad /path
+    %112 = ConstantLoad typedesc
+    %113 = $remote$forward(c,%111,req,%112) -> bb57;
   }
   bb57 {
-    headResp = $desugar$43;
+    %114 = %113 is error
+    %114 ? bb58 : bb59;
+  }
+  bb58 {
+    %0 = %113;
+    return;
+  }
+  bb59 {
+    %110 = %113;
+    GOTO bb60;
+  }
+  bb60 {
+    forwardBody = %110;
+    %116 = println(forwardBody) -> bb61;
+  }
+  bb61 {
+    %117 = ConstantLoad /path
+    $desugar$33 = %117;
+    %119 = $default$22($desugar$33) -> bb62;
+  }
+  bb62 {
+    $desugar$34 = %119;
+    %122 = $remote$head(c,$desugar$33,$desugar$34) -> bb63;
+  }
+  bb63 {
+    %123 = %122 is error
+    %123 ? bb64 : bb65;
+  }
+  bb64 {
+    %0 = %122;
+    return;
+  }
+  bb65 {
+    %121 = %122;
+    GOTO bb66;
+  }
+  bb66 {
+    headResp = %121;
     %126 = ConstantLoad statusCode
     %125 = headResp[%126];
     %127 = %125;
-    %128 = println(%127) -> bb58;
+    %128 = println(%127) -> bb67;
   }
-  bb58 {
-    %129 = ConstantLoad /path
-    %130 = ConstantLoad req
-    %131 = ConstantLoad X-Custom
-    %132 = ConstantLoad value
-    %133 = newMap {| string|[string...]... |}{%131=%132}
-    %134 = ConstantLoad text/plain
-    %135 = ConstantLoad typedesc
-    %136 = $remote$post(c,%129,%130,%133,%134,%135) -> bb59;
+  bb67 {
+    %130 = ConstantLoad /path
+    %131 = ConstantLoad req
+    %132 = ConstantLoad X-Custom
+    %133 = ConstantLoad value
+    %134 = newMap {| string|[string...]... |}{%132=%133}
+    %135 = ConstantLoad text/plain
+    %136 = ConstantLoad typedesc
+    %137 = $remote$post(c,%130,%131,%134,%135,%136) -> bb68;
   }
-  bb59 {
-    $desugar$44 = %136;
-    %138 = $desugar$44 is error
-    %138 ? bb60 : bb61;
+  bb68 {
+    %138 = %137 is error
+    %138 ? bb69 : bb70;
   }
-  bb60 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$44);
-    PopScopeFrame
+  bb69 {
+    %0 = %137;
     return;
   }
-  bb61 {
-    withHeaders = $desugar$44;
-    %140 = length(withHeaders) -> bb62;
+  bb70 {
+    %129 = %137;
+    GOTO bb71;
   }
-  bb62 {
+  bb71 {
+    withHeaders = %129;
+    %140 = length(withHeaders) -> bb72;
+  }
+  bb72 {
     %141 = %140;
-    %142 = println(%141) -> bb63;
+    %142 = println(%141) -> bb73;
   }
-  bb63 {
+  bb73 {
     %143 = ConstantLoad <nil>
     %0 = %143;
     return;

--- a/corpus/bir/library/subset3/http-client-databind-v.txt
+++ b/corpus/bir/library/subset3/http-client-databind-v.txt
@@ -7,288 +7,297 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = newObject ballerina/http:Client
-    %6 = init(%5,$desugar$0,$desugar$1) -> bb2;
+    %6 = newObject ballerina/http:Client
+    %7 = init(%6,$desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    %8 = %6 is nil
-    %8 ? bb3 : bb4;
+    %9 = %7 is nil
+    %9 ? bb3 : bb4;
   }
   bb3 {
-    %7 = %5;
+    %8 = %6;
     GOTO bb5;
   }
   bb4 {
-    %7 = %6;
+    %8 = %7;
     GOTO bb5;
   }
   bb5 {
-    $desugar$2 = %7;
-    %10 = $desugar$2 is error
+    %10 = %8 is error
     %10 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb7 {
-    c = $desugar$2;
-    %12 = ConstantLoad /path
-    $desugar$3 = %12;
-    %14 = $default$21($desugar$3) -> bb8;
+    %5 = %8;
+    GOTO bb8;
   }
   bb8 {
-    $desugar$4 = %14;
-    %16 = ConstantLoad typedesc
-    $desugar$5 = %16;
-    %18 = $remote$get(c,$desugar$3,$desugar$4,$desugar$5) -> bb9;
+    c = %5;
+    %12 = ConstantLoad /path
+    $desugar$2 = %12;
+    %14 = $default$21($desugar$2) -> bb9;
   }
   bb9 {
-    $desugar$6 = %18;
-    %20 = $desugar$6 is error
-    %20 ? bb10 : bb11;
+    $desugar$3 = %14;
+    %16 = ConstantLoad typedesc
+    $desugar$4 = %16;
+    %19 = $remote$get(c,$desugar$2,$desugar$3,$desugar$4) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    %20 = %19 is error
+    %20 ? bb11 : bb12;
   }
   bb11 {
-    r = $desugar$6;
+    %0 = %19;
+    return;
+  }
+  bb12 {
+    %18 = %19;
+    GOTO bb13;
+  }
+  bb13 {
+    r = %18;
     %23 = ConstantLoad statusCode
     %22 = r[%23];
     %24 = %22;
-    %25 = println(%24) -> bb12;
-  }
-  bb12 {
-    %26 = ConstantLoad /path
-    $desugar$7 = %26;
-    %28 = $default$21($desugar$7) -> bb13;
-  }
-  bb13 {
-    $desugar$8 = %28;
-    %30 = ConstantLoad typedesc
-    $desugar$9 = %30;
-    %32 = $remote$get(c,$desugar$7,$desugar$8,$desugar$9) -> bb14;
+    %25 = println(%24) -> bb14;
   }
   bb14 {
-    $desugar$10 = %32;
-    %34 = $desugar$10 is error
-    %34 ? bb15 : bb16;
+    %26 = ConstantLoad /path
+    $desugar$5 = %26;
+    %28 = $default$21($desugar$5) -> bb15;
   }
   bb15 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
-    return;
+    $desugar$6 = %28;
+    %30 = ConstantLoad typedesc
+    $desugar$7 = %30;
+    %33 = $remote$get(c,$desugar$5,$desugar$6,$desugar$7) -> bb16;
   }
   bb16 {
-    ru = $desugar$10;
-    %36 = ru is string
-    %37 = %36;
-    %38 = println(%37) -> bb17;
+    %34 = %33 is error
+    %34 ? bb17 : bb18;
   }
   bb17 {
-    %39 = ConstantLoad /path
-    $desugar$11 = %39;
-    %41 = $default$21($desugar$11) -> bb18;
+    %0 = %33;
+    return;
   }
   bb18 {
-    $desugar$12 = %41;
-    %43 = ConstantLoad typedesc
-    $desugar$13 = %43;
-    %45 = $remote$get(c,$desugar$11,$desugar$12,$desugar$13) -> bb19;
+    %32 = %33;
+    GOTO bb19;
   }
   bb19 {
-    $desugar$14 = %45;
-    %47 = $desugar$14 is error
-    %47 ? bb20 : bb21;
+    ru = %32;
+    %36 = ru is string
+    %37 = %36;
+    %38 = println(%37) -> bb20;
   }
   bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
-    return;
+    %39 = ConstantLoad /path
+    $desugar$8 = %39;
+    %41 = $default$21($desugar$8) -> bb21;
   }
   bb21 {
-    text = $desugar$14;
-    %49 = println(text) -> bb22;
+    $desugar$9 = %41;
+    %43 = ConstantLoad typedesc
+    $desugar$10 = %43;
+    %46 = $remote$get(c,$desugar$8,$desugar$9,$desugar$10) -> bb22;
   }
   bb22 {
-    %50 = ConstantLoad /path
-    $desugar$15 = %50;
-    %52 = $default$21($desugar$15) -> bb23;
+    %47 = %46 is error
+    %47 ? bb23 : bb24;
   }
   bb23 {
-    $desugar$16 = %52;
-    %54 = ConstantLoad typedesc
-    $desugar$17 = %54;
-    %56 = $remote$get(c,$desugar$15,$desugar$16,$desugar$17) -> bb24;
+    %0 = %46;
+    return;
   }
   bb24 {
-    $desugar$18 = %56;
-    %58 = $desugar$18 is error
-    %58 ? bb25 : bb26;
+    %45 = %46;
+    GOTO bb25;
   }
   bb25 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
-    return;
+    text = %45;
+    %49 = println(text) -> bb26;
   }
   bb26 {
-    optText = $desugar$18;
-    %60 = println(optText) -> bb27;
+    %50 = ConstantLoad /path
+    $desugar$11 = %50;
+    %52 = $default$21($desugar$11) -> bb27;
   }
   bb27 {
-    %61 = ConstantLoad /path
-    $desugar$19 = %61;
-    %63 = $default$21($desugar$19) -> bb28;
+    $desugar$12 = %52;
+    %54 = ConstantLoad typedesc
+    $desugar$13 = %54;
+    %57 = $remote$get(c,$desugar$11,$desugar$12,$desugar$13) -> bb28;
   }
   bb28 {
-    $desugar$20 = %63;
-    %65 = ConstantLoad typedesc
-    $desugar$21 = %65;
-    %67 = $remote$get(c,$desugar$19,$desugar$20,$desugar$21) -> bb29;
+    %58 = %57 is error
+    %58 ? bb29 : bb30;
   }
   bb29 {
-    $desugar$22 = %67;
-    %69 = $desugar$22 is error
-    %69 ? bb30 : bb31;
+    %0 = %57;
+    return;
   }
   bb30 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
-    return;
+    %56 = %57;
+    GOTO bb31;
   }
   bb31 {
-    bytes = $desugar$22;
-    %71 = length(bytes) -> bb32;
+    optText = %56;
+    %60 = println(optText) -> bb32;
   }
   bb32 {
-    %72 = %71;
-    %73 = println(%72) -> bb33;
+    %61 = ConstantLoad /path
+    $desugar$14 = %61;
+    %63 = $default$21($desugar$14) -> bb33;
   }
   bb33 {
-    %74 = ConstantLoad /path
-    $desugar$23 = %74;
-    %76 = $default$21($desugar$23) -> bb34;
+    $desugar$15 = %63;
+    %65 = ConstantLoad typedesc
+    $desugar$16 = %65;
+    %68 = $remote$get(c,$desugar$14,$desugar$15,$desugar$16) -> bb34;
   }
   bb34 {
-    $desugar$24 = %76;
-    %78 = ConstantLoad typedesc
-    $desugar$25 = %78;
-    %80 = $remote$get(c,$desugar$23,$desugar$24,$desugar$25) -> bb35;
+    %69 = %68 is error
+    %69 ? bb35 : bb36;
   }
   bb35 {
-    $desugar$26 = %80;
-    %82 = $desugar$26 is error
-    %82 ? bb36 : bb37;
+    %0 = %68;
+    return;
   }
   bb36 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$26);
-    PopScopeFrame
-    return;
+    %67 = %68;
+    GOTO bb37;
   }
   bb37 {
-    optBytes = $desugar$26;
-    %84 = optBytes is [int:Unsigned8...]
-    %85 = %84;
-    %86 = println(%85) -> bb38;
+    bytes = %67;
+    %71 = length(bytes) -> bb38;
   }
   bb38 {
-    %87 = ConstantLoad /path
-    $desugar$27 = %87;
-    %89 = $default$21($desugar$27) -> bb39;
+    %72 = %71;
+    %73 = println(%72) -> bb39;
   }
   bb39 {
-    $desugar$28 = %89;
-    %91 = ConstantLoad typedesc
-    $desugar$29 = %91;
-    %93 = $remote$get(c,$desugar$27,$desugar$28,$desugar$29) -> bb40;
+    %74 = ConstantLoad /path
+    $desugar$17 = %74;
+    %76 = $default$21($desugar$17) -> bb40;
   }
   bb40 {
-    $desugar$30 = %93;
-    %95 = $desugar$30 is error
-    %95 ? bb41 : bb42;
+    $desugar$18 = %76;
+    %78 = ConstantLoad typedesc
+    $desugar$19 = %78;
+    %81 = $remote$get(c,$desugar$17,$desugar$18,$desugar$19) -> bb41;
   }
   bb41 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$30);
-    PopScopeFrame
-    return;
+    %82 = %81 is error
+    %82 ? bb42 : bb43;
   }
   bb42 {
-    nothing = $desugar$30;
-    %97 = nothing;
-    %98 = println(%97) -> bb43;
-  }
-  bb43 {
-    %99 = ConstantLoad /path
-    $desugar$31 = %99;
-    %101 = $default$21($desugar$31) -> bb44;
-  }
-  bb44 {
-    $desugar$32 = %101;
-    %103 = ConstantLoad typedesc
-    $desugar$33 = %103;
-    %105 = $remote$get(c,$desugar$31,$desugar$32,$desugar$33) -> bb45;
-  }
-  bb45 {
-    $desugar$34 = %105;
-    %107 = $desugar$34 is error
-    %107 ? bb46 : bb47;
-  }
-  bb46 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$34);
-    PopScopeFrame
+    %0 = %81;
     return;
   }
+  bb43 {
+    %80 = %81;
+    GOTO bb44;
+  }
+  bb44 {
+    optBytes = %80;
+    %84 = optBytes is [int:Unsigned8...]
+    %85 = %84;
+    %86 = println(%85) -> bb45;
+  }
+  bb45 {
+    %87 = ConstantLoad /path
+    $desugar$20 = %87;
+    %89 = $default$21($desugar$20) -> bb46;
+  }
+  bb46 {
+    $desugar$21 = %89;
+    %91 = ConstantLoad typedesc
+    $desugar$22 = %91;
+    %94 = $remote$get(c,$desugar$20,$desugar$21,$desugar$22) -> bb47;
+  }
   bb47 {
-    explicitText = $desugar$34;
-    %109 = println(explicitText) -> bb48;
+    %95 = %94 is error
+    %95 ? bb48 : bb49;
   }
   bb48 {
-    %110 = ConstantLoad /path
-    $desugar$35 = %110;
-    %112 = $default$21($desugar$35) -> bb49;
+    %0 = %94;
+    return;
   }
   bb49 {
-    $desugar$36 = %112;
-    %114 = ConstantLoad typedesc
-    $desugar$37 = %114;
-    %116 = $remote$get(c,$desugar$35,$desugar$36,$desugar$37) -> bb50;
+    %93 = %94;
+    GOTO bb50;
   }
   bb50 {
+    nothing = %93;
+    %97 = nothing;
+    %98 = println(%97) -> bb51;
+  }
+  bb51 {
+    %99 = ConstantLoad /path
+    $desugar$23 = %99;
+    %101 = $default$21($desugar$23) -> bb52;
+  }
+  bb52 {
+    $desugar$24 = %101;
+    %103 = ConstantLoad typedesc
+    $desugar$25 = %103;
+    %106 = $remote$get(c,$desugar$23,$desugar$24,$desugar$25) -> bb53;
+  }
+  bb53 {
+    %107 = %106 is error
+    %107 ? bb54 : bb55;
+  }
+  bb54 {
+    %0 = %106;
+    return;
+  }
+  bb55 {
+    %105 = %106;
+    GOTO bb56;
+  }
+  bb56 {
+    explicitText = %105;
+    %109 = println(explicitText) -> bb57;
+  }
+  bb57 {
+    %110 = ConstantLoad /path
+    $desugar$26 = %110;
+    %112 = $default$21($desugar$26) -> bb58;
+  }
+  bb58 {
+    $desugar$27 = %112;
+    %114 = ConstantLoad typedesc
+    $desugar$28 = %114;
+    %116 = $remote$get(c,$desugar$26,$desugar$27,$desugar$28) -> bb59;
+  }
+  bb59 {
     person = %116;
     %118 = person is error
     %119 = %118;
-    %120 = println(%119) -> bb51;
+    %120 = println(%119) -> bb60;
   }
-  bb51 {
+  bb60 {
     %121 = ConstantLoad /path
-    $desugar$38 = %121;
-    %123 = $default$21($desugar$38) -> bb52;
+    $desugar$29 = %121;
+    %123 = $default$21($desugar$29) -> bb61;
   }
-  bb52 {
-    $desugar$39 = %123;
+  bb61 {
+    $desugar$30 = %123;
     %125 = ConstantLoad typedesc
-    $desugar$40 = %125;
-    %127 = $remote$get(c,$desugar$38,$desugar$39,$desugar$40) -> bb53;
+    $desugar$31 = %125;
+    %127 = $remote$get(c,$desugar$29,$desugar$30,$desugar$31) -> bb62;
   }
-  bb53 {
+  bb62 {
     asXml = %127;
     %129 = asXml is error
     %130 = %129;
-    %131 = println(%130) -> bb54;
+    %131 = println(%130) -> bb63;
   }
-  bb54 {
+  bb63 {
     %132 = ConstantLoad <nil>
     %0 = %132;
     return;

--- a/corpus/bir/library/subset3/io-byte-channel-base64-p.txt
+++ b/corpus/bir/library/subset3/io-byte-channel-base64-p.txt
@@ -1,57 +1,60 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 33
-    %2 = ConstantLoad 64
-    %3 = ConstantLoad 35
-    %4 = ConstantLoad 36
-    %5 = ConstantLoad 4
-    %6 = newArray [int:Unsigned8...][%5]{%1, %2, %3, %4}
-    %7 = createReadableChannel(%6) -> bb1;
+    %2 = ConstantLoad 33
+    %3 = ConstantLoad 64
+    %4 = ConstantLoad 35
+    %5 = ConstantLoad 36
+    %6 = ConstantLoad 4
+    %7 = newArray [int:Unsigned8...][%6]{%2, %3, %4, %5}
+    %8 = createReadableChannel(%7) -> bb1;
   }
   bb1 {
-    $desugar$0 = %7;
-    %9 = $desugar$0 is error
+    %9 = %8 is error
     %9 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb3 {
-    bad = $desugar$0;
-    %11 = base64Decode(bad) -> bb4;
+    %1 = %8;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$1 = %11;
-    %13 = $desugar$1 is error
-    %13 ? bb5 : bb6;
+    bad = %1;
+    %12 = base64Decode(bad) -> bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %13 = %12 is error
+    %13 ? bb6 : bb7;
   }
   bb6 {
-    dec = $desugar$1;
-    %15 = readAll(dec) -> bb7;
-  }
-  bb7 {
-    $desugar$2 = %15;
-    %17 = $desugar$2 is error
-    %17 ? bb8 : bb9;
-  }
-  bb8 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %12;
     return;
   }
+  bb7 {
+    %11 = %12;
+    GOTO bb8;
+  }
+  bb8 {
+    dec = %11;
+    %16 = readAll(dec) -> bb9;
+  }
   bb9 {
-    _ = $desugar$2;
+    %17 = %16 is error
+    %17 ? bb10 : bb11;
+  }
+  bb10 {
+    %0 = %16;
+    return;
+  }
+  bb11 {
+    %15 = %16;
+    GOTO bb12;
+  }
+  bb12 {
+    _ = %15;
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-byte-channel-base64-v.txt
+++ b/corpus/bir/library/subset3/io-byte-channel-base64-v.txt
@@ -1,415 +1,437 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 72
-    %2 = ConstantLoad 105
-    %3 = ConstantLoad 33
-    %4 = ConstantLoad 3
-    %5 = newArray [int:Unsigned8...][%4]{%1, %2, %3}
-    %6 = createReadableChannel(%5) -> bb1;
+    %2 = ConstantLoad 72
+    %3 = ConstantLoad 105
+    %4 = ConstantLoad 33
+    %5 = ConstantLoad 3
+    %6 = newArray [int:Unsigned8...][%5]{%2, %3, %4}
+    %7 = createReadableChannel(%6) -> bb1;
   }
   bb1 {
-    $desugar$0 = %6;
-    %8 = $desugar$0 is error
+    %8 = %7 is error
     %8 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %7;
     return;
   }
   bb3 {
-    src = $desugar$0;
-    %10 = base64Encode(src) -> bb4;
+    %1 = %7;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$1 = %10;
-    %12 = $desugar$1 is error
-    %12 ? bb5 : bb6;
+    src = %1;
+    %11 = base64Encode(src) -> bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %12 = %11 is error
+    %12 ? bb6 : bb7;
   }
   bb6 {
-    enc = $desugar$1;
-    %14 = readAll(enc) -> bb7;
+    %0 = %11;
+    return;
   }
   bb7 {
-    $desugar$2 = %14;
-    %16 = $desugar$2 is error
-    %16 ? bb8 : bb9;
+    %10 = %11;
+    GOTO bb8;
   }
   bb8 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    enc = %10;
+    %15 = readAll(enc) -> bb9;
   }
   bb9 {
-    encBytes = $desugar$2;
-    %18 = fromBytes(encBytes) -> bb10;
+    %16 = %15 is error
+    %16 ? bb10 : bb11;
   }
   bb10 {
-    $desugar$3 = %18;
-    %20 = $desugar$3 is error
-    %20 ? bb11 : bb12;
+    %0 = %15;
+    return;
   }
   bb11 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %14 = %15;
+    GOTO bb12;
   }
   bb12 {
-    %21 = println($desugar$3) -> bb13;
+    encBytes = %14;
+    %19 = fromBytes(encBytes) -> bb13;
   }
   bb13 {
-    %22 = createReadableChannel(encBytes) -> bb14;
+    %20 = %19 is error
+    %20 ? bb14 : bb15;
   }
   bb14 {
-    $desugar$4 = %22;
-    %24 = $desugar$4 is error
-    %24 ? bb15 : bb16;
+    %0 = %19;
+    return;
   }
   bb15 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %18 = %19;
+    GOTO bb16;
   }
   bb16 {
-    back = $desugar$4;
-    %26 = base64Decode(back) -> bb17;
+    %21 = println(%18) -> bb17;
   }
   bb17 {
-    $desugar$5 = %26;
-    %28 = $desugar$5 is error
-    %28 ? bb18 : bb19;
+    %23 = createReadableChannel(encBytes) -> bb18;
   }
   bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %24 = %23 is error
+    %24 ? bb19 : bb20;
   }
   bb19 {
-    dec = $desugar$5;
-    %30 = readAll(dec) -> bb20;
+    %0 = %23;
+    return;
   }
   bb20 {
-    $desugar$6 = %30;
-    %32 = $desugar$6 is error
-    %32 ? bb21 : bb22;
+    %22 = %23;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    back = %22;
+    %27 = base64Decode(back) -> bb22;
   }
   bb22 {
-    decBytes = $desugar$6;
-    %34 = fromBytes(decBytes) -> bb23;
+    %28 = %27 is error
+    %28 ? bb23 : bb24;
   }
   bb23 {
-    $desugar$7 = %34;
-    %36 = $desugar$7 is error
-    %36 ? bb24 : bb25;
+    %0 = %27;
+    return;
   }
   bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    %26 = %27;
+    GOTO bb25;
   }
   bb25 {
-    %37 = println($desugar$7) -> bb26;
+    dec = %26;
+    %31 = readAll(dec) -> bb26;
   }
   bb26 {
-    %38 = base64Encode(src) -> bb27;
+    %32 = %31 is error
+    %32 ? bb27 : bb28;
   }
   bb27 {
-    $desugar$8 = %38;
-    %40 = $desugar$8 is error
-    %40 ? bb28 : bb29;
-  }
-  bb28 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
+    %0 = %31;
     return;
   }
+  bb28 {
+    %30 = %31;
+    GOTO bb29;
+  }
   bb29 {
-    drainedEnc = $desugar$8;
-    %42 = readAll(drainedEnc) -> bb30;
+    decBytes = %30;
+    %35 = fromBytes(decBytes) -> bb30;
   }
   bb30 {
-    $desugar$9 = %42;
-    %44 = $desugar$9 is error
-    %44 ? bb31 : bb32;
+    %36 = %35 is error
+    %36 ? bb31 : bb32;
   }
   bb31 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %35;
     return;
   }
   bb32 {
-    emptyBytes = $desugar$9;
-    %46 = length(emptyBytes) -> bb33;
+    %34 = %35;
+    GOTO bb33;
   }
   bb33 {
-    %47 = %46;
-    %48 = println(%47) -> bb34;
+    %37 = println(%34) -> bb34;
   }
   bb34 {
-    %49 = ConstantLoad 83
-    %50 = ConstantLoad 71
-    %51 = ConstantLoad 107
-    %52 = ConstantLoad 3
-    %53 = newArray [int:Unsigned8...][%52]{%49, %50, %51}
-    %54 = createReadableChannel(%53) -> bb35;
+    %39 = base64Encode(src) -> bb35;
   }
   bb35 {
-    $desugar$10 = %54;
-    %56 = $desugar$10 is error
-    %56 ? bb36 : bb37;
+    %40 = %39 is error
+    %40 ? bb36 : bb37;
   }
   bb36 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
+    %0 = %39;
     return;
   }
   bb37 {
-    unpadded = $desugar$10;
-    %58 = base64Decode(unpadded) -> bb38;
+    %38 = %39;
+    GOTO bb38;
   }
   bb38 {
-    $desugar$11 = %58;
-    %60 = $desugar$11 is error
-    %60 ? bb39 : bb40;
+    drainedEnc = %38;
+    %43 = readAll(drainedEnc) -> bb39;
   }
   bb39 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
-    return;
+    %44 = %43 is error
+    %44 ? bb40 : bb41;
   }
   bb40 {
-    dec2 = $desugar$11;
-    %62 = readAll(dec2) -> bb41;
+    %0 = %43;
+    return;
   }
   bb41 {
-    $desugar$12 = %62;
-    %64 = $desugar$12 is error
-    %64 ? bb42 : bb43;
+    %42 = %43;
+    GOTO bb42;
   }
   bb42 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$12);
-    PopScopeFrame
-    return;
+    emptyBytes = %42;
+    %46 = length(emptyBytes) -> bb43;
   }
   bb43 {
-    unpaddedBytes = $desugar$12;
-    %66 = fromBytes(unpaddedBytes) -> bb44;
+    %47 = %46;
+    %48 = println(%47) -> bb44;
   }
   bb44 {
-    $desugar$13 = %66;
-    %68 = $desugar$13 is error
-    %68 ? bb45 : bb46;
+    %50 = ConstantLoad 83
+    %51 = ConstantLoad 71
+    %52 = ConstantLoad 107
+    %53 = ConstantLoad 3
+    %54 = newArray [int:Unsigned8...][%53]{%50, %51, %52}
+    %55 = createReadableChannel(%54) -> bb45;
   }
   bb45 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
-    return;
+    %56 = %55 is error
+    %56 ? bb46 : bb47;
   }
   bb46 {
-    %69 = println($desugar$13) -> bb47;
+    %0 = %55;
+    return;
   }
   bb47 {
+    %49 = %55;
+    GOTO bb48;
+  }
+  bb48 {
+    unpadded = %49;
+    %59 = base64Decode(unpadded) -> bb49;
+  }
+  bb49 {
+    %60 = %59 is error
+    %60 ? bb50 : bb51;
+  }
+  bb50 {
+    %0 = %59;
+    return;
+  }
+  bb51 {
+    %58 = %59;
+    GOTO bb52;
+  }
+  bb52 {
+    dec2 = %58;
+    %63 = readAll(dec2) -> bb53;
+  }
+  bb53 {
+    %64 = %63 is error
+    %64 ? bb54 : bb55;
+  }
+  bb54 {
+    %0 = %63;
+    return;
+  }
+  bb55 {
+    %62 = %63;
+    GOTO bb56;
+  }
+  bb56 {
+    unpaddedBytes = %62;
+    %67 = fromBytes(unpaddedBytes) -> bb57;
+  }
+  bb57 {
+    %68 = %67 is error
+    %68 ? bb58 : bb59;
+  }
+  bb58 {
+    %0 = %67;
+    return;
+  }
+  bb59 {
+    %66 = %67;
+    GOTO bb60;
+  }
+  bb60 {
+    %69 = println(%66) -> bb61;
+  }
+  bb61 {
     %70 = ConstantLoad /tmp/bal_io_byte_channel_base64.bin
     path = %70;
-    $desugar$14 = path;
+    $desugar$0 = path;
     %73 = ConstantLoad 72
     %74 = ConstantLoad 105
     %75 = ConstantLoad 33
     %76 = ConstantLoad 3
     %77 = newArray [int:Unsigned8...][%76]{%73, %74, %75}
-    $desugar$15 = %77;
-    %79 = $default$4($desugar$14,$desugar$15) -> bb48;
-  }
-  bb48 {
-    $desugar$16 = %79;
-    %81 = fileWriteBytes($desugar$14,$desugar$15,$desugar$16) -> bb49;
-  }
-  bb49 {
-    $desugar$17 = %81;
-    %83 = $desugar$17 is error
-    %83 ? bb50 : bb51;
-  }
-  bb50 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
-    return;
-  }
-  bb51 {
-    %84 = openReadableFile(path) -> bb52;
-  }
-  bb52 {
-    $desugar$18 = %84;
-    %86 = $desugar$18 is error
-    %86 ? bb53 : bb54;
-  }
-  bb53 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
-    return;
-  }
-  bb54 {
-    fileCh = $desugar$18;
-    %88 = base64Encode(fileCh) -> bb55;
-  }
-  bb55 {
-    $desugar$19 = %88;
-    %90 = $desugar$19 is error
-    %90 ? bb56 : bb57;
-  }
-  bb56 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$19);
-    PopScopeFrame
-    return;
-  }
-  bb57 {
-    fileEnc = $desugar$19;
-    %92 = readAll(fileEnc) -> bb58;
-  }
-  bb58 {
-    $desugar$20 = %92;
-    %94 = $desugar$20 is error
-    %94 ? bb59 : bb60;
-  }
-  bb59 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
-  }
-  bb60 {
-    fileEncBytes = $desugar$20;
-    %96 = fromBytes(fileEncBytes) -> bb61;
-  }
-  bb61 {
-    $desugar$21 = %96;
-    %98 = $desugar$21 is error
-    %98 ? bb62 : bb63;
+    $desugar$1 = %77;
+    %79 = $default$4($desugar$0,$desugar$1) -> bb62;
   }
   bb62 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$21);
-    PopScopeFrame
-    return;
+    $desugar$2 = %79;
+    %82 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb63;
   }
   bb63 {
-    %99 = println($desugar$21) -> bb64;
+    %83 = %82 is error
+    %83 ? bb64 : bb65;
   }
   bb64 {
-    %100 = close(fileCh) -> bb65;
+    %0 = %82;
+    return;
   }
   bb65 {
-    $desugar$22 = %100;
-    %102 = $desugar$22 is error
-    %102 ? bb66 : bb67;
+    %81 = %82;
+    GOTO bb66;
   }
   bb66 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
-    return;
+    %85 = openReadableFile(path) -> bb67;
   }
   bb67 {
-    %103 = ConstantLoad 1
-    %104 = ConstantLoad 2
-    %105 = ConstantLoad 3
-    %106 = ConstantLoad 3
-    %107 = newArray [int:Unsigned8...][%106]{%103, %104, %105}
-    %108 = createReadableChannel(%107) -> bb68;
+    %86 = %85 is error
+    %86 ? bb68 : bb69;
   }
   bb68 {
-    $desugar$23 = %108;
-    %110 = $desugar$23 is error
-    %110 ? bb69 : bb70;
-  }
-  bb69 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$23);
-    PopScopeFrame
+    %0 = %85;
     return;
   }
+  bb69 {
+    %84 = %85;
+    GOTO bb70;
+  }
   bb70 {
-    closedCh = $desugar$23;
-    %112 = close(closedCh) -> bb71;
+    fileCh = %84;
+    %89 = base64Encode(fileCh) -> bb71;
   }
   bb71 {
-    $desugar$24 = %112;
-    %114 = $desugar$24 is error
-    %114 ? bb72 : bb73;
+    %90 = %89 is error
+    %90 ? bb72 : bb73;
   }
   bb72 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$24);
-    PopScopeFrame
+    %0 = %89;
     return;
   }
   bb73 {
-    %115 = base64Encode(closedCh) -> bb74;
+    %88 = %89;
+    GOTO bb74;
   }
   bb74 {
-    encClosed = %115;
-    %117 = encClosed is error
-    %117 ? bb75 : bb78;
+    fileEnc = %88;
+    %93 = readAll(fileEnc) -> bb75;
   }
   bb75 {
-    PushScopeFrame 2
-    %0 = message((1, encClosed)) -> bb76;
+    %94 = %93 is error
+    %94 ? bb76 : bb77;
   }
   bb76 {
-    %1 = println(%0) -> bb77;
+    %0 = %93;
+    return;
   }
   bb77 {
-    PopScopeFrame
+    %92 = %93;
     GOTO bb78;
   }
   bb78 {
-    PushScopeFrame 3
-    %0 = base64Decode((1, closedCh)) -> bb79;
+    fileEncBytes = %92;
+    %97 = fromBytes(fileEncBytes) -> bb79;
   }
   bb79 {
-    decClosed = %0;
-    %2 = decClosed is error
-    %2 ? bb80 : bb83;
+    %98 = %97 is error
+    %98 ? bb80 : bb81;
   }
   bb80 {
-    PushScopeFrame 2
-    %0 = message((1, decClosed)) -> bb81;
+    %0 = %97;
+    return;
   }
   bb81 {
-    %1 = println(%0) -> bb82;
+    %96 = %97;
+    GOTO bb82;
   }
   bb82 {
-    PopScopeFrame
-    GOTO bb83;
+    %99 = println(%96) -> bb83;
   }
   bb83 {
+    %101 = close(fileCh) -> bb84;
+  }
+  bb84 {
+    %102 = %101 is error
+    %102 ? bb85 : bb86;
+  }
+  bb85 {
+    %0 = %101;
+    return;
+  }
+  bb86 {
+    %100 = %101;
+    GOTO bb87;
+  }
+  bb87 {
+    %104 = ConstantLoad 1
+    %105 = ConstantLoad 2
+    %106 = ConstantLoad 3
+    %107 = ConstantLoad 3
+    %108 = newArray [int:Unsigned8...][%107]{%104, %105, %106}
+    %109 = createReadableChannel(%108) -> bb88;
+  }
+  bb88 {
+    %110 = %109 is error
+    %110 ? bb89 : bb90;
+  }
+  bb89 {
+    %0 = %109;
+    return;
+  }
+  bb90 {
+    %103 = %109;
+    GOTO bb91;
+  }
+  bb91 {
+    closedCh = %103;
+    %113 = close(closedCh) -> bb92;
+  }
+  bb92 {
+    %114 = %113 is error
+    %114 ? bb93 : bb94;
+  }
+  bb93 {
+    %0 = %113;
+    return;
+  }
+  bb94 {
+    %112 = %113;
+    GOTO bb95;
+  }
+  bb95 {
+    %115 = base64Encode(closedCh) -> bb96;
+  }
+  bb96 {
+    encClosed = %115;
+    %117 = encClosed is error
+    %117 ? bb97 : bb100;
+  }
+  bb97 {
+    PushScopeFrame 2
+    %0 = message((1, encClosed)) -> bb98;
+  }
+  bb98 {
+    %1 = println(%0) -> bb99;
+  }
+  bb99 {
+    PopScopeFrame
+    GOTO bb100;
+  }
+  bb100 {
+    PushScopeFrame 3
+    %0 = base64Decode((1, closedCh)) -> bb101;
+  }
+  bb101 {
+    decClosed = %0;
+    %2 = decClosed is error
+    %2 ? bb102 : bb105;
+  }
+  bb102 {
+    PushScopeFrame 2
+    %0 = message((1, decClosed)) -> bb103;
+  }
+  bb103 {
+    %1 = println(%0) -> bb104;
+  }
+  bb104 {
+    PopScopeFrame
+    GOTO bb105;
+  }
+  bb105 {
     PushScopeFrame 0
     PopScopeFrame
     PopScopeFrame

--- a/corpus/bir/library/subset3/io-byte-channel-blockstream-v.txt
+++ b/corpus/bir/library/subset3/io-byte-channel-blockstream-v.txt
@@ -18,150 +18,149 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %14;
-    %16 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %17 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %16;
-    %18 = $desugar$3 is error
+    %18 = %17 is error
     %18 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %17;
     return;
   }
   bb4 {
-    %19 = openReadableFile(path) -> bb5;
+    %16 = %17;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %19;
-    %21 = $desugar$4 is error
-    %21 ? bb6 : bb7;
+    %20 = openReadableFile(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %21 = %20 is error
+    %21 ? bb7 : bb8;
   }
   bb7 {
-    channel = $desugar$4;
-    %23 = ConstantLoad 3
-    %24 = %23;
-    %25 = blockStream(channel,%24) -> bb8;
+    %0 = %20;
+    return;
   }
   bb8 {
-    s = %25;
-    %27 = s is stream
-    %27 ? bb9 : bb29;
+    %19 = %20;
+    GOTO bb9;
   }
   bb9 {
+    channel = %19;
+    %23 = ConstantLoad 3
+    %24 = %23;
+    %25 = blockStream(channel,%24) -> bb10;
+  }
+  bb10 {
+    s = %25;
+    %27 = s is stream
+    %27 ? bb11 : bb32;
+  }
+  bb11 {
     PushScopeFrame 3
     %0 = streamNext (1, s)
     r1 = %0;
     %2 = r1 is {| value: readonly&[int:Unsigned8...], never... |}
-    %2 ? bb10 : bb14;
+    %2 ? bb12 : bb16;
   }
-  bb10 {
+  bb12 {
     PushScopeFrame 11
     %1 = ConstantLoad value
     %0 = (1, r1)[%1];
-    %2 = length(%0) -> bb11;
+    %2 = length(%0) -> bb13;
   }
-  bb11 {
+  bb13 {
     %3 = %2;
-    %4 = println(%3) -> bb12;
+    %4 = println(%3) -> bb14;
   }
-  bb12 {
+  bb14 {
     %6 = ConstantLoad 0
     %8 = ConstantLoad value
     %7 = (1, r1)[%8];
     %5 = %7[%6];
     %9 = %5;
-    %10 = println(%9) -> bb13;
+    %10 = println(%9) -> bb15;
   }
-  bb13 {
+  bb15 {
     PopScopeFrame
-    GOTO bb14;
+    GOTO bb16;
   }
-  bb14 {
+  bb16 {
     PushScopeFrame 3
     %0 = streamNext (2, s)
     r2 = %0;
     %2 = r2 is {| value: readonly&[int:Unsigned8...], never... |}
-    %2 ? bb15 : bb18;
+    %2 ? bb17 : bb20;
   }
-  bb15 {
+  bb17 {
     PushScopeFrame 5
     %1 = ConstantLoad value
     %0 = (1, r2)[%1];
-    %2 = length(%0) -> bb16;
-  }
-  bb16 {
-    %3 = %2;
-    %4 = println(%3) -> bb17;
-  }
-  bb17 {
-    PopScopeFrame
-    GOTO bb18;
+    %2 = length(%0) -> bb18;
   }
   bb18 {
+    %3 = %2;
+    %4 = println(%3) -> bb19;
+  }
+  bb19 {
+    PopScopeFrame
+    GOTO bb20;
+  }
+  bb20 {
     PushScopeFrame 3
     %0 = streamNext (3, s)
     r3 = %0;
     %2 = r3 is {| value: readonly&[int:Unsigned8...], never... |}
-    %2 ? bb19 : bb23;
+    %2 ? bb21 : bb25;
   }
-  bb19 {
+  bb21 {
     PushScopeFrame 11
     %1 = ConstantLoad value
     %0 = (1, r3)[%1];
-    %2 = length(%0) -> bb20;
+    %2 = length(%0) -> bb22;
   }
-  bb20 {
+  bb22 {
     %3 = %2;
-    %4 = println(%3) -> bb21;
+    %4 = println(%3) -> bb23;
   }
-  bb21 {
+  bb23 {
     %6 = ConstantLoad 0
     %8 = ConstantLoad value
     %7 = (1, r3)[%8];
     %5 = %7[%6];
     %9 = %5;
-    %10 = println(%9) -> bb22;
+    %10 = println(%9) -> bb24;
   }
-  bb22 {
+  bb24 {
     PopScopeFrame
-    GOTO bb23;
+    GOTO bb25;
   }
-  bb23 {
+  bb25 {
     PushScopeFrame 3
     %0 = streamNext (4, s)
     r4 = %0;
     %2 = r4 is nil
-    %2 ? bb24 : bb26;
-  }
-  bb24 {
-    PushScopeFrame 2
-    %0 = ConstantLoad done
-    %1 = println(%0) -> bb25;
-  }
-  bb25 {
-    PopScopeFrame
-    GOTO bb26;
+    %2 ? bb26 : bb28;
   }
   bb26 {
-    PushScopeFrame 3
-    %0 = streamClose (5, s)
-    $desugar$5 = %0;
-    %2 = $desugar$5 is error
-    %2 ? bb27 : bb28;
+    PushScopeFrame 2
+    %0 = ConstantLoad done
+    %1 = println(%0) -> bb27;
   }
   bb27 {
-    PushScopeFrame 0
-    (6, %0) = (1, $desugar$5);
     PopScopeFrame
+    GOTO bb28;
+  }
+  bb28 {
+    PushScopeFrame 3
+    %1 = streamClose (5, s)
+    %2 = %1 is error
+    %2 ? bb29 : bb30;
+  }
+  bb29 {
+    (5, %0) = %1;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
@@ -169,23 +168,27 @@ main() -> nil|error{
     PopScopeFrame
     return;
   }
-  bb28 {
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    GOTO bb29;
-  }
-  bb29 {
-    PushScopeFrame 3
-    %0 = close((1, channel)) -> bb30;
-  }
   bb30 {
-    closeResult = %0;
-    %2 = println(closeResult) -> bb31;
+    %0 = %1;
+    GOTO bb31;
   }
   bb31 {
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb32;
+  }
+  bb32 {
+    PushScopeFrame 3
+    %0 = close((1, channel)) -> bb33;
+  }
+  bb33 {
+    closeResult = %0;
+    %2 = println(closeResult) -> bb34;
+  }
+  bb34 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset3/io-byte-channel-closed-v.txt
+++ b/corpus/bir/library/subset3/io-byte-channel-closed-v.txt
@@ -14,135 +14,140 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %10;
-    %12 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %13 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %12;
-    %14 = $desugar$3 is error
+    %14 = %13 is error
     %14 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %13;
     return;
   }
   bb4 {
-    %15 = openReadableFile(path) -> bb5;
+    %12 = %13;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %15;
-    %17 = $desugar$4 is error
-    %17 ? bb6 : bb7;
+    %16 = openReadableFile(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %17 = %16 is error
+    %17 ? bb7 : bb8;
   }
   bb7 {
-    reader = $desugar$4;
-    %19 = close(reader) -> bb8;
-  }
-  bb8 {
-    $desugar$5 = %19;
-    %21 = $desugar$5 is error
-    %21 ? bb9 : bb10;
-  }
-  bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %16;
     return;
   }
+  bb8 {
+    %15 = %16;
+    GOTO bb9;
+  }
+  bb9 {
+    reader = %15;
+    %20 = close(reader) -> bb10;
+  }
   bb10 {
-    %22 = close(reader) -> bb11;
+    %21 = %20 is error
+    %21 ? bb11 : bb12;
   }
   bb11 {
+    %0 = %20;
+    return;
+  }
+  bb12 {
+    %19 = %20;
+    GOTO bb13;
+  }
+  bb13 {
+    %22 = close(reader) -> bb14;
+  }
+  bb14 {
     secondClose = %22;
     %24 = secondClose is error
     %25 = %24;
-    %26 = println(%25) -> bb12;
-  }
-  bb12 {
-    %27 = secondClose is error
-    %27 ? bb13 : bb16;
-  }
-  bb13 {
-    PushScopeFrame 2
-    %0 = message((1, secondClose)) -> bb14;
-  }
-  bb14 {
-    %1 = println(%0) -> bb15;
+    %26 = println(%25) -> bb15;
   }
   bb15 {
-    PopScopeFrame
-    GOTO bb16;
+    %27 = secondClose is error
+    %27 ? bb16 : bb19;
   }
   bb16 {
+    PushScopeFrame 2
+    %0 = message((1, secondClose)) -> bb17;
+  }
+  bb17 {
+    %1 = println(%0) -> bb18;
+  }
+  bb18 {
+    PopScopeFrame
+    GOTO bb19;
+  }
+  bb19 {
     PushScopeFrame 27
     %0 = ConstantLoad 1
     %1 = %0;
-    %2 = read((1, reader),%1) -> bb17;
+    %2 = read((1, reader),%1) -> bb20;
   }
-  bb17 {
+  bb20 {
     readAfterClose = %2;
     %4 = readAfterClose is error
     %5 = %4;
-    %6 = println(%5) -> bb18;
-  }
-  bb18 {
-    $desugar$6 = (1, path);
-    %8 = $default$11($desugar$6) -> bb19;
-  }
-  bb19 {
-    $desugar$7 = %8;
-    %10 = openWritableFile($desugar$6,$desugar$7) -> bb20;
-  }
-  bb20 {
-    $desugar$8 = %10;
-    %12 = $desugar$8 is error
-    %12 ? bb21 : bb22;
+    %6 = println(%5) -> bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$8);
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    $desugar$3 = (1, path);
+    %8 = $default$11($desugar$3) -> bb22;
   }
   bb22 {
-    writer = $desugar$8;
-    %14 = close(writer) -> bb23;
+    $desugar$4 = %8;
+    %11 = openWritableFile($desugar$3,$desugar$4) -> bb23;
   }
   bb23 {
-    $desugar$9 = %14;
-    %16 = $desugar$9 is error
-    %16 ? bb24 : bb25;
+    %12 = %11 is error
+    %12 ? bb24 : bb25;
   }
   bb24 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$9);
-    PopScopeFrame
+    (1, %0) = %11;
     PopScopeFrame
     return;
   }
   bb25 {
+    %10 = %11;
+    GOTO bb26;
+  }
+  bb26 {
+    writer = %10;
+    %15 = close(writer) -> bb27;
+  }
+  bb27 {
+    %16 = %15 is error
+    %16 ? bb28 : bb29;
+  }
+  bb28 {
+    (1, %0) = %15;
+    PopScopeFrame
+    return;
+  }
+  bb29 {
+    %14 = %15;
+    GOTO bb30;
+  }
+  bb30 {
     %17 = ConstantLoad 1
     %18 = ConstantLoad 1
     %19 = newArray [int:Unsigned8...][%18]{%17}
     %20 = ConstantLoad 0
     %21 = %20;
-    %22 = write(writer,%19,%21) -> bb26;
+    %22 = write(writer,%19,%21) -> bb31;
   }
-  bb26 {
+  bb31 {
     writeAfterClose = %22;
     %24 = writeAfterClose is error
     %25 = %24;
-    %26 = println(%25) -> bb27;
+    %26 = println(%25) -> bb32;
   }
-  bb27 {
+  bb32 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset3/io-byte-channel-inmem-v.txt
+++ b/corpus/bir/library/subset3/io-byte-channel-inmem-v.txt
@@ -8,78 +8,80 @@ main() -> nil|error{
     %5 = ConstantLoad 4
     %6 = newArray [int:Unsigned8...][%5]{%1, %2, %3, %4}
     content = %6;
-    %8 = createReadableChannel(content) -> bb1;
+    %9 = createReadableChannel(content) -> bb1;
   }
   bb1 {
-    $desugar$0 = %8;
-    %10 = $desugar$0 is error
+    %10 = %9 is error
     %10 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %9;
     return;
   }
   bb3 {
-    channel = $desugar$0;
-    %12 = readAll(channel) -> bb4;
+    %8 = %9;
+    GOTO bb4;
   }
   bb4 {
-    result = %12;
-    %14 = result is [int:Unsigned8...]
-    %14 ? bb5 : bb10;
+    channel = %8;
+    %12 = readAll(channel) -> bb5;
   }
   bb5 {
-    PushScopeFrame 11
-    %0 = length((1, result)) -> bb6;
+    result = %12;
+    %14 = result is [int:Unsigned8...]
+    %14 ? bb6 : bb11;
   }
   bb6 {
-    %1 = %0;
-    %2 = println(%1) -> bb7;
+    PushScopeFrame 11
+    %0 = length((1, result)) -> bb7;
   }
   bb7 {
+    %1 = %0;
+    %2 = println(%1) -> bb8;
+  }
+  bb8 {
     %4 = ConstantLoad 0
     %3 = (1, result)[%4];
     %5 = %3;
-    %6 = println(%5) -> bb8;
+    %6 = println(%5) -> bb9;
   }
-  bb8 {
+  bb9 {
     %8 = ConstantLoad 3
     %7 = (1, result)[%8];
     %9 = %7;
-    %10 = println(%9) -> bb9;
-  }
-  bb9 {
-    PopScopeFrame
-    GOTO bb10;
+    %10 = println(%9) -> bb10;
   }
   bb10 {
-    PushScopeFrame 8
-    %0 = close((1, channel)) -> bb11;
+    PopScopeFrame
+    GOTO bb11;
   }
   bb11 {
-    $desugar$1 = %0;
-    %2 = $desugar$1 is error
-    %2 ? bb12 : bb13;
+    PushScopeFrame 8
+    %1 = close((1, channel)) -> bb12;
   }
   bb12 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$1);
-    PopScopeFrame
+    %2 = %1 is error
+    %2 ? bb13 : bb14;
+  }
+  bb13 {
+    (1, %0) = %1;
     PopScopeFrame
     return;
   }
-  bb13 {
-    %3 = close((1, channel)) -> bb14;
-  }
   bb14 {
+    %0 = %1;
+    GOTO bb15;
+  }
+  bb15 {
+    %3 = close((1, channel)) -> bb16;
+  }
+  bb16 {
     second = %3;
     %5 = second is error
     %6 = %5;
-    %7 = println(%6) -> bb15;
+    %7 = println(%6) -> bb17;
   }
-  bb15 {
+  bb17 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset3/io-byte-channel-read-v.txt
+++ b/corpus/bir/library/subset3/io-byte-channel-read-v.txt
@@ -18,155 +18,158 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %14;
-    %16 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %17 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %16;
-    %18 = $desugar$3 is error
+    %18 = %17 is error
     %18 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %17;
     return;
   }
   bb4 {
-    %19 = openReadableFile(path) -> bb5;
+    %16 = %17;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %19;
-    %21 = $desugar$4 is error
-    %21 ? bb6 : bb7;
+    %20 = openReadableFile(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %21 = %20 is error
+    %21 ? bb7 : bb8;
   }
   bb7 {
-    channel = $desugar$4;
-    %23 = channel is object { private function attachBytes([int:Unsigned8...]) returns nil|error; private function attachFile(string) returns nil|error; public function base64Decode() returns error|...; private function base64DecodeBytes() returns error|[int:Unsigned8...]; public function base64Encode() returns error|...; private function base64EncodeBytes() returns error|[int:Unsigned8...]; public function blockStream(int) returns error|stream; public function close() returns nil|error; public function init() returns nil; public function read(int) returns error|[int:Unsigned8...]; public function readAll() returns error|readonly&[int:Unsigned8...] }
-    %24 = %23;
-    %25 = println(%24) -> bb8;
+    %0 = %20;
+    return;
   }
   bb8 {
-    %26 = ConstantLoad 3
-    %27 = %26;
-    %28 = read(channel,%27) -> bb9;
+    %19 = %20;
+    GOTO bb9;
   }
   bb9 {
-    r1 = %28;
-    %30 = r1 is [int:Unsigned8...]
-    %30 ? bb10 : bb15;
+    channel = %19;
+    %23 = channel is object { private function attachBytes([int:Unsigned8...]) returns nil|error; private function attachFile(string) returns nil|error; public function base64Decode() returns error|...; private function base64DecodeBytes() returns error|[int:Unsigned8...]; public function base64Encode() returns error|...; private function base64EncodeBytes() returns error|[int:Unsigned8...]; public function blockStream(int) returns error|stream; public function close() returns nil|error; public function init() returns nil; public function read(int) returns error|[int:Unsigned8...]; public function readAll() returns error|readonly&[int:Unsigned8...] }
+    %24 = %23;
+    %25 = println(%24) -> bb10;
   }
   bb10 {
-    PushScopeFrame 11
-    %0 = length((1, r1)) -> bb11;
+    %26 = ConstantLoad 3
+    %27 = %26;
+    %28 = read(channel,%27) -> bb11;
   }
   bb11 {
-    %1 = %0;
-    %2 = println(%1) -> bb12;
+    r1 = %28;
+    %30 = r1 is [int:Unsigned8...]
+    %30 ? bb12 : bb17;
   }
   bb12 {
+    PushScopeFrame 11
+    %0 = length((1, r1)) -> bb13;
+  }
+  bb13 {
+    %1 = %0;
+    %2 = println(%1) -> bb14;
+  }
+  bb14 {
     %4 = ConstantLoad 0
     %3 = (1, r1)[%4];
     %5 = %3;
-    %6 = println(%5) -> bb13;
+    %6 = println(%5) -> bb15;
   }
-  bb13 {
+  bb15 {
     %8 = ConstantLoad 2
     %7 = (1, r1)[%8];
     %9 = %7;
-    %10 = println(%9) -> bb14;
+    %10 = println(%9) -> bb16;
   }
-  bb14 {
+  bb16 {
     PopScopeFrame
-    GOTO bb15;
+    GOTO bb17;
   }
-  bb15 {
+  bb17 {
     PushScopeFrame 5
     %0 = ConstantLoad 100
     %1 = %0;
-    %2 = read((1, channel),%1) -> bb16;
-  }
-  bb16 {
-    r2 = %2;
-    %4 = r2 is [int:Unsigned8...]
-    %4 ? bb17 : bb21;
-  }
-  bb17 {
-    PushScopeFrame 7
-    %0 = length((1, r2)) -> bb18;
+    %2 = read((1, channel),%1) -> bb18;
   }
   bb18 {
-    %1 = %0;
-    %2 = println(%1) -> bb19;
+    r2 = %2;
+    %4 = r2 is [int:Unsigned8...]
+    %4 ? bb19 : bb23;
   }
   bb19 {
+    PushScopeFrame 7
+    %0 = length((1, r2)) -> bb20;
+  }
+  bb20 {
+    %1 = %0;
+    %2 = println(%1) -> bb21;
+  }
+  bb21 {
     %4 = ConstantLoad 3
     %3 = (1, r2)[%4];
     %5 = %3;
-    %6 = println(%5) -> bb20;
+    %6 = println(%5) -> bb22;
   }
-  bb20 {
+  bb22 {
     PopScopeFrame
-    GOTO bb21;
+    GOTO bb23;
   }
-  bb21 {
+  bb23 {
     PushScopeFrame 5
     %0 = ConstantLoad 10
     %1 = %0;
-    %2 = read((2, channel),%1) -> bb22;
-  }
-  bb22 {
-    r3 = %2;
-    %4 = r3 is [int:Unsigned8...]
-    %4 ? bb23 : bb26;
-  }
-  bb23 {
-    PushScopeFrame 3
-    %0 = length((1, r3)) -> bb24;
+    %2 = read((2, channel),%1) -> bb24;
   }
   bb24 {
-    %1 = %0;
-    %2 = println(%1) -> bb25;
+    r3 = %2;
+    %4 = r3 is [int:Unsigned8...]
+    %4 ? bb25 : bb28;
   }
   bb25 {
-    PopScopeFrame
-    GOTO bb26;
+    PushScopeFrame 3
+    %0 = length((1, r3)) -> bb26;
   }
   bb26 {
+    %1 = %0;
+    %2 = println(%1) -> bb27;
+  }
+  bb27 {
+    PopScopeFrame
+    GOTO bb28;
+  }
+  bb28 {
     PushScopeFrame 10
     %0 = ConstantLoad 10
     %1 = %0;
-    %2 = read((3, channel),%1) -> bb27;
+    %2 = read((3, channel),%1) -> bb29;
   }
-  bb27 {
+  bb29 {
     r4 = %2;
     %4 = r4 is error
     %5 = %4;
-    %6 = println(%5) -> bb28;
-  }
-  bb28 {
-    %7 = close((3, channel)) -> bb29;
-  }
-  bb29 {
-    $desugar$5 = %7;
-    %9 = $desugar$5 is error
-    %9 ? bb30 : bb31;
+    %6 = println(%5) -> bb30;
   }
   bb30 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %8 = close((3, channel)) -> bb31;
+  }
+  bb31 {
+    %9 = %8 is error
+    %9 ? bb32 : bb33;
+  }
+  bb32 {
+    (3, %0) = %8;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
-  bb31 {
+  bb33 {
+    %7 = %8;
+    GOTO bb34;
+  }
+  bb34 {
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame

--- a/corpus/bir/library/subset3/io-byte-channel-readall-v.txt
+++ b/corpus/bir/library/subset3/io-byte-channel-readall-v.txt
@@ -16,83 +16,86 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %12;
-    %14 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %15 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %14;
-    %16 = $desugar$3 is error
+    %16 = %15 is error
     %16 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %15;
     return;
   }
   bb4 {
-    %17 = openReadableFile(path) -> bb5;
+    %14 = %15;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %17;
-    %19 = $desugar$4 is error
-    %19 ? bb6 : bb7;
+    %18 = openReadableFile(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %19 = %18 is error
+    %19 ? bb7 : bb8;
   }
   bb7 {
-    channel = $desugar$4;
-    %21 = readAll(channel) -> bb8;
+    %0 = %18;
+    return;
   }
   bb8 {
-    content = %21;
-    %23 = content is [int:Unsigned8...]
-    %23 ? bb9 : bb14;
+    %17 = %18;
+    GOTO bb9;
   }
   bb9 {
-    PushScopeFrame 11
-    %0 = length((1, content)) -> bb10;
+    channel = %17;
+    %21 = readAll(channel) -> bb10;
   }
   bb10 {
-    %1 = %0;
-    %2 = println(%1) -> bb11;
+    content = %21;
+    %23 = content is [int:Unsigned8...]
+    %23 ? bb11 : bb16;
   }
   bb11 {
+    PushScopeFrame 11
+    %0 = length((1, content)) -> bb12;
+  }
+  bb12 {
+    %1 = %0;
+    %2 = println(%1) -> bb13;
+  }
+  bb13 {
     %4 = ConstantLoad 0
     %3 = (1, content)[%4];
     %5 = %3;
-    %6 = println(%5) -> bb12;
+    %6 = println(%5) -> bb14;
   }
-  bb12 {
+  bb14 {
     %8 = ConstantLoad 4
     %7 = (1, content)[%8];
     %9 = %7;
-    %10 = println(%9) -> bb13;
-  }
-  bb13 {
-    PopScopeFrame
-    GOTO bb14;
-  }
-  bb14 {
-    PushScopeFrame 3
-    %0 = close((1, channel)) -> bb15;
+    %10 = println(%9) -> bb15;
   }
   bb15 {
-    $desugar$5 = %0;
-    %2 = $desugar$5 is error
-    %2 ? bb16 : bb17;
+    PopScopeFrame
+    GOTO bb16;
   }
   bb16 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$5);
-    PopScopeFrame
+    PushScopeFrame 3
+    %1 = close((1, channel)) -> bb17;
+  }
+  bb17 {
+    %2 = %1 is error
+    %2 ? bb18 : bb19;
+  }
+  bb18 {
+    (1, %0) = %1;
     PopScopeFrame
     return;
   }
-  bb17 {
+  bb19 {
+    %0 = %1;
+    GOTO bb20;
+  }
+  bb20 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset3/io-byte-channel-write-v.txt
+++ b/corpus/bir/library/subset3/io-byte-channel-write-v.txt
@@ -8,21 +8,22 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %4;
-    %6 = openWritableFile($desugar$0,$desugar$1) -> bb2;
+    %7 = openWritableFile($desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    $desugar$2 = %6;
-    %8 = $desugar$2 is error
+    %8 = %7 is error
     %8 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %7;
     return;
   }
   bb4 {
-    writer = $desugar$2;
+    %6 = %7;
+    GOTO bb5;
+  }
+  bb5 {
+    writer = %6;
     %10 = ConstantLoad 1
     %11 = ConstantLoad 2
     %12 = ConstantLoad 3
@@ -32,162 +33,168 @@ main() -> nil|error{
     %16 = newArray [int:Unsigned8...][%15]{%10, %11, %12, %13, %14}
     %17 = ConstantLoad 2
     %18 = %17;
-    %19 = write(writer,%16,%18) -> bb5;
-  }
-  bb5 {
-    n1 = %19;
-    %21 = n1 is int
-    %21 ? bb6 : bb8;
+    %19 = write(writer,%16,%18) -> bb6;
   }
   bb6 {
-    PushScopeFrame 1
-    %0 = println((1, n1)) -> bb7;
+    n1 = %19;
+    %21 = n1 is int
+    %21 ? bb7 : bb9;
   }
   bb7 {
-    PopScopeFrame
-    GOTO bb8;
+    PushScopeFrame 1
+    %0 = println((1, n1)) -> bb8;
   }
   bb8 {
-    PushScopeFrame 51
-    %0 = close((1, writer)) -> bb9;
+    PopScopeFrame
+    GOTO bb9;
   }
   bb9 {
-    $desugar$3 = %0;
-    %2 = $desugar$3 is error
-    %2 ? bb10 : bb11;
+    PushScopeFrame 51
+    %1 = close((1, writer)) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %2 = %1 is error
+    %2 ? bb11 : bb12;
   }
   bb11 {
-    %3 = fileReadBytes((1, path)) -> bb12;
-  }
-  bb12 {
-    $desugar$4 = %3;
-    %5 = $desugar$4 is error
-    %5 ? bb13 : bb14;
-  }
-  bb13 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$4);
-    PopScopeFrame
+    (1, %0) = %1;
     PopScopeFrame
     return;
   }
+  bb12 {
+    %0 = %1;
+    GOTO bb13;
+  }
+  bb13 {
+    %4 = fileReadBytes((1, path)) -> bb14;
+  }
   bb14 {
-    written = $desugar$4;
-    %7 = length(written) -> bb15;
+    %5 = %4 is error
+    %5 ? bb15 : bb16;
   }
   bb15 {
-    %8 = %7;
-    %9 = println(%8) -> bb16;
+    (1, %0) = %4;
+    PopScopeFrame
+    return;
   }
   bb16 {
+    %3 = %4;
+    GOTO bb17;
+  }
+  bb17 {
+    written = %3;
+    %7 = length(written) -> bb18;
+  }
+  bb18 {
+    %8 = %7;
+    %9 = println(%8) -> bb19;
+  }
+  bb19 {
     %11 = ConstantLoad 0
     %10 = written[%11];
     %12 = %10;
-    %13 = println(%12) -> bb17;
+    %13 = println(%12) -> bb20;
   }
-  bb17 {
+  bb20 {
     %15 = ConstantLoad 2
     %14 = written[%15];
     %16 = %14;
-    %17 = println(%16) -> bb18;
-  }
-  bb18 {
-    %18 = ConstantLoad APPEND
-    %19 = openWritableFile((1, path),%18) -> bb19;
-  }
-  bb19 {
-    $desugar$5 = %19;
-    %21 = $desugar$5 is error
-    %21 ? bb20 : bb21;
-  }
-  bb20 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$5);
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %17 = println(%16) -> bb21;
   }
   bb21 {
-    appender = $desugar$5;
-    %23 = ConstantLoad 9
-    %24 = ConstantLoad 8
-    %25 = ConstantLoad 2
-    %26 = newArray [int:Unsigned8...][%25]{%23, %24}
-    %27 = ConstantLoad 0
-    %28 = %27;
-    %29 = write(appender,%26,%28) -> bb22;
+    %19 = ConstantLoad APPEND
+    %20 = openWritableFile((1, path),%19) -> bb22;
   }
   bb22 {
-    $desugar$6 = %29;
-    %31 = $desugar$6 is error
-    %31 ? bb23 : bb24;
+    %21 = %20 is error
+    %21 ? bb23 : bb24;
   }
   bb23 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$6);
-    PopScopeFrame
+    (1, %0) = %20;
     PopScopeFrame
     return;
   }
   bb24 {
-    %32 = $desugar$6;
-    %33 = close(appender) -> bb25;
+    %18 = %20;
+    GOTO bb25;
   }
   bb25 {
-    $desugar$7 = %33;
-    %35 = $desugar$7 is error
-    %35 ? bb26 : bb27;
+    appender = %18;
+    %24 = ConstantLoad 9
+    %25 = ConstantLoad 8
+    %26 = ConstantLoad 2
+    %27 = newArray [int:Unsigned8...][%26]{%24, %25}
+    %28 = ConstantLoad 0
+    %29 = %28;
+    %30 = write(appender,%27,%29) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$7);
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %31 = %30 is error
+    %31 ? bb27 : bb28;
   }
   bb27 {
-    %36 = fileReadBytes((1, path)) -> bb28;
-  }
-  bb28 {
-    $desugar$8 = %36;
-    %38 = $desugar$8 is error
-    %38 ? bb29 : bb30;
-  }
-  bb29 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$8);
-    PopScopeFrame
+    (1, %0) = %30;
     PopScopeFrame
     return;
   }
+  bb28 {
+    %23 = %30;
+    GOTO bb29;
+  }
+  bb29 {
+    %32 = %23;
+    %34 = close(appender) -> bb30;
+  }
   bb30 {
-    appended = $desugar$8;
-    %40 = length(appended) -> bb31;
+    %35 = %34 is error
+    %35 ? bb31 : bb32;
   }
   bb31 {
-    %41 = %40;
-    %42 = println(%41) -> bb32;
+    (1, %0) = %34;
+    PopScopeFrame
+    return;
   }
   bb32 {
+    %33 = %34;
+    GOTO bb33;
+  }
+  bb33 {
+    %37 = fileReadBytes((1, path)) -> bb34;
+  }
+  bb34 {
+    %38 = %37 is error
+    %38 ? bb35 : bb36;
+  }
+  bb35 {
+    (1, %0) = %37;
+    PopScopeFrame
+    return;
+  }
+  bb36 {
+    %36 = %37;
+    GOTO bb37;
+  }
+  bb37 {
+    appended = %36;
+    %40 = length(appended) -> bb38;
+  }
+  bb38 {
+    %41 = %40;
+    %42 = println(%41) -> bb39;
+  }
+  bb39 {
     %44 = ConstantLoad 3
     %43 = appended[%44];
     %45 = %43;
-    %46 = println(%45) -> bb33;
+    %46 = println(%45) -> bb40;
   }
-  bb33 {
+  bb40 {
     %48 = ConstantLoad 4
     %47 = appended[%48];
     %49 = %47;
-    %50 = println(%49) -> bb34;
+    %50 = println(%49) -> bb41;
   }
-  bb34 {
+  bb41 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset3/io-byte-readonly-v.txt
+++ b/corpus/bir/library/subset3/io-byte-readonly-v.txt
@@ -16,154 +16,161 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %12;
-    %14 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %15 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %14;
-    %16 = $desugar$3 is error
+    %16 = %15 is error
     %16 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %15;
     return;
   }
   bb4 {
-    %17 = fileReadBytes(path) -> bb5;
+    %14 = %15;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %17;
-    %19 = $desugar$4 is error
-    %19 ? bb6 : bb7;
+    %18 = fileReadBytes(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %19 = %18 is error
+    %19 ? bb7 : bb8;
   }
   bb7 {
-    bytes = $desugar$4;
-    %21 = bytes is readonly&[int:Unsigned8...]
-    %22 = %21;
-    %23 = println(%22) -> bb8;
-  }
-  bb8 {
-    %24 = length(bytes) -> bb9;
-  }
-  bb9 {
-    %25 = %24;
-    %26 = println(%25) -> bb10;
-  }
-  bb10 {
-    %27 = ConstantLoad 2
-    %28 = %27;
-    %29 = fileReadBlocksAsStream(path,%28) -> bb11;
-  }
-  bb11 {
-    $desugar$5 = %29;
-    %31 = $desugar$5 is error
-    %31 ? bb12 : bb13;
-  }
-  bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %18;
     return;
   }
+  bb8 {
+    %17 = %18;
+    GOTO bb9;
+  }
+  bb9 {
+    bytes = %17;
+    %21 = bytes is readonly&[int:Unsigned8...]
+    %22 = %21;
+    %23 = println(%22) -> bb10;
+  }
+  bb10 {
+    %24 = length(bytes) -> bb11;
+  }
+  bb11 {
+    %25 = %24;
+    %26 = println(%25) -> bb12;
+  }
+  bb12 {
+    %28 = ConstantLoad 2
+    %29 = %28;
+    %30 = fileReadBlocksAsStream(path,%29) -> bb13;
+  }
   bb13 {
-    blocks = $desugar$5;
+    %31 = %30 is error
+    %31 ? bb14 : bb15;
+  }
+  bb14 {
+    %0 = %30;
+    return;
+  }
+  bb15 {
+    %27 = %30;
+    GOTO bb16;
+  }
+  bb16 {
+    blocks = %27;
     %33 = streamNext blocks
     first = %33;
     %35 = first is {| value: readonly&[int:Unsigned8...], never... |}
-    %35 ? bb14 : bb16;
+    %35 ? bb17 : bb19;
   }
-  bb14 {
+  bb17 {
     PushScopeFrame 5
     %1 = ConstantLoad value
     %0 = (1, first)[%1];
     %2 = %0 is readonly&[int:Unsigned8...]
     %3 = %2;
-    %4 = println(%3) -> bb15;
-  }
-  bb15 {
-    PopScopeFrame
-    GOTO bb16;
-  }
-  bb16 {
-    PushScopeFrame 21
-    %0 = streamClose (1, blocks)
-    $desugar$6 = %0;
-    %2 = $desugar$6 is error
-    %2 ? bb17 : bb18;
-  }
-  bb17 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$6);
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %4 = println(%3) -> bb18;
   }
   bb18 {
-    %3 = openReadableFile((1, path)) -> bb19;
+    PopScopeFrame
+    GOTO bb19;
   }
   bb19 {
-    $desugar$7 = %3;
-    %5 = $desugar$7 is error
-    %5 ? bb20 : bb21;
+    PushScopeFrame 21
+    %1 = streamClose (1, blocks)
+    %2 = %1 is error
+    %2 ? bb20 : bb21;
   }
   bb20 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$7);
-    PopScopeFrame
+    (1, %0) = %1;
     PopScopeFrame
     return;
   }
   bb21 {
-    channel = $desugar$7;
-    %7 = readAll(channel) -> bb22;
+    %0 = %1;
+    GOTO bb22;
   }
   bb22 {
-    $desugar$8 = %7;
-    %9 = $desugar$8 is error
-    %9 ? bb23 : bb24;
+    %4 = openReadableFile((1, path)) -> bb23;
   }
   bb23 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$8);
-    PopScopeFrame
+    %5 = %4 is error
+    %5 ? bb24 : bb25;
+  }
+  bb24 {
+    (1, %0) = %4;
     PopScopeFrame
     return;
   }
-  bb24 {
-    all = $desugar$8;
-    %11 = all is readonly&[int:Unsigned8...]
-    %12 = %11;
-    %13 = println(%12) -> bb25;
-  }
   bb25 {
-    %15 = ConstantLoad 4
-    %14 = all[%15];
-    %16 = %14;
-    %17 = println(%16) -> bb26;
+    %3 = %4;
+    GOTO bb26;
   }
   bb26 {
-    %18 = close(channel) -> bb27;
+    channel = %3;
+    %8 = readAll(channel) -> bb27;
   }
   bb27 {
-    $desugar$9 = %18;
-    %20 = $desugar$9 is error
-    %20 ? bb28 : bb29;
+    %9 = %8 is error
+    %9 ? bb28 : bb29;
   }
   bb28 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$9);
-    PopScopeFrame
+    (1, %0) = %8;
     PopScopeFrame
     return;
   }
   bb29 {
+    %7 = %8;
+    GOTO bb30;
+  }
+  bb30 {
+    all = %7;
+    %11 = all is readonly&[int:Unsigned8...]
+    %12 = %11;
+    %13 = println(%12) -> bb31;
+  }
+  bb31 {
+    %15 = ConstantLoad 4
+    %14 = all[%15];
+    %16 = %14;
+    %17 = println(%16) -> bb32;
+  }
+  bb32 {
+    %19 = close(channel) -> bb33;
+  }
+  bb33 {
+    %20 = %19 is error
+    %20 ? bb34 : bb35;
+  }
+  bb34 {
+    (1, %0) = %19;
+    PopScopeFrame
+    return;
+  }
+  bb35 {
+    %18 = %19;
+    GOTO bb36;
+  }
+  bb36 {
     PopScopeFrame
     return;
   }

--- a/corpus/bir/library/subset3/io-char-channel-badcharset-p.txt
+++ b/corpus/bir/library/subset3/io-char-channel-badcharset-p.txt
@@ -1,60 +1,62 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 1
-    %2 = ConstantLoad 2
+    %2 = ConstantLoad 1
     %3 = ConstantLoad 2
-    %4 = newArray [int:Unsigned8...][%3]{%1, %2}
-    %5 = createReadableChannel(%4) -> bb1;
+    %4 = ConstantLoad 2
+    %5 = newArray [int:Unsigned8...][%4]{%2, %3}
+    %6 = createReadableChannel(%5) -> bb1;
   }
   bb1 {
-    $desugar$0 = %5;
-    %7 = $desugar$0 is error
+    %7 = %6 is error
     %7 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %6;
     return;
   }
   bb3 {
-    rb = $desugar$0;
-    %9 = newObject ballerina/io:ReadableCharacterChannel
-    %10 = ConstantLoad NOT-A-CHARSET
-    %11 = init(%9,rb,%10) -> bb4;
+    %1 = %6;
+    GOTO bb4;
   }
   bb4 {
-    %13 = %11 is nil
-    %13 ? bb5 : bb6;
+    rb = %1;
+    %9 = newObject ballerina/io:ReadableCharacterChannel
+    %10 = ConstantLoad NOT-A-CHARSET
+    %11 = init(%9,rb,%10) -> bb5;
   }
   bb5 {
-    %12 = %9;
-    GOTO bb7;
+    %13 = %11 is nil
+    %13 ? bb6 : bb7;
   }
   bb6 {
-    %12 = %11;
-    GOTO bb7;
+    %12 = %9;
+    GOTO bb8;
   }
   bb7 {
-    rc = %12;
-    %15 = ConstantLoad 1
-    %16 = %15;
-    %17 = read(rc,%16) -> bb8;
+    %12 = %11;
+    GOTO bb8;
   }
   bb8 {
-    $desugar$1 = %17;
-    %19 = $desugar$1 is error
-    %19 ? bb9 : bb10;
+    rc = %12;
+    %16 = ConstantLoad 1
+    %17 = %16;
+    %18 = read(rc,%17) -> bb9;
   }
   bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %19 = %18 is error
+    %19 ? bb10 : bb11;
   }
   bb10 {
-    _ = $desugar$1;
+    %0 = %18;
+    return;
+  }
+  bb11 {
+    %15 = %18;
+    GOTO bb12;
+  }
+  bb12 {
+    _ = %15;
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-char-channel-json-xml-v.txt
+++ b/corpus/bir/library/subset3/io-char-channel-json-xml-v.txt
@@ -8,225 +8,234 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %4;
-    %6 = openWritableFile($desugar$0,$desugar$1) -> bb2;
+    %7 = openWritableFile($desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    $desugar$2 = %6;
-    %8 = $desugar$2 is error
+    %8 = %7 is error
     %8 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %7;
     return;
   }
   bb4 {
-    wjb = $desugar$2;
-    %10 = newObject ballerina/io:WritableCharacterChannel
-    %11 = ConstantLoad UTF-8
-    %12 = init(%10,wjb,%11) -> bb5;
+    %6 = %7;
+    GOTO bb5;
   }
   bb5 {
-    %14 = %12 is nil
-    %14 ? bb6 : bb7;
+    wjb = %6;
+    %10 = newObject ballerina/io:WritableCharacterChannel
+    %11 = ConstantLoad UTF-8
+    %12 = init(%10,wjb,%11) -> bb6;
   }
   bb6 {
-    %13 = %10;
-    GOTO bb8;
+    %14 = %12 is nil
+    %14 ? bb7 : bb8;
   }
   bb7 {
-    %13 = %12;
-    GOTO bb8;
+    %13 = %10;
+    GOTO bb9;
   }
   bb8 {
-    wjc = %13;
-    %16 = ConstantLoad name
-    %17 = ConstantLoad Ballerina
-    %18 = ConstantLoad age
-    %19 = ConstantLoad 12
-    %20 = newMap {| json... |}{%16=%17, %18=%19}
-    %21 = writeJson(wjc,%20) -> bb9;
+    %13 = %12;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$3 = %21;
-    %23 = $desugar$3 is error
-    %23 ? bb10 : bb11;
+    wjc = %13;
+    %17 = ConstantLoad name
+    %18 = ConstantLoad Ballerina
+    %19 = ConstantLoad age
+    %20 = ConstantLoad 12
+    %21 = newMap {| json... |}{%17=%18, %19=%20}
+    %22 = writeJson(wjc,%21) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %23 = %22 is error
+    %23 ? bb11 : bb12;
   }
   bb11 {
-    %24 = close(wjc) -> bb12;
+    %0 = %22;
+    return;
   }
   bb12 {
-    $desugar$4 = %24;
-    %26 = $desugar$4 is error
-    %26 ? bb13 : bb14;
+    %16 = %22;
+    GOTO bb13;
   }
   bb13 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %25 = close(wjc) -> bb14;
   }
   bb14 {
-    %27 = openReadableFile(jpath) -> bb15;
+    %26 = %25 is error
+    %26 ? bb15 : bb16;
   }
   bb15 {
-    $desugar$5 = %27;
-    %29 = $desugar$5 is error
-    %29 ? bb16 : bb17;
-  }
-  bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %25;
     return;
   }
+  bb16 {
+    %24 = %25;
+    GOTO bb17;
+  }
   bb17 {
-    rjb = $desugar$5;
-    %31 = newObject ballerina/io:ReadableCharacterChannel
-    %32 = ConstantLoad UTF-8
-    %33 = init(%31,rjb,%32) -> bb18;
+    %28 = openReadableFile(jpath) -> bb18;
   }
   bb18 {
-    %35 = %33 is nil
-    %35 ? bb19 : bb20;
+    %29 = %28 is error
+    %29 ? bb19 : bb20;
   }
   bb19 {
-    %34 = %31;
-    GOTO bb21;
+    %0 = %28;
+    return;
   }
   bb20 {
-    %34 = %33;
+    %27 = %28;
     GOTO bb21;
   }
   bb21 {
-    rjc = %34;
-    %37 = readJson(rjc) -> bb22;
+    rjb = %27;
+    %31 = newObject ballerina/io:ReadableCharacterChannel
+    %32 = ConstantLoad UTF-8
+    %33 = init(%31,rjb,%32) -> bb22;
   }
   bb22 {
-    $desugar$6 = %37;
-    %39 = $desugar$6 is error
-    %39 ? bb23 : bb24;
+    %35 = %33 is nil
+    %35 ? bb23 : bb24;
   }
   bb23 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
+    %34 = %31;
+    GOTO bb25;
   }
   bb24 {
-    j = $desugar$6;
+    %34 = %33;
+    GOTO bb25;
+  }
+  bb25 {
+    rjc = %34;
+    %38 = readJson(rjc) -> bb26;
+  }
+  bb26 {
+    %39 = %38 is error
+    %39 ? bb27 : bb28;
+  }
+  bb27 {
+    %0 = %38;
+    return;
+  }
+  bb28 {
+    %37 = %38;
+    GOTO bb29;
+  }
+  bb29 {
+    j = %37;
     %41 = <{| json... |}>(j)
     jm = %41;
     %44 = ConstantLoad name
     %43 = jm[%44];
-    %45 = println(%43) -> bb25;
-  }
-  bb25 {
-    %47 = ConstantLoad age
-    %46 = jm[%47];
-    %48 = println(%46) -> bb26;
-  }
-  bb26 {
-    %49 = close(rjc) -> bb27;
-  }
-  bb27 {
-    $desugar$7 = %49;
-    %51 = $desugar$7 is error
-    %51 ? bb28 : bb29;
-  }
-  bb28 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
-  }
-  bb29 {
-    %52 = ConstantLoad /tmp/bal_io_char_json_bad.json
-    bpath = %52;
-    $desugar$8 = bpath;
-    %55 = ConstantLoad {oops
-    $desugar$9 = %55;
-    %57 = $default$1($desugar$8,$desugar$9) -> bb30;
+    %45 = println(%43) -> bb30;
   }
   bb30 {
-    $desugar$10 = %57;
-    %59 = fileWriteString($desugar$8,$desugar$9,$desugar$10) -> bb31;
+    %47 = ConstantLoad age
+    %46 = jm[%47];
+    %48 = println(%46) -> bb31;
   }
   bb31 {
-    $desugar$11 = %59;
-    %61 = $desugar$11 is error
-    %61 ? bb32 : bb33;
+    %50 = close(rjc) -> bb32;
   }
   bb32 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
-    return;
+    %51 = %50 is error
+    %51 ? bb33 : bb34;
   }
   bb33 {
-    %62 = openReadableFile(bpath) -> bb34;
-  }
-  bb34 {
-    $desugar$12 = %62;
-    %64 = $desugar$12 is error
-    %64 ? bb35 : bb36;
-  }
-  bb35 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$12);
-    PopScopeFrame
+    %0 = %50;
     return;
   }
+  bb34 {
+    %49 = %50;
+    GOTO bb35;
+  }
+  bb35 {
+    %52 = ConstantLoad /tmp/bal_io_char_json_bad.json
+    bpath = %52;
+    $desugar$2 = bpath;
+    %55 = ConstantLoad {oops
+    $desugar$3 = %55;
+    %57 = $default$1($desugar$2,$desugar$3) -> bb36;
+  }
   bb36 {
-    bjb = $desugar$12;
-    %66 = newObject ballerina/io:ReadableCharacterChannel
-    %67 = ConstantLoad UTF-8
-    %68 = init(%66,bjb,%67) -> bb37;
+    $desugar$4 = %57;
+    %60 = fileWriteString($desugar$2,$desugar$3,$desugar$4) -> bb37;
   }
   bb37 {
-    %70 = %68 is nil
-    %70 ? bb38 : bb39;
+    %61 = %60 is error
+    %61 ? bb38 : bb39;
   }
   bb38 {
-    %69 = %66;
-    GOTO bb40;
+    %0 = %60;
+    return;
   }
   bb39 {
-    %69 = %68;
+    %59 = %60;
     GOTO bb40;
   }
   bb40 {
-    bjc = %69;
-    %72 = readJson(bjc) -> bb41;
+    %63 = openReadableFile(bpath) -> bb41;
   }
   bb41 {
+    %64 = %63 is error
+    %64 ? bb42 : bb43;
+  }
+  bb42 {
+    %0 = %63;
+    return;
+  }
+  bb43 {
+    %62 = %63;
+    GOTO bb44;
+  }
+  bb44 {
+    bjb = %62;
+    %66 = newObject ballerina/io:ReadableCharacterChannel
+    %67 = ConstantLoad UTF-8
+    %68 = init(%66,bjb,%67) -> bb45;
+  }
+  bb45 {
+    %70 = %68 is nil
+    %70 ? bb46 : bb47;
+  }
+  bb46 {
+    %69 = %66;
+    GOTO bb48;
+  }
+  bb47 {
+    %69 = %68;
+    GOTO bb48;
+  }
+  bb48 {
+    bjc = %69;
+    %72 = readJson(bjc) -> bb49;
+  }
+  bb49 {
     bad = %72;
     %74 = bad is error
     %75 = %74;
-    %76 = println(%75) -> bb42;
+    %76 = println(%75) -> bb50;
   }
-  bb42 {
-    %77 = close(bjc) -> bb43;
+  bb50 {
+    %78 = close(bjc) -> bb51;
   }
-  bb43 {
-    $desugar$13 = %77;
-    %79 = $desugar$13 is error
-    %79 ? bb44 : bb45;
+  bb51 {
+    %79 = %78 is error
+    %79 ? bb52 : bb53;
   }
-  bb44 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
+  bb52 {
+    %0 = %78;
     return;
   }
-  bb45 {
+  bb53 {
+    %77 = %78;
+    GOTO bb54;
+  }
+  bb54 {
     %80 = ConstantLoad note
     %81 = ConstantLoad to
     %82 = ConstantLoad Tove
@@ -236,419 +245,438 @@ main() -> nil|error{
     note = %85;
     %87 = ConstantLoad /tmp/bal_io_char_xml.xml
     xpath = %87;
-    $desugar$14 = xpath;
-    %90 = $default$11($desugar$14) -> bb46;
-  }
-  bb46 {
-    $desugar$15 = %90;
-    %92 = openWritableFile($desugar$14,$desugar$15) -> bb47;
-  }
-  bb47 {
-    $desugar$16 = %92;
-    %94 = $desugar$16 is error
-    %94 ? bb48 : bb49;
-  }
-  bb48 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$16);
-    PopScopeFrame
-    return;
-  }
-  bb49 {
-    wxb1 = $desugar$16;
-    %96 = newObject ballerina/io:WritableCharacterChannel
-    %97 = ConstantLoad UTF-8
-    %98 = init(%96,wxb1,%97) -> bb50;
-  }
-  bb50 {
-    %100 = %98 is nil
-    %100 ? bb51 : bb52;
-  }
-  bb51 {
-    %99 = %96;
-    GOTO bb53;
-  }
-  bb52 {
-    %99 = %98;
-    GOTO bb53;
-  }
-  bb53 {
-    wxc1 = %99;
-    %102 = ConstantLoad system
-    %103 = ConstantLoad note.dtd
-    %104 = newMap {| internalSubset: nil|string, public: nil|string, system: nil|string, never... |}{%102=%103} defaults{system=ballerina/io:$desugar$0, public=ballerina/io:$desugar$1, internalSubset=ballerina/io:$desugar$2}
-    %105 = writeXml(wxc1,note,%104) -> bb54;
-  }
-  bb54 {
-    $desugar$17 = %105;
-    %107 = $desugar$17 is error
-    %107 ? bb55 : bb56;
+    $desugar$5 = xpath;
+    %90 = $default$11($desugar$5) -> bb55;
   }
   bb55 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
-    return;
+    $desugar$6 = %90;
+    %93 = openWritableFile($desugar$5,$desugar$6) -> bb56;
   }
   bb56 {
-    %108 = close(wxc1) -> bb57;
+    %94 = %93 is error
+    %94 ? bb57 : bb58;
   }
   bb57 {
-    $desugar$18 = %108;
-    %110 = $desugar$18 is error
-    %110 ? bb58 : bb59;
+    %0 = %93;
+    return;
   }
   bb58 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
-    return;
+    %92 = %93;
+    GOTO bb59;
   }
   bb59 {
-    %111 = fileReadString(xpath) -> bb60;
+    wxb1 = %92;
+    %96 = newObject ballerina/io:WritableCharacterChannel
+    %97 = ConstantLoad UTF-8
+    %98 = init(%96,wxb1,%97) -> bb60;
   }
   bb60 {
-    $desugar$19 = %111;
-    %113 = $desugar$19 is error
-    %113 ? bb61 : bb62;
+    %100 = %98 is nil
+    %100 ? bb61 : bb62;
   }
   bb61 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$19);
-    PopScopeFrame
-    return;
+    %99 = %96;
+    GOTO bb63;
   }
   bb62 {
-    %114 = println($desugar$19) -> bb63;
+    %99 = %98;
+    GOTO bb63;
   }
   bb63 {
-    $desugar$20 = xpath;
-    %116 = $default$11($desugar$20) -> bb64;
+    wxc1 = %99;
+    %103 = ConstantLoad system
+    %104 = ConstantLoad note.dtd
+    %105 = newMap {| internalSubset: nil|string, public: nil|string, system: nil|string, never... |}{%103=%104} defaults{system=ballerina/io:$desugar$0, public=ballerina/io:$desugar$1, internalSubset=ballerina/io:$desugar$2}
+    %106 = writeXml(wxc1,note,%105) -> bb64;
   }
   bb64 {
-    $desugar$21 = %116;
-    %118 = openWritableFile($desugar$20,$desugar$21) -> bb65;
+    %107 = %106 is error
+    %107 ? bb65 : bb66;
   }
   bb65 {
-    $desugar$22 = %118;
-    %120 = $desugar$22 is error
-    %120 ? bb66 : bb67;
-  }
-  bb66 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
+    %0 = %106;
     return;
   }
+  bb66 {
+    %102 = %106;
+    GOTO bb67;
+  }
   bb67 {
-    wxb2 = $desugar$22;
-    %122 = newObject ballerina/io:WritableCharacterChannel
-    %123 = ConstantLoad UTF-8
-    %124 = init(%122,wxb2,%123) -> bb68;
+    %109 = close(wxc1) -> bb68;
   }
   bb68 {
-    %126 = %124 is nil
-    %126 ? bb69 : bb70;
+    %110 = %109 is error
+    %110 ? bb69 : bb70;
   }
   bb69 {
-    %125 = %122;
-    GOTO bb71;
+    %0 = %109;
+    return;
   }
   bb70 {
-    %125 = %124;
+    %108 = %109;
     GOTO bb71;
   }
   bb71 {
-    wxc2 = %125;
-    %128 = ConstantLoad public
-    %129 = ConstantLoad -//W3C//DTD//EN
-    %130 = ConstantLoad system
-    %131 = ConstantLoad note.dtd
-    %132 = newMap {| internalSubset: nil|string, public: nil|string, system: nil|string, never... |}{%128=%129, %130=%131} defaults{system=ballerina/io:$desugar$0, public=ballerina/io:$desugar$1, internalSubset=ballerina/io:$desugar$2}
-    %133 = writeXml(wxc2,note,%132) -> bb72;
+    %112 = fileReadString(xpath) -> bb72;
   }
   bb72 {
-    $desugar$23 = %133;
-    %135 = $desugar$23 is error
-    %135 ? bb73 : bb74;
+    %113 = %112 is error
+    %113 ? bb73 : bb74;
   }
   bb73 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$23);
-    PopScopeFrame
+    %0 = %112;
     return;
   }
   bb74 {
-    %136 = close(wxc2) -> bb75;
+    %111 = %112;
+    GOTO bb75;
   }
   bb75 {
-    $desugar$24 = %136;
-    %138 = $desugar$24 is error
-    %138 ? bb76 : bb77;
+    %114 = println(%111) -> bb76;
   }
   bb76 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$24);
-    PopScopeFrame
-    return;
+    $desugar$7 = xpath;
+    %116 = $default$11($desugar$7) -> bb77;
   }
   bb77 {
-    %139 = fileReadString(xpath) -> bb78;
+    $desugar$8 = %116;
+    %119 = openWritableFile($desugar$7,$desugar$8) -> bb78;
   }
   bb78 {
-    $desugar$25 = %139;
-    %141 = $desugar$25 is error
-    %141 ? bb79 : bb80;
+    %120 = %119 is error
+    %120 ? bb79 : bb80;
   }
   bb79 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$25);
-    PopScopeFrame
+    %0 = %119;
     return;
   }
   bb80 {
-    %142 = println($desugar$25) -> bb81;
+    %118 = %119;
+    GOTO bb81;
   }
   bb81 {
-    $desugar$26 = xpath;
-    %144 = $default$11($desugar$26) -> bb82;
+    wxb2 = %118;
+    %122 = newObject ballerina/io:WritableCharacterChannel
+    %123 = ConstantLoad UTF-8
+    %124 = init(%122,wxb2,%123) -> bb82;
   }
   bb82 {
-    $desugar$27 = %144;
-    %146 = openWritableFile($desugar$26,$desugar$27) -> bb83;
+    %126 = %124 is nil
+    %126 ? bb83 : bb84;
   }
   bb83 {
-    $desugar$28 = %146;
-    %148 = $desugar$28 is error
-    %148 ? bb84 : bb85;
+    %125 = %122;
+    GOTO bb85;
   }
   bb84 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$28);
-    PopScopeFrame
-    return;
+    %125 = %124;
+    GOTO bb85;
   }
   bb85 {
-    wxb3 = $desugar$28;
-    %150 = newObject ballerina/io:WritableCharacterChannel
-    %151 = ConstantLoad UTF-8
-    %152 = init(%150,wxb3,%151) -> bb86;
+    wxc2 = %125;
+    %129 = ConstantLoad public
+    %130 = ConstantLoad -//W3C//DTD//EN
+    %131 = ConstantLoad system
+    %132 = ConstantLoad note.dtd
+    %133 = newMap {| internalSubset: nil|string, public: nil|string, system: nil|string, never... |}{%129=%130, %131=%132} defaults{system=ballerina/io:$desugar$0, public=ballerina/io:$desugar$1, internalSubset=ballerina/io:$desugar$2}
+    %134 = writeXml(wxc2,note,%133) -> bb86;
   }
   bb86 {
-    %154 = %152 is nil
-    %154 ? bb87 : bb88;
+    %135 = %134 is error
+    %135 ? bb87 : bb88;
   }
   bb87 {
-    %153 = %150;
-    GOTO bb89;
+    %0 = %134;
+    return;
   }
   bb88 {
-    %153 = %152;
+    %128 = %134;
     GOTO bb89;
   }
   bb89 {
-    wxc3 = %153;
-    %156 = ConstantLoad internalSubset
-    %157 = ConstantLoad [<!ELEMENT to (#PCDATA)>]
-    %158 = newMap {| internalSubset: nil|string, public: nil|string, system: nil|string, never... |}{%156=%157} defaults{system=ballerina/io:$desugar$0, public=ballerina/io:$desugar$1, internalSubset=ballerina/io:$desugar$2}
-    %159 = writeXml(wxc3,note,%158) -> bb90;
+    %137 = close(wxc2) -> bb90;
   }
   bb90 {
-    $desugar$29 = %159;
-    %161 = $desugar$29 is error
-    %161 ? bb91 : bb92;
+    %138 = %137 is error
+    %138 ? bb91 : bb92;
   }
   bb91 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$29);
-    PopScopeFrame
+    %0 = %137;
     return;
   }
   bb92 {
-    %162 = close(wxc3) -> bb93;
+    %136 = %137;
+    GOTO bb93;
   }
   bb93 {
-    $desugar$30 = %162;
-    %164 = $desugar$30 is error
-    %164 ? bb94 : bb95;
+    %140 = fileReadString(xpath) -> bb94;
   }
   bb94 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$30);
-    PopScopeFrame
-    return;
+    %141 = %140 is error
+    %141 ? bb95 : bb96;
   }
   bb95 {
-    %165 = fileReadString(xpath) -> bb96;
+    %0 = %140;
+    return;
   }
   bb96 {
-    $desugar$31 = %165;
-    %167 = $desugar$31 is error
-    %167 ? bb97 : bb98;
+    %139 = %140;
+    GOTO bb97;
   }
   bb97 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$31);
-    PopScopeFrame
-    return;
+    %142 = println(%139) -> bb98;
   }
   bb98 {
-    %168 = println($desugar$31) -> bb99;
+    $desugar$9 = xpath;
+    %144 = $default$11($desugar$9) -> bb99;
   }
   bb99 {
-    $desugar$32 = xpath;
-    %170 = $default$11($desugar$32) -> bb100;
+    $desugar$10 = %144;
+    %147 = openWritableFile($desugar$9,$desugar$10) -> bb100;
   }
   bb100 {
-    $desugar$33 = %170;
-    %172 = openWritableFile($desugar$32,$desugar$33) -> bb101;
+    %148 = %147 is error
+    %148 ? bb101 : bb102;
   }
   bb101 {
-    $desugar$34 = %172;
-    %174 = $desugar$34 is error
-    %174 ? bb102 : bb103;
-  }
-  bb102 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$34);
-    PopScopeFrame
+    %0 = %147;
     return;
   }
+  bb102 {
+    %146 = %147;
+    GOTO bb103;
+  }
   bb103 {
-    wxb4 = $desugar$34;
-    %176 = newObject ballerina/io:WritableCharacterChannel
-    %177 = ConstantLoad UTF-8
-    %178 = init(%176,wxb4,%177) -> bb104;
+    wxb3 = %146;
+    %150 = newObject ballerina/io:WritableCharacterChannel
+    %151 = ConstantLoad UTF-8
+    %152 = init(%150,wxb3,%151) -> bb104;
   }
   bb104 {
-    %180 = %178 is nil
-    %180 ? bb105 : bb106;
+    %154 = %152 is nil
+    %154 ? bb105 : bb106;
   }
   bb105 {
-    %179 = %176;
+    %153 = %150;
     GOTO bb107;
   }
   bb106 {
-    %179 = %178;
+    %153 = %152;
     GOTO bb107;
   }
   bb107 {
-    wxc4 = %179;
-    $desugar$35 = note;
-    %183 = $default$8($desugar$35) -> bb108;
+    wxc3 = %153;
+    %157 = ConstantLoad internalSubset
+    %158 = ConstantLoad [<!ELEMENT to (#PCDATA)>]
+    %159 = newMap {| internalSubset: nil|string, public: nil|string, system: nil|string, never... |}{%157=%158} defaults{system=ballerina/io:$desugar$0, public=ballerina/io:$desugar$1, internalSubset=ballerina/io:$desugar$2}
+    %160 = writeXml(wxc3,note,%159) -> bb108;
   }
   bb108 {
-    $desugar$36 = %183;
-    %185 = writeXml(wxc4,$desugar$35,$desugar$36) -> bb109;
+    %161 = %160 is error
+    %161 ? bb109 : bb110;
   }
   bb109 {
-    $desugar$37 = %185;
-    %187 = $desugar$37 is error
-    %187 ? bb110 : bb111;
-  }
-  bb110 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$37);
-    PopScopeFrame
+    %0 = %160;
     return;
   }
+  bb110 {
+    %156 = %160;
+    GOTO bb111;
+  }
   bb111 {
-    %188 = close(wxc4) -> bb112;
+    %163 = close(wxc3) -> bb112;
   }
   bb112 {
-    $desugar$38 = %188;
-    %190 = $desugar$38 is error
-    %190 ? bb113 : bb114;
+    %164 = %163 is error
+    %164 ? bb113 : bb114;
   }
   bb113 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$38);
-    PopScopeFrame
+    %0 = %163;
     return;
   }
   bb114 {
-    %191 = fileReadString(xpath) -> bb115;
+    %162 = %163;
+    GOTO bb115;
   }
   bb115 {
-    $desugar$39 = %191;
-    %193 = $desugar$39 is error
-    %193 ? bb116 : bb117;
+    %166 = fileReadString(xpath) -> bb116;
   }
   bb116 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$39);
-    PopScopeFrame
-    return;
+    %167 = %166 is error
+    %167 ? bb117 : bb118;
   }
   bb117 {
-    %194 = println($desugar$39) -> bb118;
-  }
-  bb118 {
-    %195 = openReadableFile(xpath) -> bb119;
-  }
-  bb119 {
-    $desugar$40 = %195;
-    %197 = $desugar$40 is error
-    %197 ? bb120 : bb121;
-  }
-  bb120 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$40);
-    PopScopeFrame
+    %0 = %166;
     return;
   }
+  bb118 {
+    %165 = %166;
+    GOTO bb119;
+  }
+  bb119 {
+    %168 = println(%165) -> bb120;
+  }
+  bb120 {
+    $desugar$11 = xpath;
+    %170 = $default$11($desugar$11) -> bb121;
+  }
   bb121 {
-    rxb = $desugar$40;
-    %199 = newObject ballerina/io:ReadableCharacterChannel
-    %200 = ConstantLoad UTF-8
-    %201 = init(%199,rxb,%200) -> bb122;
+    $desugar$12 = %170;
+    %173 = openWritableFile($desugar$11,$desugar$12) -> bb122;
   }
   bb122 {
-    %203 = %201 is nil
-    %203 ? bb123 : bb124;
+    %174 = %173 is error
+    %174 ? bb123 : bb124;
   }
   bb123 {
-    %202 = %199;
-    GOTO bb125;
+    %0 = %173;
+    return;
   }
   bb124 {
-    %202 = %201;
+    %172 = %173;
     GOTO bb125;
   }
   bb125 {
-    rxc = %202;
-    %205 = readXml(rxc) -> bb126;
+    wxb4 = %172;
+    %176 = newObject ballerina/io:WritableCharacterChannel
+    %177 = ConstantLoad UTF-8
+    %178 = init(%176,wxb4,%177) -> bb126;
   }
   bb126 {
-    $desugar$41 = %205;
-    %207 = $desugar$41 is error
-    %207 ? bb127 : bb128;
+    %180 = %178 is nil
+    %180 ? bb127 : bb128;
   }
   bb127 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$41);
-    PopScopeFrame
-    return;
+    %179 = %176;
+    GOTO bb129;
   }
   bb128 {
-    parsed = $desugar$41;
-    %209 = println(parsed) -> bb129;
+    %179 = %178;
+    GOTO bb129;
   }
   bb129 {
-    %210 = close(rxc) -> bb130;
+    wxc4 = %179;
+    $desugar$13 = note;
+    %183 = $default$8($desugar$13) -> bb130;
   }
   bb130 {
-    $desugar$42 = %210;
-    %212 = $desugar$42 is error
-    %212 ? bb131 : bb132;
+    $desugar$14 = %183;
+    %186 = writeXml(wxc4,$desugar$13,$desugar$14) -> bb131;
   }
   bb131 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$42);
-    PopScopeFrame
-    return;
+    %187 = %186 is error
+    %187 ? bb132 : bb133;
   }
   bb132 {
+    %0 = %186;
+    return;
+  }
+  bb133 {
+    %185 = %186;
+    GOTO bb134;
+  }
+  bb134 {
+    %189 = close(wxc4) -> bb135;
+  }
+  bb135 {
+    %190 = %189 is error
+    %190 ? bb136 : bb137;
+  }
+  bb136 {
+    %0 = %189;
+    return;
+  }
+  bb137 {
+    %188 = %189;
+    GOTO bb138;
+  }
+  bb138 {
+    %192 = fileReadString(xpath) -> bb139;
+  }
+  bb139 {
+    %193 = %192 is error
+    %193 ? bb140 : bb141;
+  }
+  bb140 {
+    %0 = %192;
+    return;
+  }
+  bb141 {
+    %191 = %192;
+    GOTO bb142;
+  }
+  bb142 {
+    %194 = println(%191) -> bb143;
+  }
+  bb143 {
+    %196 = openReadableFile(xpath) -> bb144;
+  }
+  bb144 {
+    %197 = %196 is error
+    %197 ? bb145 : bb146;
+  }
+  bb145 {
+    %0 = %196;
+    return;
+  }
+  bb146 {
+    %195 = %196;
+    GOTO bb147;
+  }
+  bb147 {
+    rxb = %195;
+    %199 = newObject ballerina/io:ReadableCharacterChannel
+    %200 = ConstantLoad UTF-8
+    %201 = init(%199,rxb,%200) -> bb148;
+  }
+  bb148 {
+    %203 = %201 is nil
+    %203 ? bb149 : bb150;
+  }
+  bb149 {
+    %202 = %199;
+    GOTO bb151;
+  }
+  bb150 {
+    %202 = %201;
+    GOTO bb151;
+  }
+  bb151 {
+    rxc = %202;
+    %206 = readXml(rxc) -> bb152;
+  }
+  bb152 {
+    %207 = %206 is error
+    %207 ? bb153 : bb154;
+  }
+  bb153 {
+    %0 = %206;
+    return;
+  }
+  bb154 {
+    %205 = %206;
+    GOTO bb155;
+  }
+  bb155 {
+    parsed = %205;
+    %209 = println(parsed) -> bb156;
+  }
+  bb156 {
+    %211 = close(rxc) -> bb157;
+  }
+  bb157 {
+    %212 = %211 is error
+    %212 ? bb158 : bb159;
+  }
+  bb158 {
+    %0 = %211;
+    return;
+  }
+  bb159 {
+    %210 = %211;
+    GOTO bb160;
+  }
+  bb160 {
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-char-channel-props-v.txt
+++ b/corpus/bir/library/subset3/io-char-channel-props-v.txt
@@ -22,492 +22,511 @@ nl=a\nb
   }
   bb1 {
     $desugar$2 = %7;
-    %9 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %10 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %9;
-    %11 = $desugar$3 is error
+    %11 = %10 is error
     %11 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %10;
     return;
   }
   bb4 {
-    %12 = openReadableFile(path) -> bb5;
+    %9 = %10;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %12;
-    %14 = $desugar$4 is error
-    %14 ? bb6 : bb7;
+    %13 = openReadableFile(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %14 = %13 is error
+    %14 ? bb7 : bb8;
   }
   bb7 {
-    rb = $desugar$4;
-    %16 = newObject ballerina/io:ReadableCharacterChannel
-    %17 = ConstantLoad UTF-8
-    %18 = init(%16,rb,%17) -> bb8;
+    %0 = %13;
+    return;
   }
   bb8 {
-    %20 = %18 is nil
-    %20 ? bb9 : bb10;
+    %12 = %13;
+    GOTO bb9;
   }
   bb9 {
-    %19 = %16;
-    GOTO bb11;
+    rb = %12;
+    %16 = newObject ballerina/io:ReadableCharacterChannel
+    %17 = ConstantLoad UTF-8
+    %18 = init(%16,rb,%17) -> bb10;
   }
   bb10 {
-    %19 = %18;
-    GOTO bb11;
+    %20 = %18 is nil
+    %20 ? bb11 : bb12;
   }
   bb11 {
-    rc = %19;
-    %22 = ConstantLoad name
-    $desugar$5 = %22;
-    %24 = $default$7($desugar$5) -> bb12;
+    %19 = %16;
+    GOTO bb13;
   }
   bb12 {
-    $desugar$6 = %24;
-    %26 = readProperty(rc,$desugar$5,$desugar$6) -> bb13;
+    %19 = %18;
+    GOTO bb13;
   }
   bb13 {
-    $desugar$7 = %26;
-    %28 = $desugar$7 is error
-    %28 ? bb14 : bb15;
+    rc = %19;
+    %22 = ConstantLoad name
+    $desugar$3 = %22;
+    %24 = $default$7($desugar$3) -> bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    $desugar$4 = %24;
+    %27 = readProperty(rc,$desugar$3,$desugar$4) -> bb15;
   }
   bb15 {
-    %29 = println($desugar$7) -> bb16;
+    %28 = %27 is error
+    %28 ? bb16 : bb17;
   }
   bb16 {
-    %30 = ConstantLoad spaced.key
-    $desugar$8 = %30;
-    %32 = $default$7($desugar$8) -> bb17;
+    %0 = %27;
+    return;
   }
   bb17 {
-    $desugar$9 = %32;
-    %34 = readProperty(rc,$desugar$8,$desugar$9) -> bb18;
+    %26 = %27;
+    GOTO bb18;
   }
   bb18 {
-    $desugar$10 = %34;
-    %36 = $desugar$10 is error
-    %36 ? bb19 : bb20;
+    %29 = println(%26) -> bb19;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
-    return;
+    %30 = ConstantLoad spaced.key
+    $desugar$5 = %30;
+    %32 = $default$7($desugar$5) -> bb20;
   }
   bb20 {
-    %37 = ConstantLoad [
-    %38 = ConstantLoad ]
-    %39 = println(%37,$desugar$10,%38) -> bb21;
+    $desugar$6 = %32;
+    %34 = ConstantLoad [
+    %36 = readProperty(rc,$desugar$5,$desugar$6) -> bb21;
   }
   bb21 {
-    %40 = ConstantLoad missing
-    %41 = ConstantLoad fallback
-    %42 = readProperty(rc,%40,%41) -> bb22;
+    %37 = %36 is error
+    %37 ? bb22 : bb23;
   }
   bb22 {
-    $desugar$11 = %42;
-    %44 = $desugar$11 is error
-    %44 ? bb23 : bb24;
+    %0 = %36;
+    return;
   }
   bb23 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
-    return;
+    %35 = %36;
+    GOTO bb24;
   }
   bb24 {
-    %45 = println($desugar$11) -> bb25;
+    %38 = ConstantLoad ]
+    %39 = println(%34,%35,%38) -> bb25;
   }
   bb25 {
-    %46 = ConstantLoad esc:aped
-    $desugar$12 = %46;
-    %48 = $default$7($desugar$12) -> bb26;
+    %41 = ConstantLoad missing
+    %42 = ConstantLoad fallback
+    %43 = readProperty(rc,%41,%42) -> bb26;
   }
   bb26 {
-    $desugar$13 = %48;
-    %50 = readProperty(rc,$desugar$12,$desugar$13) -> bb27;
+    %44 = %43 is error
+    %44 ? bb27 : bb28;
   }
   bb27 {
-    $desugar$14 = %50;
-    %52 = $desugar$14 is error
-    %52 ? bb28 : bb29;
-  }
-  bb28 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
+    %0 = %43;
     return;
   }
+  bb28 {
+    %40 = %43;
+    GOTO bb29;
+  }
   bb29 {
-    %53 = println($desugar$14) -> bb30;
+    %45 = println(%40) -> bb30;
   }
   bb30 {
-    %54 = ConstantLoad multi
-    $desugar$15 = %54;
-    %56 = $default$7($desugar$15) -> bb31;
+    %46 = ConstantLoad esc:aped
+    $desugar$7 = %46;
+    %48 = $default$7($desugar$7) -> bb31;
   }
   bb31 {
-    $desugar$16 = %56;
-    %58 = readProperty(rc,$desugar$15,$desugar$16) -> bb32;
+    $desugar$8 = %48;
+    %51 = readProperty(rc,$desugar$7,$desugar$8) -> bb32;
   }
   bb32 {
-    $desugar$17 = %58;
-    %60 = $desugar$17 is error
-    %60 ? bb33 : bb34;
+    %52 = %51 is error
+    %52 ? bb33 : bb34;
   }
   bb33 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
+    %0 = %51;
     return;
   }
   bb34 {
-    %61 = println($desugar$17) -> bb35;
+    %50 = %51;
+    GOTO bb35;
   }
   bb35 {
-    %62 = ConstantLoad tabbed
-    $desugar$18 = %62;
-    %64 = $default$7($desugar$18) -> bb36;
+    %53 = println(%50) -> bb36;
   }
   bb36 {
-    $desugar$19 = %64;
-    %66 = readProperty(rc,$desugar$18,$desugar$19) -> bb37;
+    %54 = ConstantLoad multi
+    $desugar$9 = %54;
+    %56 = $default$7($desugar$9) -> bb37;
   }
   bb37 {
-    $desugar$20 = %66;
-    %68 = $desugar$20 is error
-    %68 ? bb38 : bb39;
+    $desugar$10 = %56;
+    %59 = readProperty(rc,$desugar$9,$desugar$10) -> bb38;
   }
   bb38 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
+    %60 = %59 is error
+    %60 ? bb39 : bb40;
   }
   bb39 {
-    %69 = println($desugar$20) -> bb40;
+    %0 = %59;
+    return;
   }
   bb40 {
-    %70 = ConstantLoad uni
-    $desugar$21 = %70;
-    %72 = $default$7($desugar$21) -> bb41;
+    %58 = %59;
+    GOTO bb41;
   }
   bb41 {
-    $desugar$22 = %72;
-    %74 = readProperty(rc,$desugar$21,$desugar$22) -> bb42;
+    %61 = println(%58) -> bb42;
   }
   bb42 {
-    $desugar$23 = %74;
-    %76 = $desugar$23 is error
-    %76 ? bb43 : bb44;
+    %62 = ConstantLoad tabbed
+    $desugar$11 = %62;
+    %64 = $default$7($desugar$11) -> bb43;
   }
   bb43 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$23);
-    PopScopeFrame
-    return;
+    $desugar$12 = %64;
+    %67 = readProperty(rc,$desugar$11,$desugar$12) -> bb44;
   }
   bb44 {
-    %77 = println($desugar$23) -> bb45;
+    %68 = %67 is error
+    %68 ? bb45 : bb46;
   }
   bb45 {
-    %78 = ConstantLoad nl
-    $desugar$24 = %78;
-    %80 = $default$7($desugar$24) -> bb46;
+    %0 = %67;
+    return;
   }
   bb46 {
-    $desugar$25 = %80;
-    %82 = readProperty(rc,$desugar$24,$desugar$25) -> bb47;
+    %66 = %67;
+    GOTO bb47;
   }
   bb47 {
-    $desugar$26 = %82;
-    %84 = $desugar$26 is error
-    %84 ? bb48 : bb49;
+    %69 = println(%66) -> bb48;
   }
   bb48 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$26);
-    PopScopeFrame
-    return;
+    %70 = ConstantLoad uni
+    $desugar$13 = %70;
+    %72 = $default$7($desugar$13) -> bb49;
   }
   bb49 {
-    nl = $desugar$26;
-    %86 = length(nl) -> bb50;
+    $desugar$14 = %72;
+    %75 = readProperty(rc,$desugar$13,$desugar$14) -> bb50;
   }
   bb50 {
-    %87 = %86;
-    %88 = println(%87) -> bb51;
+    %76 = %75 is error
+    %76 ? bb51 : bb52;
   }
   bb51 {
-    %89 = readAllProperties(rc) -> bb52;
-  }
-  bb52 {
-    $desugar$27 = %89;
-    %91 = $desugar$27 is error
-    %91 ? bb53 : bb54;
-  }
-  bb53 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$27);
-    PopScopeFrame
+    %0 = %75;
     return;
   }
+  bb52 {
+    %74 = %75;
+    GOTO bb53;
+  }
+  bb53 {
+    %77 = println(%74) -> bb54;
+  }
   bb54 {
-    all = $desugar$27;
-    %93 = length(all) -> bb55;
+    %78 = ConstantLoad nl
+    $desugar$15 = %78;
+    %80 = $default$7($desugar$15) -> bb55;
   }
   bb55 {
-    %94 = %93;
-    %95 = println(%94) -> bb56;
+    $desugar$16 = %80;
+    %83 = readProperty(rc,$desugar$15,$desugar$16) -> bb56;
   }
   bb56 {
+    %84 = %83 is error
+    %84 ? bb57 : bb58;
+  }
+  bb57 {
+    %0 = %83;
+    return;
+  }
+  bb58 {
+    %82 = %83;
+    GOTO bb59;
+  }
+  bb59 {
+    nl = %82;
+    %86 = length(nl) -> bb60;
+  }
+  bb60 {
+    %87 = %86;
+    %88 = println(%87) -> bb61;
+  }
+  bb61 {
+    %90 = readAllProperties(rc) -> bb62;
+  }
+  bb62 {
+    %91 = %90 is error
+    %91 ? bb63 : bb64;
+  }
+  bb63 {
+    %0 = %90;
+    return;
+  }
+  bb64 {
+    %89 = %90;
+    GOTO bb65;
+  }
+  bb65 {
+    all = %89;
+    %93 = length(all) -> bb66;
+  }
+  bb66 {
+    %94 = %93;
+    %95 = println(%94) -> bb67;
+  }
+  bb67 {
     %98 = ConstantLoad empty
     %97 = all[%98];
     %99 = ConstantLoad 
     %96 = == %97 %99;
     %100 = %96;
-    %101 = println(%100) -> bb57;
-  }
-  bb57 {
-    %102 = close(rc) -> bb58;
-  }
-  bb58 {
-    $desugar$28 = %102;
-    %104 = $desugar$28 is error
-    %104 ? bb59 : bb60;
-  }
-  bb59 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$28);
-    PopScopeFrame
-    return;
-  }
-  bb60 {
-    %105 = ConstantLoad /tmp/bal_io_char_props_out.properties
-    wpath = %105;
-    $desugar$29 = wpath;
-    %108 = $default$11($desugar$29) -> bb61;
-  }
-  bb61 {
-    $desugar$30 = %108;
-    %110 = openWritableFile($desugar$29,$desugar$30) -> bb62;
-  }
-  bb62 {
-    $desugar$31 = %110;
-    %112 = $desugar$31 is error
-    %112 ? bb63 : bb64;
-  }
-  bb63 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$31);
-    PopScopeFrame
-    return;
-  }
-  bb64 {
-    wb = $desugar$31;
-    %114 = newObject ballerina/io:WritableCharacterChannel
-    %115 = ConstantLoad UTF-8
-    %116 = init(%114,wb,%115) -> bb65;
-  }
-  bb65 {
-    %118 = %116 is nil
-    %118 ? bb66 : bb67;
-  }
-  bb66 {
-    %117 = %114;
-    GOTO bb68;
-  }
-  bb67 {
-    %117 = %116;
-    GOTO bb68;
+    %101 = println(%100) -> bb68;
   }
   bb68 {
-    wc = %117;
-    %120 = ConstantLoad key one
-    %121 = ConstantLoad value=1
-    %122 = ConstantLoad plain
-    %123 = ConstantLoad text
-    %124 = ConstantLoad uni
-    %125 = ConstantLoad ü
-    %126 = ConstantLoad tab
-    %127 = ConstantLoad a	b
-    %128 = ConstantLoad line
-    %129 = ConstantLoad a
-b
-    %130 = newMap {| string... |}{%120=%121, %122=%123, %124=%125, %126=%127, %128=%129}
-    %131 = ConstantLoad first line
-second line
-    %132 = writeProperties(wc,%130,%131) -> bb69;
+    %103 = close(rc) -> bb69;
   }
   bb69 {
-    $desugar$32 = %132;
-    %134 = $desugar$32 is error
-    %134 ? bb70 : bb71;
+    %104 = %103 is error
+    %104 ? bb70 : bb71;
   }
   bb70 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$32);
-    PopScopeFrame
+    %0 = %103;
     return;
   }
   bb71 {
-    %135 = close(wc) -> bb72;
+    %102 = %103;
+    GOTO bb72;
   }
   bb72 {
-    $desugar$33 = %135;
-    %137 = $desugar$33 is error
-    %137 ? bb73 : bb74;
+    %105 = ConstantLoad /tmp/bal_io_char_props_out.properties
+    wpath = %105;
+    $desugar$17 = wpath;
+    %108 = $default$11($desugar$17) -> bb73;
   }
   bb73 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$33);
-    PopScopeFrame
-    return;
+    $desugar$18 = %108;
+    %111 = openWritableFile($desugar$17,$desugar$18) -> bb74;
   }
   bb74 {
-    %138 = fileReadLines(wpath) -> bb75;
+    %112 = %111 is error
+    %112 ? bb75 : bb76;
   }
   bb75 {
-    $desugar$34 = %138;
-    %140 = $desugar$34 is error
-    %140 ? bb76 : bb77;
+    %0 = %111;
+    return;
   }
   bb76 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$34);
-    PopScopeFrame
-    return;
+    %110 = %111;
+    GOTO bb77;
   }
   bb77 {
-    outLines = $desugar$34;
-    %143 = ConstantLoad 0
-    %142 = outLines[%143];
-    %144 = println(%142) -> bb78;
+    wb = %110;
+    %114 = newObject ballerina/io:WritableCharacterChannel
+    %115 = ConstantLoad UTF-8
+    %116 = init(%114,wb,%115) -> bb78;
   }
   bb78 {
-    %146 = ConstantLoad 1
-    %145 = outLines[%146];
-    %147 = println(%145) -> bb79;
+    %118 = %116 is nil
+    %118 ? bb79 : bb80;
   }
   bb79 {
-    %148 = openReadableFile(wpath) -> bb80;
+    %117 = %114;
+    GOTO bb81;
   }
   bb80 {
-    $desugar$35 = %148;
-    %150 = $desugar$35 is error
-    %150 ? bb81 : bb82;
+    %117 = %116;
+    GOTO bb81;
   }
   bb81 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$35);
-    PopScopeFrame
-    return;
+    wc = %117;
+    %121 = ConstantLoad key one
+    %122 = ConstantLoad value=1
+    %123 = ConstantLoad plain
+    %124 = ConstantLoad text
+    %125 = ConstantLoad uni
+    %126 = ConstantLoad ü
+    %127 = ConstantLoad tab
+    %128 = ConstantLoad a	b
+    %129 = ConstantLoad line
+    %130 = ConstantLoad a
+b
+    %131 = newMap {| string... |}{%121=%122, %123=%124, %125=%126, %127=%128, %129=%130}
+    %132 = ConstantLoad first line
+second line
+    %133 = writeProperties(wc,%131,%132) -> bb82;
   }
   bb82 {
-    vb = $desugar$35;
-    %152 = newObject ballerina/io:ReadableCharacterChannel
-    %153 = ConstantLoad UTF-8
-    %154 = init(%152,vb,%153) -> bb83;
+    %134 = %133 is error
+    %134 ? bb83 : bb84;
   }
   bb83 {
-    %156 = %154 is nil
-    %156 ? bb84 : bb85;
-  }
-  bb84 {
-    %155 = %152;
-    GOTO bb86;
-  }
-  bb85 {
-    %155 = %154;
-    GOTO bb86;
-  }
-  bb86 {
-    vc = %155;
-    %158 = readAllProperties(vc) -> bb87;
-  }
-  bb87 {
-    $desugar$36 = %158;
-    %160 = $desugar$36 is error
-    %160 ? bb88 : bb89;
-  }
-  bb88 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$36);
-    PopScopeFrame
+    %0 = %133;
     return;
   }
+  bb84 {
+    %120 = %133;
+    GOTO bb85;
+  }
+  bb85 {
+    %136 = close(wc) -> bb86;
+  }
+  bb86 {
+    %137 = %136 is error
+    %137 ? bb87 : bb88;
+  }
+  bb87 {
+    %0 = %136;
+    return;
+  }
+  bb88 {
+    %135 = %136;
+    GOTO bb89;
+  }
   bb89 {
-    written = $desugar$36;
-    %162 = length(written) -> bb90;
+    %139 = fileReadLines(wpath) -> bb90;
   }
   bb90 {
-    %163 = %162;
-    %164 = println(%163) -> bb91;
+    %140 = %139 is error
+    %140 ? bb91 : bb92;
   }
   bb91 {
-    %166 = ConstantLoad key one
-    %165 = written[%166];
-    %167 = println(%165) -> bb92;
+    %0 = %139;
+    return;
   }
   bb92 {
-    %169 = ConstantLoad plain
-    %168 = written[%169];
-    %170 = println(%168) -> bb93;
+    %138 = %139;
+    GOTO bb93;
   }
   bb93 {
-    %172 = ConstantLoad uni
-    %171 = written[%172];
-    %173 = println(%171) -> bb94;
+    outLines = %138;
+    %143 = ConstantLoad 0
+    %142 = outLines[%143];
+    %144 = println(%142) -> bb94;
   }
   bb94 {
+    %146 = ConstantLoad 1
+    %145 = outLines[%146];
+    %147 = println(%145) -> bb95;
+  }
+  bb95 {
+    %149 = openReadableFile(wpath) -> bb96;
+  }
+  bb96 {
+    %150 = %149 is error
+    %150 ? bb97 : bb98;
+  }
+  bb97 {
+    %0 = %149;
+    return;
+  }
+  bb98 {
+    %148 = %149;
+    GOTO bb99;
+  }
+  bb99 {
+    vb = %148;
+    %152 = newObject ballerina/io:ReadableCharacterChannel
+    %153 = ConstantLoad UTF-8
+    %154 = init(%152,vb,%153) -> bb100;
+  }
+  bb100 {
+    %156 = %154 is nil
+    %156 ? bb101 : bb102;
+  }
+  bb101 {
+    %155 = %152;
+    GOTO bb103;
+  }
+  bb102 {
+    %155 = %154;
+    GOTO bb103;
+  }
+  bb103 {
+    vc = %155;
+    %159 = readAllProperties(vc) -> bb104;
+  }
+  bb104 {
+    %160 = %159 is error
+    %160 ? bb105 : bb106;
+  }
+  bb105 {
+    %0 = %159;
+    return;
+  }
+  bb106 {
+    %158 = %159;
+    GOTO bb107;
+  }
+  bb107 {
+    written = %158;
+    %162 = length(written) -> bb108;
+  }
+  bb108 {
+    %163 = %162;
+    %164 = println(%163) -> bb109;
+  }
+  bb109 {
+    %166 = ConstantLoad key one
+    %165 = written[%166];
+    %167 = println(%165) -> bb110;
+  }
+  bb110 {
+    %169 = ConstantLoad plain
+    %168 = written[%169];
+    %170 = println(%168) -> bb111;
+  }
+  bb111 {
+    %172 = ConstantLoad uni
+    %171 = written[%172];
+    %173 = println(%171) -> bb112;
+  }
+  bb112 {
     %176 = ConstantLoad tab
     %175 = written[%176];
     %177 = ConstantLoad a	b
     %174 = == %175 %177;
     %178 = %174;
-    %179 = println(%178) -> bb95;
+    %179 = println(%178) -> bb113;
   }
-  bb95 {
+  bb113 {
     %182 = ConstantLoad line
     %181 = written[%182];
     %183 = ConstantLoad a
 b
     %180 = == %181 %183;
     %184 = %180;
-    %185 = println(%184) -> bb96;
+    %185 = println(%184) -> bb114;
   }
-  bb96 {
-    %186 = close(vc) -> bb97;
+  bb114 {
+    %187 = close(vc) -> bb115;
   }
-  bb97 {
-    $desugar$37 = %186;
-    %188 = $desugar$37 is error
-    %188 ? bb98 : bb99;
+  bb115 {
+    %188 = %187 is error
+    %188 ? bb116 : bb117;
   }
-  bb98 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$37);
-    PopScopeFrame
+  bb116 {
+    %0 = %187;
     return;
   }
-  bb99 {
+  bb117 {
+    %186 = %187;
+    GOTO bb118;
+  }
+  bb118 {
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-char-channel-read-v.txt
+++ b/corpus/bir/library/subset3/io-char-channel-read-v.txt
@@ -11,382 +11,334 @@ wörld
   }
   bb1 {
     $desugar$2 = %6;
-    %8 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %9 = fileWriteString($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %8;
-    %10 = $desugar$3 is error
+    %10 = %9 is error
     %10 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %9;
     return;
   }
   bb4 {
-    %11 = ConstantLoad 13
-    %12 = ConstantLoad 10
-    %13 = ConstantLoad 2
-    %14 = newArray [int:Unsigned8...][%13]{%11, %12}
-    %15 = ConstantLoad APPEND
-    %16 = fileWriteBytes(path,%14,%15) -> bb5;
+    %8 = %9;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %16;
-    %18 = $desugar$4 is error
-    %18 ? bb6 : bb7;
+    %12 = ConstantLoad 13
+    %13 = ConstantLoad 10
+    %14 = ConstantLoad 2
+    %15 = newArray [int:Unsigned8...][%14]{%12, %13}
+    %16 = ConstantLoad APPEND
+    %17 = fileWriteBytes(path,%15,%16) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %18 = %17 is error
+    %18 ? bb7 : bb8;
   }
   bb7 {
-    %19 = ConstantLoad last
-    %20 = ConstantLoad APPEND
-    %21 = fileWriteString(path,%19,%20) -> bb8;
+    %0 = %17;
+    return;
   }
   bb8 {
-    $desugar$5 = %21;
-    %23 = $desugar$5 is error
-    %23 ? bb9 : bb10;
+    %11 = %17;
+    GOTO bb9;
   }
   bb9 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %20 = ConstantLoad last
+    %21 = ConstantLoad APPEND
+    %22 = fileWriteString(path,%20,%21) -> bb10;
   }
   bb10 {
-    %24 = openReadableFile(path) -> bb11;
+    %23 = %22 is error
+    %23 ? bb11 : bb12;
   }
   bb11 {
-    $desugar$6 = %24;
-    %26 = $desugar$6 is error
-    %26 ? bb12 : bb13;
-  }
-  bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+    %0 = %22;
     return;
   }
+  bb12 {
+    %19 = %22;
+    GOTO bb13;
+  }
   bb13 {
-    rb = $desugar$6;
-    %28 = newObject ballerina/io:ReadableCharacterChannel
-    %29 = ConstantLoad UTF-8
-    %30 = init(%28,rb,%29) -> bb14;
+    %25 = openReadableFile(path) -> bb14;
   }
   bb14 {
-    %32 = %30 is nil
-    %32 ? bb15 : bb16;
+    %26 = %25 is error
+    %26 ? bb15 : bb16;
   }
   bb15 {
-    %31 = %28;
-    GOTO bb17;
+    %0 = %25;
+    return;
   }
   bb16 {
-    %31 = %30;
+    %24 = %25;
     GOTO bb17;
   }
   bb17 {
-    rc = %31;
-    %34 = ConstantLoad 5
-    %35 = %34;
-    %36 = read(rc,%35) -> bb18;
+    rb = %24;
+    %28 = newObject ballerina/io:ReadableCharacterChannel
+    %29 = ConstantLoad UTF-8
+    %30 = init(%28,rb,%29) -> bb18;
   }
   bb18 {
-    $desugar$7 = %36;
-    %38 = $desugar$7 is error
-    %38 ? bb19 : bb20;
+    %32 = %30 is nil
+    %32 ? bb19 : bb20;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    %31 = %28;
+    GOTO bb21;
   }
   bb20 {
-    first = $desugar$7;
-    %40 = println(first) -> bb21;
+    %31 = %30;
+    GOTO bb21;
   }
   bb21 {
-    %41 = readString(rc) -> bb22;
+    rc = %31;
+    %35 = ConstantLoad 5
+    %36 = %35;
+    %37 = read(rc,%36) -> bb22;
   }
   bb22 {
-    $desugar$8 = %41;
-    %43 = $desugar$8 is error
-    %43 ? bb23 : bb24;
+    %38 = %37 is error
+    %38 ? bb23 : bb24;
   }
   bb23 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
+    %0 = %37;
     return;
   }
   bb24 {
-    rest = $desugar$8;
-    %45 = println(rest) -> bb25;
+    %34 = %37;
+    GOTO bb25;
   }
   bb25 {
-    %46 = ConstantLoad 1
-    %47 = %46;
-    %48 = read(rc,%47) -> bb26;
+    first = %34;
+    %40 = println(first) -> bb26;
   }
   bb26 {
-    atEnd = %48;
-    %50 = atEnd is error
-    %50 ? bb27 : bb30;
+    %42 = readString(rc) -> bb27;
   }
   bb27 {
-    PushScopeFrame 2
-    %0 = message((1, atEnd)) -> bb28;
+    %43 = %42 is error
+    %43 ? bb28 : bb29;
   }
   bb28 {
-    %1 = println(%0) -> bb29;
+    %0 = %42;
+    return;
   }
   bb29 {
-    PopScopeFrame
+    %41 = %42;
     GOTO bb30;
   }
   bb30 {
-    PushScopeFrame 6
-    %0 = close((1, rc)) -> bb31;
+    rest = %41;
+    %45 = println(rest) -> bb31;
   }
   bb31 {
-    $desugar$9 = %0;
-    %2 = $desugar$9 is error
-    %2 ? bb32 : bb33;
+    %46 = ConstantLoad 1
+    %47 = %46;
+    %48 = read(rc,%47) -> bb32;
   }
   bb32 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$9);
+    atEnd = %48;
+    %50 = atEnd is error
+    %50 ? bb33 : bb36;
+  }
+  bb33 {
+    PushScopeFrame 2
+    %0 = message((1, atEnd)) -> bb34;
+  }
+  bb34 {
+    %1 = println(%0) -> bb35;
+  }
+  bb35 {
     PopScopeFrame
+    GOTO bb36;
+  }
+  bb36 {
+    PushScopeFrame 6
+    %1 = close((1, rc)) -> bb37;
+  }
+  bb37 {
+    %2 = %1 is error
+    %2 ? bb38 : bb39;
+  }
+  bb38 {
+    (1, %0) = %1;
     PopScopeFrame
     return;
   }
-  bb33 {
-    %3 = close((1, rc)) -> bb34;
+  bb39 {
+    %0 = %1;
+    GOTO bb40;
   }
-  bb34 {
+  bb40 {
+    %3 = close((1, rc)) -> bb41;
+  }
+  bb41 {
     closedAgain = %3;
     %5 = closedAgain is error
-    %5 ? bb35 : bb38;
+    %5 ? bb42 : bb45;
   }
-  bb35 {
+  bb42 {
     PushScopeFrame 2
-    %0 = message((1, closedAgain)) -> bb36;
+    %0 = message((1, closedAgain)) -> bb43;
   }
-  bb36 {
-    %1 = println(%0) -> bb37;
+  bb43 {
+    %1 = println(%0) -> bb44;
   }
-  bb37 {
+  bb44 {
     PopScopeFrame
-    GOTO bb38;
+    GOTO bb45;
   }
-  bb38 {
+  bb45 {
     PushScopeFrame 5
     %0 = ConstantLoad 1
     %1 = %0;
-    %2 = read((2, rc),%1) -> bb39;
-  }
-  bb39 {
-    afterClose = %2;
-    %4 = afterClose is error
-    %4 ? bb40 : bb43;
-  }
-  bb40 {
-    PushScopeFrame 2
-    %0 = message((1, afterClose)) -> bb41;
-  }
-  bb41 {
-    %1 = println(%0) -> bb42;
-  }
-  bb42 {
-    PopScopeFrame
-    GOTO bb43;
-  }
-  bb43 {
-    PushScopeFrame 34
-    %0 = ConstantLoad 97
-    %1 = ConstantLoad 98
-    %2 = ConstantLoad 2
-    %3 = newArray [int:Unsigned8...][%2]{%0, %1}
-    %4 = createReadableChannel(%3) -> bb44;
-  }
-  bb44 {
-    $desugar$10 = %4;
-    %6 = $desugar$10 is error
-    %6 ? bb45 : bb46;
-  }
-  bb45 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$10);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %2 = read((2, rc),%1) -> bb46;
   }
   bb46 {
-    mb = $desugar$10;
-    %8 = newObject ballerina/io:ReadableCharacterChannel
-    %9 = ConstantLoad UTF-8
-    %10 = init(%8,mb,%9) -> bb47;
+    afterClose = %2;
+    %4 = afterClose is error
+    %4 ? bb47 : bb50;
   }
   bb47 {
-    %12 = %10 is nil
-    %12 ? bb48 : bb49;
+    PushScopeFrame 2
+    %0 = message((1, afterClose)) -> bb48;
   }
   bb48 {
-    %11 = %8;
-    GOTO bb50;
+    %1 = println(%0) -> bb49;
   }
   bb49 {
-    %11 = %10;
+    PopScopeFrame
     GOTO bb50;
   }
   bb50 {
-    mc = %11;
-    %14 = ConstantLoad 2
-    %15 = %14;
-    %16 = read(mc,%15) -> bb51;
+    PushScopeFrame 34
+    %1 = ConstantLoad 97
+    %2 = ConstantLoad 98
+    %3 = ConstantLoad 2
+    %4 = newArray [int:Unsigned8...][%3]{%1, %2}
+    %5 = createReadableChannel(%4) -> bb51;
   }
   bb51 {
-    $desugar$11 = %16;
-    %18 = $desugar$11 is error
-    %18 ? bb52 : bb53;
+    %6 = %5 is error
+    %6 ? bb52 : bb53;
   }
   bb52 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$11);
-    PopScopeFrame
+    (3, %0) = %5;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
   bb53 {
-    %19 = println($desugar$11) -> bb54;
+    %0 = %5;
+    GOTO bb54;
   }
   bb54 {
-    %20 = ConstantLoad 1
-    %21 = %20;
-    %22 = read(mc,%21) -> bb55;
+    mb = %0;
+    %8 = newObject ballerina/io:ReadableCharacterChannel
+    %9 = ConstantLoad UTF-8
+    %10 = init(%8,mb,%9) -> bb55;
   }
   bb55 {
-    $desugar$12 = %22;
-    %24 = $desugar$12 is error
-    %24 ? bb56 : bb57;
+    %12 = %10 is nil
+    %12 ? bb56 : bb57;
   }
   bb56 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$12);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %11 = %8;
+    GOTO bb58;
   }
   bb57 {
-    empty = $desugar$12;
-    %26 = length(empty) -> bb58;
+    %11 = %10;
+    GOTO bb58;
   }
   bb58 {
-    %27 = %26;
-    %28 = println(%27) -> bb59;
+    mc = %11;
+    %15 = ConstantLoad 2
+    %16 = %15;
+    %17 = read(mc,%16) -> bb59;
   }
   bb59 {
-    %29 = ConstantLoad 1
-    %30 = %29;
-    %31 = read(mc,%30) -> bb60;
+    %18 = %17 is error
+    %18 ? bb60 : bb61;
   }
   bb60 {
-    eof = %31;
-    %33 = eof is error
-    %33 ? bb61 : bb64;
+    (3, %0) = %17;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb61 {
-    PushScopeFrame 2
-    %0 = message((1, eof)) -> bb62;
+    %14 = %17;
+    GOTO bb62;
   }
   bb62 {
-    %1 = println(%0) -> bb63;
+    %19 = println(%14) -> bb63;
   }
   bb63 {
-    PopScopeFrame
-    GOTO bb64;
+    %21 = ConstantLoad 1
+    %22 = %21;
+    %23 = read(mc,%22) -> bb64;
   }
   bb64 {
-    PushScopeFrame 43
-    %0 = close((1, mc)) -> bb65;
+    %24 = %23 is error
+    %24 ? bb65 : bb66;
   }
   bb65 {
-    $desugar$13 = %0;
-    %2 = $desugar$13 is error
-    %2 ? bb66 : bb67;
+    (3, %0) = %23;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb66 {
-    PushScopeFrame 0
-    (5, %0) = (1, $desugar$13);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %20 = %23;
+    GOTO bb67;
   }
   bb67 {
-    %3 = openReadableFile((4, path)) -> bb68;
+    empty = %20;
+    %26 = length(empty) -> bb68;
   }
   bb68 {
-    $desugar$14 = %3;
-    %5 = $desugar$14 is error
-    %5 ? bb69 : bb70;
+    %27 = %26;
+    %28 = println(%27) -> bb69;
   }
   bb69 {
-    PushScopeFrame 0
-    (5, %0) = (1, $desugar$14);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %29 = ConstantLoad 1
+    %30 = %29;
+    %31 = read(mc,%30) -> bb70;
   }
   bb70 {
-    lb = $desugar$14;
-    %7 = newObject ballerina/io:ReadableCharacterChannel
-    %8 = ConstantLoad UTF-8
-    %9 = init(%7,lb,%8) -> bb71;
+    eof = %31;
+    %33 = eof is error
+    %33 ? bb71 : bb74;
   }
   bb71 {
-    %11 = %9 is nil
-    %11 ? bb72 : bb73;
+    PushScopeFrame 2
+    %0 = message((1, eof)) -> bb72;
   }
   bb72 {
-    %10 = %7;
-    GOTO bb74;
+    %1 = println(%0) -> bb73;
   }
   bb73 {
-    %10 = %9;
+    PopScopeFrame
     GOTO bb74;
   }
   bb74 {
-    lc = %10;
-    %13 = readAllLines(lc) -> bb75;
+    PushScopeFrame 43
+    %1 = close((1, mc)) -> bb75;
   }
   bb75 {
-    $desugar$15 = %13;
-    %15 = $desugar$15 is error
-    %15 ? bb76 : bb77;
+    %2 = %1 is error
+    %2 ? bb76 : bb77;
   }
   bb76 {
-    PushScopeFrame 0
-    (5, %0) = (1, $desugar$15);
-    PopScopeFrame
+    (4, %0) = %1;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
@@ -394,160 +346,221 @@ wörld
     return;
   }
   bb77 {
-    lines = $desugar$15;
-    %17 = length(lines) -> bb78;
+    %0 = %1;
+    GOTO bb78;
   }
   bb78 {
-    %18 = %17;
-    %19 = println(%18) -> bb79;
+    %4 = openReadableFile((4, path)) -> bb79;
   }
   bb79 {
-    %21 = ConstantLoad 1
-    %20 = lines[%21];
-    %22 = println(%20) -> bb80;
+    %5 = %4 is error
+    %5 ? bb80 : bb81;
   }
   bb80 {
-    %23 = close(lc) -> bb81;
+    (4, %0) = %4;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb81 {
-    $desugar$16 = %23;
-    %25 = $desugar$16 is error
-    %25 ? bb82 : bb83;
+    %3 = %4;
+    GOTO bb82;
   }
   bb82 {
-    PushScopeFrame 0
-    (5, %0) = (1, $desugar$16);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    lb = %3;
+    %7 = newObject ballerina/io:ReadableCharacterChannel
+    %8 = ConstantLoad UTF-8
+    %9 = init(%7,lb,%8) -> bb83;
   }
   bb83 {
-    %26 = openReadableFile((4, path)) -> bb84;
+    %11 = %9 is nil
+    %11 ? bb84 : bb85;
   }
   bb84 {
-    $desugar$17 = %26;
-    %28 = $desugar$17 is error
-    %28 ? bb85 : bb86;
+    %10 = %7;
+    GOTO bb86;
   }
   bb85 {
-    PushScopeFrame 0
-    (5, %0) = (1, $desugar$17);
-    PopScopeFrame
+    %10 = %9;
+    GOTO bb86;
+  }
+  bb86 {
+    lc = %10;
+    %14 = readAllLines(lc) -> bb87;
+  }
+  bb87 {
+    %15 = %14 is error
+    %15 ? bb88 : bb89;
+  }
+  bb88 {
+    (4, %0) = %14;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
-  bb86 {
-    sb = $desugar$17;
-    %30 = newObject ballerina/io:ReadableCharacterChannel
-    %31 = ConstantLoad UTF-8
-    %32 = init(%30,sb,%31) -> bb87;
-  }
-  bb87 {
-    %34 = %32 is nil
-    %34 ? bb88 : bb89;
-  }
-  bb88 {
-    %33 = %30;
-    GOTO bb90;
-  }
   bb89 {
-    %33 = %32;
+    %13 = %14;
     GOTO bb90;
   }
   bb90 {
-    sc = %33;
-    %36 = lineStream(sc) -> bb91;
+    lines = %13;
+    %17 = length(lines) -> bb91;
   }
   bb91 {
-    $desugar$18 = %36;
-    %38 = $desugar$18 is error
-    %38 ? bb92 : bb93;
+    %18 = %17;
+    %19 = println(%18) -> bb92;
   }
   bb92 {
-    PushScopeFrame 0
-    (5, %0) = (1, $desugar$18);
-    PopScopeFrame
+    %21 = ConstantLoad 1
+    %20 = lines[%21];
+    %22 = println(%20) -> bb93;
+  }
+  bb93 {
+    %24 = close(lc) -> bb94;
+  }
+  bb94 {
+    %25 = %24 is error
+    %25 ? bb95 : bb96;
+  }
+  bb95 {
+    (4, %0) = %24;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
-  bb93 {
-    ls = $desugar$18;
+  bb96 {
+    %23 = %24;
+    GOTO bb97;
+  }
+  bb97 {
+    %27 = openReadableFile((4, path)) -> bb98;
+  }
+  bb98 {
+    %28 = %27 is error
+    %28 ? bb99 : bb100;
+  }
+  bb99 {
+    (4, %0) = %27;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb100 {
+    %26 = %27;
+    GOTO bb101;
+  }
+  bb101 {
+    sb = %26;
+    %30 = newObject ballerina/io:ReadableCharacterChannel
+    %31 = ConstantLoad UTF-8
+    %32 = init(%30,sb,%31) -> bb102;
+  }
+  bb102 {
+    %34 = %32 is nil
+    %34 ? bb103 : bb104;
+  }
+  bb103 {
+    %33 = %30;
+    GOTO bb105;
+  }
+  bb104 {
+    %33 = %32;
+    GOTO bb105;
+  }
+  bb105 {
+    sc = %33;
+    %37 = lineStream(sc) -> bb106;
+  }
+  bb106 {
+    %38 = %37 is error
+    %38 ? bb107 : bb108;
+  }
+  bb107 {
+    (4, %0) = %37;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb108 {
+    %36 = %37;
+    GOTO bb109;
+  }
+  bb109 {
+    ls = %36;
     %40 = streamNext ls
     l1 = %40;
     %42 = l1 is {| value: string, never... |}
-    %42 ? bb94 : bb96;
+    %42 ? bb110 : bb112;
   }
-  bb94 {
+  bb110 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, l1)[%1];
-    %2 = println(%0) -> bb95;
+    %2 = println(%0) -> bb111;
   }
-  bb95 {
+  bb111 {
     PopScopeFrame
-    GOTO bb96;
+    GOTO bb112;
   }
-  bb96 {
+  bb112 {
     PushScopeFrame 3
     %0 = streamNext (1, ls)
     l2 = %0;
     %2 = l2 is {| value: string, never... |}
-    %2 ? bb97 : bb99;
+    %2 ? bb113 : bb115;
   }
-  bb97 {
+  bb113 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, l2)[%1];
-    %2 = println(%0) -> bb98;
+    %2 = println(%0) -> bb114;
   }
-  bb98 {
+  bb114 {
     PopScopeFrame
-    GOTO bb99;
+    GOTO bb115;
   }
-  bb99 {
+  bb115 {
     PushScopeFrame 3
     %0 = streamNext (2, ls)
     l3 = %0;
     %2 = l3 is {| value: string, never... |}
-    %2 ? bb100 : bb102;
+    %2 ? bb116 : bb118;
   }
-  bb100 {
+  bb116 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, l3)[%1];
-    %2 = println(%0) -> bb101;
+    %2 = println(%0) -> bb117;
   }
-  bb101 {
+  bb117 {
     PopScopeFrame
-    GOTO bb102;
+    GOTO bb118;
   }
-  bb102 {
+  bb118 {
     PushScopeFrame 8
     %0 = streamNext (3, ls)
     l4 = %0;
     %2 = l4 is nil
     %3 = %2;
-    %4 = println(%3) -> bb103;
+    %4 = println(%3) -> bb119;
   }
-  bb103 {
-    %5 = streamClose (3, ls)
-    $desugar$19 = %5;
-    %7 = $desugar$19 is error
-    %7 ? bb104 : bb105;
+  bb119 {
+    %6 = streamClose (3, ls)
+    %7 = %6 is error
+    %7 ? bb120 : bb121;
   }
-  bb104 {
-    PushScopeFrame 0
-    (8, %0) = (1, $desugar$19);
-    PopScopeFrame
+  bb120 {
+    (7, %0) = %6;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
@@ -557,7 +570,11 @@ wörld
     PopScopeFrame
     return;
   }
-  bb105 {
+  bb121 {
+    %5 = %6;
+    GOTO bb122;
+  }
+  bb122 {
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame

--- a/corpus/bir/library/subset3/io-char-channel-write-v.txt
+++ b/corpus/bir/library/subset3/io-char-channel-write-v.txt
@@ -8,145 +8,127 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %4;
-    %6 = openWritableFile($desugar$0,$desugar$1) -> bb2;
+    %7 = openWritableFile($desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    $desugar$2 = %6;
-    %8 = $desugar$2 is error
+    %8 = %7 is error
     %8 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %7;
     return;
   }
   bb4 {
-    wb = $desugar$2;
-    %10 = newObject ballerina/io:WritableCharacterChannel
-    %11 = ConstantLoad UTF-8
-    %12 = init(%10,wb,%11) -> bb5;
+    %6 = %7;
+    GOTO bb5;
   }
   bb5 {
-    %14 = %12 is nil
-    %14 ? bb6 : bb7;
+    wb = %6;
+    %10 = newObject ballerina/io:WritableCharacterChannel
+    %11 = ConstantLoad UTF-8
+    %12 = init(%10,wb,%11) -> bb6;
   }
   bb6 {
-    %13 = %10;
-    GOTO bb8;
+    %14 = %12 is nil
+    %14 ? bb7 : bb8;
   }
   bb7 {
-    %13 = %12;
-    GOTO bb8;
+    %13 = %10;
+    GOTO bb9;
   }
   bb8 {
-    wc = %13;
-    %16 = ConstantLoad héllo wörld
-    %17 = ConstantLoad 0
-    %18 = %17;
-    %19 = write(wc,%16,%18) -> bb9;
+    %13 = %12;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$3 = %19;
-    %21 = $desugar$3 is error
-    %21 ? bb10 : bb11;
+    wc = %13;
+    %17 = ConstantLoad héllo wörld
+    %18 = ConstantLoad 0
+    %19 = %18;
+    %20 = write(wc,%17,%19) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %21 = %20 is error
+    %21 ? bb11 : bb12;
   }
   bb11 {
-    n1 = $desugar$3;
-    %23 = n1;
-    %24 = println(%23) -> bb12;
+    %0 = %20;
+    return;
   }
   bb12 {
-    %25 = ConstantLoad abc
-    %26 = ConstantLoad 1
-    %27 = %26;
-    %28 = write(wc,%25,%27) -> bb13;
+    %16 = %20;
+    GOTO bb13;
   }
   bb13 {
-    $desugar$4 = %28;
-    %30 = $desugar$4 is error
-    %30 ? bb14 : bb15;
+    n1 = %16;
+    %23 = n1;
+    %24 = println(%23) -> bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %26 = ConstantLoad abc
+    %27 = ConstantLoad 1
+    %28 = %27;
+    %29 = write(wc,%26,%28) -> bb15;
   }
   bb15 {
-    n2 = $desugar$4;
-    %32 = n2;
-    %33 = println(%32) -> bb16;
+    %30 = %29 is error
+    %30 ? bb16 : bb17;
   }
   bb16 {
-    %34 = ConstantLoad !
-    %35 = writeLine(wc,%34) -> bb17;
-  }
-  bb17 {
-    $desugar$5 = %35;
-    %37 = $desugar$5 is error
-    %37 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %29;
     return;
   }
+  bb17 {
+    %25 = %29;
+    GOTO bb18;
+  }
+  bb18 {
+    n2 = %25;
+    %32 = n2;
+    %33 = println(%32) -> bb19;
+  }
   bb19 {
-    %38 = close(wc) -> bb20;
+    %35 = ConstantLoad !
+    %36 = writeLine(wc,%35) -> bb20;
   }
   bb20 {
-    $desugar$6 = %38;
-    %40 = $desugar$6 is error
-    %40 ? bb21 : bb22;
+    %37 = %36 is error
+    %37 ? bb21 : bb22;
   }
   bb21 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+    %0 = %36;
     return;
   }
   bb22 {
-    %41 = close(wc) -> bb23;
+    %34 = %36;
+    GOTO bb23;
   }
   bb23 {
-    closedWrite = %41;
-    %43 = closedWrite is error
-    %43 ? bb24 : bb27;
+    %39 = close(wc) -> bb24;
   }
   bb24 {
-    PushScopeFrame 2
-    %0 = message((1, closedWrite)) -> bb25;
+    %40 = %39 is error
+    %40 ? bb25 : bb26;
   }
   bb25 {
-    %1 = println(%0) -> bb26;
+    %0 = %39;
+    return;
   }
   bb26 {
-    PopScopeFrame
+    %38 = %39;
     GOTO bb27;
   }
   bb27 {
-    PushScopeFrame 6
-    %0 = ConstantLoad x
-    %1 = ConstantLoad 0
-    %2 = %1;
-    %3 = write((1, wc),%0,%2) -> bb28;
+    %41 = close(wc) -> bb28;
   }
   bb28 {
-    afterClose = %3;
-    %5 = afterClose is error
-    %5 ? bb29 : bb32;
+    closedWrite = %41;
+    %43 = closedWrite is error
+    %43 ? bb29 : bb32;
   }
   bb29 {
     PushScopeFrame 2
-    %0 = message((1, afterClose)) -> bb30;
+    %0 = message((1, closedWrite)) -> bb30;
   }
   bb30 {
     %1 = println(%0) -> bb31;
@@ -156,433 +138,473 @@ main() -> nil|error{
     GOTO bb32;
   }
   bb32 {
-    PushScopeFrame 129
-    %0 = fileReadString((2, path)) -> bb33;
+    PushScopeFrame 6
+    %0 = ConstantLoad x
+    %1 = ConstantLoad 0
+    %2 = %1;
+    %3 = write((1, wc),%0,%2) -> bb33;
   }
   bb33 {
-    $desugar$7 = %0;
-    %2 = $desugar$7 is error
-    %2 ? bb34 : bb35;
+    afterClose = %3;
+    %5 = afterClose is error
+    %5 ? bb34 : bb37;
   }
   bb34 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$7);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    PushScopeFrame 2
+    %0 = message((1, afterClose)) -> bb35;
   }
   bb35 {
-    %3 = println($desugar$7) -> bb36;
+    %1 = println(%0) -> bb36;
   }
   bb36 {
-    %4 = ConstantLoad APPEND
-    %5 = openWritableFile((2, path),%4) -> bb37;
+    PopScopeFrame
+    GOTO bb37;
   }
   bb37 {
-    $desugar$8 = %5;
-    %7 = $desugar$8 is error
-    %7 ? bb38 : bb39;
+    PushScopeFrame 129
+    %1 = fileReadString((2, path)) -> bb38;
   }
   bb38 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$8);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %2 = %1 is error
+    %2 ? bb39 : bb40;
   }
   bb39 {
-    ab = $desugar$8;
-    %9 = newObject ballerina/io:WritableCharacterChannel
-    %10 = ConstantLoad UTF-8
-    %11 = init(%9,ab,%10) -> bb40;
+    (2, %0) = %1;
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb40 {
-    %13 = %11 is nil
-    %13 ? bb41 : bb42;
+    %0 = %1;
+    GOTO bb41;
   }
   bb41 {
-    %12 = %9;
-    GOTO bb43;
+    %3 = println(%0) -> bb42;
   }
   bb42 {
-    %12 = %11;
-    GOTO bb43;
+    %5 = ConstantLoad APPEND
+    %6 = openWritableFile((2, path),%5) -> bb43;
   }
   bb43 {
-    ac = %12;
-    %15 = ConstantLoad +more
-    %16 = ConstantLoad 0
-    %17 = %16;
-    %18 = write(ac,%15,%17) -> bb44;
+    %7 = %6 is error
+    %7 ? bb44 : bb45;
   }
   bb44 {
-    $desugar$9 = %18;
-    %20 = $desugar$9 is error
-    %20 ? bb45 : bb46;
+    (2, %0) = %6;
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb45 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$9);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %4 = %6;
+    GOTO bb46;
   }
   bb46 {
-    %21 = $desugar$9;
-    %22 = close(ac) -> bb47;
+    ab = %4;
+    %9 = newObject ballerina/io:WritableCharacterChannel
+    %10 = ConstantLoad UTF-8
+    %11 = init(%9,ab,%10) -> bb47;
   }
   bb47 {
-    $desugar$10 = %22;
-    %24 = $desugar$10 is error
-    %24 ? bb48 : bb49;
+    %13 = %11 is nil
+    %13 ? bb48 : bb49;
   }
   bb48 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$10);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %12 = %9;
+    GOTO bb50;
   }
   bb49 {
-    %25 = fileReadString((2, path)) -> bb50;
+    %12 = %11;
+    GOTO bb50;
   }
   bb50 {
-    $desugar$11 = %25;
-    %27 = $desugar$11 is error
-    %27 ? bb51 : bb52;
+    ac = %12;
+    %16 = ConstantLoad +more
+    %17 = ConstantLoad 0
+    %18 = %17;
+    %19 = write(ac,%16,%18) -> bb51;
   }
   bb51 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$11);
-    PopScopeFrame
+    %20 = %19 is error
+    %20 ? bb52 : bb53;
+  }
+  bb52 {
+    (2, %0) = %19;
     PopScopeFrame
     PopScopeFrame
     return;
   }
-  bb52 {
-    %28 = println($desugar$11) -> bb53;
-  }
   bb53 {
-    %29 = ConstantLoad /tmp/bal_io_char_write_latin1.txt
-    lpath = %29;
-    $desugar$12 = lpath;
-    %32 = $default$11($desugar$12) -> bb54;
+    %15 = %19;
+    GOTO bb54;
   }
   bb54 {
-    $desugar$13 = %32;
-    %34 = openWritableFile($desugar$12,$desugar$13) -> bb55;
+    %21 = %15;
+    %23 = close(ac) -> bb55;
   }
   bb55 {
-    $desugar$14 = %34;
-    %36 = $desugar$14 is error
-    %36 ? bb56 : bb57;
+    %24 = %23 is error
+    %24 ? bb56 : bb57;
   }
   bb56 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$14);
-    PopScopeFrame
+    (2, %0) = %23;
     PopScopeFrame
     PopScopeFrame
     return;
   }
   bb57 {
-    lb = $desugar$14;
-    %38 = newObject ballerina/io:WritableCharacterChannel
-    %39 = ConstantLoad ISO-8859-1
-    %40 = init(%38,lb,%39) -> bb58;
+    %22 = %23;
+    GOTO bb58;
   }
   bb58 {
-    %42 = %40 is nil
-    %42 ? bb59 : bb60;
+    %26 = fileReadString((2, path)) -> bb59;
   }
   bb59 {
-    %41 = %38;
-    GOTO bb61;
+    %27 = %26 is error
+    %27 ? bb60 : bb61;
   }
   bb60 {
-    %41 = %40;
-    GOTO bb61;
+    (2, %0) = %26;
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb61 {
-    lc = %41;
-    %44 = ConstantLoad café
-    %45 = ConstantLoad 0
-    %46 = %45;
-    %47 = write(lc,%44,%46) -> bb62;
+    %25 = %26;
+    GOTO bb62;
   }
   bb62 {
-    $desugar$15 = %47;
-    %49 = $desugar$15 is error
-    %49 ? bb63 : bb64;
+    %28 = println(%25) -> bb63;
   }
   bb63 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$15);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %29 = ConstantLoad /tmp/bal_io_char_write_latin1.txt
+    lpath = %29;
+    $desugar$2 = lpath;
+    %32 = $default$11($desugar$2) -> bb64;
   }
   bb64 {
-    n3 = $desugar$15;
-    %51 = n3;
-    %52 = println(%51) -> bb65;
+    $desugar$3 = %32;
+    %35 = openWritableFile($desugar$2,$desugar$3) -> bb65;
   }
   bb65 {
-    %53 = close(lc) -> bb66;
+    %36 = %35 is error
+    %36 ? bb66 : bb67;
   }
   bb66 {
-    $desugar$16 = %53;
-    %55 = $desugar$16 is error
-    %55 ? bb67 : bb68;
+    (2, %0) = %35;
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb67 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$16);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %34 = %35;
+    GOTO bb68;
   }
   bb68 {
-    %56 = fileReadBytes(lpath) -> bb69;
+    lb = %34;
+    %38 = newObject ballerina/io:WritableCharacterChannel
+    %39 = ConstantLoad ISO-8859-1
+    %40 = init(%38,lb,%39) -> bb69;
   }
   bb69 {
-    $desugar$17 = %56;
-    %58 = $desugar$17 is error
-    %58 ? bb70 : bb71;
+    %42 = %40 is nil
+    %42 ? bb70 : bb71;
   }
   bb70 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$17);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %41 = %38;
+    GOTO bb72;
   }
   bb71 {
-    latinBytes = $desugar$17;
-    %60 = length(latinBytes) -> bb72;
+    %41 = %40;
+    GOTO bb72;
   }
   bb72 {
-    %61 = %60;
-    %62 = println(%61) -> bb73;
+    lc = %41;
+    %45 = ConstantLoad café
+    %46 = ConstantLoad 0
+    %47 = %46;
+    %48 = write(lc,%45,%47) -> bb73;
   }
   bb73 {
-    %63 = openReadableFile(lpath) -> bb74;
+    %49 = %48 is error
+    %49 ? bb74 : bb75;
   }
   bb74 {
-    $desugar$18 = %63;
-    %65 = $desugar$18 is error
-    %65 ? bb75 : bb76;
+    (2, %0) = %48;
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb75 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$18);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %44 = %48;
+    GOTO bb76;
   }
   bb76 {
-    lrb = $desugar$18;
-    %67 = newObject ballerina/io:ReadableCharacterChannel
-    %68 = ConstantLoad ISO-8859-1
-    %69 = init(%67,lrb,%68) -> bb77;
+    n3 = %44;
+    %51 = n3;
+    %52 = println(%51) -> bb77;
   }
   bb77 {
-    %71 = %69 is nil
-    %71 ? bb78 : bb79;
+    %54 = close(lc) -> bb78;
   }
   bb78 {
-    %70 = %67;
-    GOTO bb80;
+    %55 = %54 is error
+    %55 ? bb79 : bb80;
   }
   bb79 {
-    %70 = %69;
-    GOTO bb80;
+    (2, %0) = %54;
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb80 {
-    lrc = %70;
-    %73 = readString(lrc) -> bb81;
+    %53 = %54;
+    GOTO bb81;
   }
   bb81 {
-    $desugar$19 = %73;
-    %75 = $desugar$19 is error
-    %75 ? bb82 : bb83;
+    %57 = fileReadBytes(lpath) -> bb82;
   }
   bb82 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$19);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %58 = %57 is error
+    %58 ? bb83 : bb84;
   }
   bb83 {
-    %76 = println($desugar$19) -> bb84;
+    (2, %0) = %57;
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb84 {
-    %77 = close(lrc) -> bb85;
+    %56 = %57;
+    GOTO bb85;
   }
   bb85 {
-    $desugar$20 = %77;
-    %79 = $desugar$20 is error
-    %79 ? bb86 : bb87;
+    latinBytes = %56;
+    %60 = length(latinBytes) -> bb86;
   }
   bb86 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$20);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %61 = %60;
+    %62 = println(%61) -> bb87;
   }
   bb87 {
-    %80 = ConstantLoad /tmp/bal_io_char_write_utf16.bin
-    upath = %80;
-    $desugar$21 = upath;
-    %83 = $default$11($desugar$21) -> bb88;
+    %64 = openReadableFile(lpath) -> bb88;
   }
   bb88 {
-    $desugar$22 = %83;
-    %85 = openWritableFile($desugar$21,$desugar$22) -> bb89;
+    %65 = %64 is error
+    %65 ? bb89 : bb90;
   }
   bb89 {
-    $desugar$23 = %85;
-    %87 = $desugar$23 is error
-    %87 ? bb90 : bb91;
-  }
-  bb90 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$23);
-    PopScopeFrame
+    (2, %0) = %64;
     PopScopeFrame
     PopScopeFrame
     return;
   }
+  bb90 {
+    %63 = %64;
+    GOTO bb91;
+  }
   bb91 {
-    ub = $desugar$23;
-    %89 = newObject ballerina/io:WritableCharacterChannel
-    %90 = ConstantLoad UTF-16
-    %91 = init(%89,ub,%90) -> bb92;
+    lrb = %63;
+    %67 = newObject ballerina/io:ReadableCharacterChannel
+    %68 = ConstantLoad ISO-8859-1
+    %69 = init(%67,lrb,%68) -> bb92;
   }
   bb92 {
-    %93 = %91 is nil
-    %93 ? bb93 : bb94;
+    %71 = %69 is nil
+    %71 ? bb93 : bb94;
   }
   bb93 {
-    %92 = %89;
+    %70 = %67;
     GOTO bb95;
   }
   bb94 {
-    %92 = %91;
+    %70 = %69;
     GOTO bb95;
   }
   bb95 {
-    uc = %92;
-    %95 = ConstantLoad hi
-    %96 = writeLine(uc,%95) -> bb96;
+    lrc = %70;
+    %74 = readString(lrc) -> bb96;
   }
   bb96 {
-    $desugar$24 = %96;
-    %98 = $desugar$24 is error
-    %98 ? bb97 : bb98;
+    %75 = %74 is error
+    %75 ? bb97 : bb98;
   }
   bb97 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$24);
-    PopScopeFrame
+    (2, %0) = %74;
     PopScopeFrame
     PopScopeFrame
     return;
   }
   bb98 {
-    %99 = ConstantLoad bye
-    %100 = writeLine(uc,%99) -> bb99;
+    %73 = %74;
+    GOTO bb99;
   }
   bb99 {
-    $desugar$25 = %100;
-    %102 = $desugar$25 is error
-    %102 ? bb100 : bb101;
+    %76 = println(%73) -> bb100;
   }
   bb100 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$25);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %78 = close(lrc) -> bb101;
   }
   bb101 {
-    %103 = close(uc) -> bb102;
+    %79 = %78 is error
+    %79 ? bb102 : bb103;
   }
   bb102 {
-    $desugar$26 = %103;
-    %105 = $desugar$26 is error
-    %105 ? bb103 : bb104;
+    (2, %0) = %78;
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb103 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$26);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %77 = %78;
+    GOTO bb104;
   }
   bb104 {
-    %106 = fileReadBytes(upath) -> bb105;
+    %80 = ConstantLoad /tmp/bal_io_char_write_utf16.bin
+    upath = %80;
+    $desugar$4 = upath;
+    %83 = $default$11($desugar$4) -> bb105;
   }
   bb105 {
-    $desugar$27 = %106;
-    %108 = $desugar$27 is error
-    %108 ? bb106 : bb107;
+    $desugar$5 = %83;
+    %86 = openWritableFile($desugar$4,$desugar$5) -> bb106;
   }
   bb106 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$27);
-    PopScopeFrame
+    %87 = %86 is error
+    %87 ? bb107 : bb108;
+  }
+  bb107 {
+    (2, %0) = %86;
     PopScopeFrame
     PopScopeFrame
     return;
   }
-  bb107 {
-    utf16Bytes = $desugar$27;
-    %110 = length(utf16Bytes) -> bb108;
-  }
   bb108 {
-    %111 = %110;
-    %112 = println(%111) -> bb109;
+    %85 = %86;
+    GOTO bb109;
   }
   bb109 {
+    ub = %85;
+    %89 = newObject ballerina/io:WritableCharacterChannel
+    %90 = ConstantLoad UTF-16
+    %91 = init(%89,ub,%90) -> bb110;
+  }
+  bb110 {
+    %93 = %91 is nil
+    %93 ? bb111 : bb112;
+  }
+  bb111 {
+    %92 = %89;
+    GOTO bb113;
+  }
+  bb112 {
+    %92 = %91;
+    GOTO bb113;
+  }
+  bb113 {
+    uc = %92;
+    %96 = ConstantLoad hi
+    %97 = writeLine(uc,%96) -> bb114;
+  }
+  bb114 {
+    %98 = %97 is error
+    %98 ? bb115 : bb116;
+  }
+  bb115 {
+    (2, %0) = %97;
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb116 {
+    %95 = %97;
+    GOTO bb117;
+  }
+  bb117 {
+    %100 = ConstantLoad bye
+    %101 = writeLine(uc,%100) -> bb118;
+  }
+  bb118 {
+    %102 = %101 is error
+    %102 ? bb119 : bb120;
+  }
+  bb119 {
+    (2, %0) = %101;
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb120 {
+    %99 = %101;
+    GOTO bb121;
+  }
+  bb121 {
+    %104 = close(uc) -> bb122;
+  }
+  bb122 {
+    %105 = %104 is error
+    %105 ? bb123 : bb124;
+  }
+  bb123 {
+    (2, %0) = %104;
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb124 {
+    %103 = %104;
+    GOTO bb125;
+  }
+  bb125 {
+    %107 = fileReadBytes(upath) -> bb126;
+  }
+  bb126 {
+    %108 = %107 is error
+    %108 ? bb127 : bb128;
+  }
+  bb127 {
+    (2, %0) = %107;
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb128 {
+    %106 = %107;
+    GOTO bb129;
+  }
+  bb129 {
+    utf16Bytes = %106;
+    %110 = length(utf16Bytes) -> bb130;
+  }
+  bb130 {
+    %111 = %110;
+    %112 = println(%111) -> bb131;
+  }
+  bb131 {
     %114 = ConstantLoad 0
     %113 = utf16Bytes[%114];
     %115 = %113;
-    %116 = println(%115) -> bb110;
+    %116 = println(%115) -> bb132;
   }
-  bb110 {
+  bb132 {
     %118 = ConstantLoad 1
     %117 = utf16Bytes[%118];
     %119 = %117;
-    %120 = println(%119) -> bb111;
+    %120 = println(%119) -> bb133;
   }
-  bb111 {
+  bb133 {
     %122 = ConstantLoad 8
     %121 = utf16Bytes[%122];
     %123 = %121;
-    %124 = println(%123) -> bb112;
+    %124 = println(%123) -> bb134;
   }
-  bb112 {
+  bb134 {
     %126 = ConstantLoad 9
     %125 = utf16Bytes[%126];
     %127 = %125;
-    %128 = println(%127) -> bb113;
+    %128 = println(%127) -> bb135;
   }
-  bb113 {
+  bb135 {
     PopScopeFrame
     PopScopeFrame
     return;

--- a/corpus/bir/library/subset3/io-char-channel-xml-nonelement-p.txt
+++ b/corpus/bir/library/subset3/io-char-channel-xml-nonelement-p.txt
@@ -7,38 +7,39 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$1 = %3;
-    %5 = openWritableFile($desugar$0,$desugar$1) -> bb2;
+    %6 = openWritableFile($desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    $desugar$2 = %5;
-    %7 = $desugar$2 is error
+    %7 = %6 is error
     %7 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %6;
     return;
   }
   bb4 {
-    wb = $desugar$2;
-    %9 = newObject ballerina/io:WritableCharacterChannel
-    %10 = ConstantLoad UTF-8
-    %11 = init(%9,wb,%10) -> bb5;
+    %5 = %6;
+    GOTO bb5;
   }
   bb5 {
-    %13 = %11 is nil
-    %13 ? bb6 : bb7;
+    wb = %5;
+    %9 = newObject ballerina/io:WritableCharacterChannel
+    %10 = ConstantLoad UTF-8
+    %11 = init(%9,wb,%10) -> bb6;
   }
   bb6 {
-    %12 = %9;
-    GOTO bb8;
+    %13 = %11 is nil
+    %13 ? bb7 : bb8;
   }
   bb7 {
-    %12 = %11;
-    GOTO bb8;
+    %12 = %9;
+    GOTO bb9;
   }
   bb8 {
+    %12 = %11;
+    GOTO bb9;
+  }
+  bb9 {
     wc = %12;
     %15 = ConstantLoad c
     %16 = newXMLComment(%15)
@@ -46,27 +47,28 @@ main() -> nil|error{
     %18 = newXMLElement(%17, ())
     %19 = newXMLSequence{%16, %18}
     seq = %19;
-    %21 = ConstantLoad system
-    %22 = ConstantLoad note.dtd
-    %23 = newMap {| internalSubset: nil|string, public: nil|string, system: nil|string, never... |}{%21=%22} defaults{system=ballerina/io:$desugar$0, public=ballerina/io:$desugar$1, internalSubset=ballerina/io:$desugar$2}
-    %24 = writeXml(wc,seq,%23) -> bb9;
-  }
-  bb9 {
-    $desugar$3 = %24;
-    %26 = $desugar$3 is error
-    %26 ? bb10 : bb11;
+    %22 = ConstantLoad system
+    %23 = ConstantLoad note.dtd
+    %24 = newMap {| internalSubset: nil|string, public: nil|string, system: nil|string, never... |}{%22=%23} defaults{system=ballerina/io:$desugar$0, public=ballerina/io:$desugar$1, internalSubset=ballerina/io:$desugar$2}
+    %25 = writeXml(wc,seq,%24) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %26 = %25 is error
+    %26 ? bb11 : bb12;
   }
   bb11 {
-    %27 = ConstantLoad unreached
-    %28 = println(%27) -> bb12;
+    %0 = %25;
+    return;
   }
   bb12 {
+    %21 = %25;
+    GOTO bb13;
+  }
+  bb13 {
+    %27 = ConstantLoad unreached
+    %28 = println(%27) -> bb14;
+  }
+  bb14 {
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-data-channel-edge-v.txt
+++ b/corpus/bir/library/subset3/io-data-channel-edge-v.txt
@@ -1,657 +1,684 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 1
-    %2 = ConstantLoad 2
+    %2 = ConstantLoad 1
     %3 = ConstantLoad 2
-    %4 = newArray [int:Unsigned8...][%3]{%1, %2}
-    %5 = createReadableChannel(%4) -> bb1;
+    %4 = ConstantLoad 2
+    %5 = newArray [int:Unsigned8...][%4]{%2, %3}
+    %6 = createReadableChannel(%5) -> bb1;
   }
   bb1 {
-    $desugar$0 = %5;
-    %7 = $desugar$0 is error
+    %7 = %6 is error
     %7 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %6;
     return;
   }
   bb3 {
-    cb = $desugar$0;
-    $desugar$1 = cb;
-    %10 = $default$9($desugar$1) -> bb4;
+    %1 = %6;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$2 = %10;
-    %12 = newObject ballerina/io:ReadableDataChannel
-    %13 = init(%12,$desugar$1,$desugar$2) -> bb5;
+    cb = %1;
+    $desugar$0 = cb;
+    %10 = $default$9($desugar$0) -> bb5;
   }
   bb5 {
-    %15 = %13 is nil
-    %15 ? bb6 : bb7;
+    $desugar$1 = %10;
+    %12 = newObject ballerina/io:ReadableDataChannel
+    %13 = init(%12,$desugar$0,$desugar$1) -> bb6;
   }
   bb6 {
-    %14 = %12;
-    GOTO bb8;
+    %15 = %13 is nil
+    %15 ? bb7 : bb8;
   }
   bb7 {
-    %14 = %13;
-    GOTO bb8;
+    %14 = %12;
+    GOTO bb9;
   }
   bb8 {
-    cd = %14;
-    %17 = close(cd) -> bb9;
+    %14 = %13;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$3 = %17;
-    %19 = $desugar$3 is error
-    %19 ? bb10 : bb11;
+    cd = %14;
+    %18 = close(cd) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %19 = %18 is error
+    %19 ? bb11 : bb12;
   }
   bb11 {
-    %20 = close(cd) -> bb12;
+    %0 = %18;
+    return;
   }
   bb12 {
-    closedAgain = %20;
-    %22 = closedAgain is error
-    %22 ? bb13 : bb16;
+    %17 = %18;
+    GOTO bb13;
   }
   bb13 {
-    PushScopeFrame 2
-    %0 = message((1, closedAgain)) -> bb14;
+    %20 = close(cd) -> bb14;
   }
   bb14 {
-    %1 = println(%0) -> bb15;
+    closedAgain = %20;
+    %22 = closedAgain is error
+    %22 ? bb15 : bb18;
   }
   bb15 {
-    PopScopeFrame
-    GOTO bb16;
+    PushScopeFrame 2
+    %0 = message((1, closedAgain)) -> bb16;
   }
   bb16 {
-    PushScopeFrame 3
-    %0 = readInt16((1, cd)) -> bb17;
+    %1 = println(%0) -> bb17;
   }
   bb17 {
-    closedRead = %0;
-    %2 = closedRead is error
-    %2 ? bb18 : bb21;
+    PopScopeFrame
+    GOTO bb18;
   }
   bb18 {
-    PushScopeFrame 2
-    %0 = message((1, closedRead)) -> bb19;
+    PushScopeFrame 3
+    %0 = readInt16((1, cd)) -> bb19;
   }
   bb19 {
-    %1 = println(%0) -> bb20;
+    closedRead = %0;
+    %2 = closedRead is error
+    %2 ? bb20 : bb23;
   }
   bb20 {
-    PopScopeFrame
-    GOTO bb21;
+    PushScopeFrame 2
+    %0 = message((1, closedRead)) -> bb21;
   }
   bb21 {
-    PushScopeFrame 30
-    %0 = ConstantLoad 0
-    %1 = newArray [int:Unsigned8...][%0]{}
-    %2 = createReadableChannel(%1) -> bb22;
+    %1 = println(%0) -> bb22;
   }
   bb22 {
-    $desugar$4 = %2;
-    %4 = $desugar$4 is error
-    %4 ? bb23 : bb24;
+    PopScopeFrame
+    GOTO bb23;
   }
   bb23 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$4);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    PushScopeFrame 30
+    %1 = ConstantLoad 0
+    %2 = newArray [int:Unsigned8...][%1]{}
+    %3 = createReadableChannel(%2) -> bb24;
   }
   bb24 {
-    eb = $desugar$4;
-    $desugar$5 = eb;
-    %7 = $default$9($desugar$5) -> bb25;
+    %4 = %3 is error
+    %4 ? bb25 : bb26;
   }
   bb25 {
-    $desugar$6 = %7;
-    %9 = newObject ballerina/io:ReadableDataChannel
-    %10 = init(%9,$desugar$5,$desugar$6) -> bb26;
-  }
-  bb26 {
-    %12 = %10 is nil
-    %12 ? bb27 : bb28;
-  }
-  bb27 {
-    %11 = %9;
-    GOTO bb29;
-  }
-  bb28 {
-    %11 = %10;
-    GOTO bb29;
-  }
-  bb29 {
-    ed = %11;
-    %14 = ConstantLoad 3
-    %15 = %14;
-    %16 = ConstantLoad UTF-8
-    %17 = readString(ed,%15,%16) -> bb30;
-  }
-  bb30 {
-    $desugar$7 = %17;
-    %19 = $desugar$7 is error
-    %19 ? bb31 : bb32;
-  }
-  bb31 {
-    PushScopeFrame 0
-    (3, %0) = (1, $desugar$7);
-    PopScopeFrame
+    (2, %0) = %3;
     PopScopeFrame
     PopScopeFrame
     return;
   }
+  bb26 {
+    %0 = %3;
+    GOTO bb27;
+  }
+  bb27 {
+    eb = %0;
+    $desugar$2 = eb;
+    %7 = $default$9($desugar$2) -> bb28;
+  }
+  bb28 {
+    $desugar$3 = %7;
+    %9 = newObject ballerina/io:ReadableDataChannel
+    %10 = init(%9,$desugar$2,$desugar$3) -> bb29;
+  }
+  bb29 {
+    %12 = %10 is nil
+    %12 ? bb30 : bb31;
+  }
+  bb30 {
+    %11 = %9;
+    GOTO bb32;
+  }
+  bb31 {
+    %11 = %10;
+    GOTO bb32;
+  }
   bb32 {
-    first = $desugar$7;
-    %21 = length(first) -> bb33;
+    ed = %11;
+    %15 = ConstantLoad 3
+    %16 = %15;
+    %17 = ConstantLoad UTF-8
+    %18 = readString(ed,%16,%17) -> bb33;
   }
   bb33 {
-    %22 = %21;
-    %23 = println(%22) -> bb34;
+    %19 = %18 is error
+    %19 ? bb34 : bb35;
   }
   bb34 {
+    (2, %0) = %18;
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb35 {
+    %14 = %18;
+    GOTO bb36;
+  }
+  bb36 {
+    first = %14;
+    %21 = length(first) -> bb37;
+  }
+  bb37 {
+    %22 = %21;
+    %23 = println(%22) -> bb38;
+  }
+  bb38 {
     %24 = ConstantLoad 3
     %25 = %24;
     %26 = ConstantLoad UTF-8
-    %27 = readString(ed,%25,%26) -> bb35;
-  }
-  bb35 {
-    second = %27;
-    %29 = second is error
-    %29 ? bb36 : bb39;
-  }
-  bb36 {
-    PushScopeFrame 2
-    %0 = message((1, second)) -> bb37;
-  }
-  bb37 {
-    %1 = println(%0) -> bb38;
-  }
-  bb38 {
-    PopScopeFrame
-    GOTO bb39;
+    %27 = readString(ed,%25,%26) -> bb39;
   }
   bb39 {
-    PushScopeFrame 135
-    %0 = ConstantLoad 0
-    %1 = newArray [int:Unsigned8...][%0]{}
-    %2 = createReadableChannel(%1) -> bb40;
+    second = %27;
+    %29 = second is error
+    %29 ? bb40 : bb43;
   }
   bb40 {
-    $desugar$8 = %2;
-    %4 = $desugar$8 is error
-    %4 ? bb41 : bb42;
+    PushScopeFrame 2
+    %0 = message((1, second)) -> bb41;
   }
   bb41 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$8);
+    %1 = println(%0) -> bb42;
+  }
+  bb42 {
     PopScopeFrame
+    GOTO bb43;
+  }
+  bb43 {
+    PushScopeFrame 141
+    %1 = ConstantLoad 0
+    %2 = newArray [int:Unsigned8...][%1]{}
+    %3 = createReadableChannel(%2) -> bb44;
+  }
+  bb44 {
+    %4 = %3 is error
+    %4 ? bb45 : bb46;
+  }
+  bb45 {
+    (3, %0) = %3;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
-  bb42 {
-    tb = $desugar$8;
-    $desugar$9 = tb;
-    %7 = $default$9($desugar$9) -> bb43;
-  }
-  bb43 {
-    $desugar$10 = %7;
-    %9 = newObject ballerina/io:ReadableDataChannel
-    %10 = init(%9,$desugar$9,$desugar$10) -> bb44;
-  }
-  bb44 {
-    %12 = %10 is nil
-    %12 ? bb45 : bb46;
-  }
-  bb45 {
-    %11 = %9;
-    GOTO bb47;
-  }
   bb46 {
-    %11 = %10;
+    %0 = %3;
     GOTO bb47;
   }
   bb47 {
-    td = %11;
-    GOTO bb48;
+    tb = %0;
+    $desugar$4 = tb;
+    %7 = $default$9($desugar$4) -> bb48;
   }
   bb48 {
-    %15 = readInt16(td) -> bb49;
+    $desugar$5 = %7;
+    %9 = newObject ballerina/io:ReadableDataChannel
+    %10 = init(%9,$desugar$4,$desugar$5) -> bb49;
   }
   bb49 {
-    %14 = %15;
-    GOTO bb50;
+    %12 = %10 is nil
+    %12 ? bb50 : bb51;
   }
   bb50 {
+    %11 = %9;
+    GOTO bb52;
+  }
+  bb51 {
+    %11 = %10;
+    GOTO bb52;
+  }
+  bb52 {
+    td = %11;
+    GOTO bb53;
+  }
+  bb53 {
+    %15 = readInt16(td) -> bb54;
+  }
+  bb54 {
+    %14 = %15;
+    GOTO bb55;
+  }
+  bb55 {
     trapped = %14;
     %17 = trapped is error
     %18 = %17;
-    %19 = println(%18) -> bb51;
-  }
-  bb51 {
-    %20 = ConstantLoad 1
-    %21 = ConstantLoad 2
-    %22 = ConstantLoad 2
-    %23 = newArray [int:Unsigned8...][%22]{%20, %21}
-    %24 = createReadableChannel(%23) -> bb52;
-  }
-  bb52 {
-    $desugar$11 = %24;
-    %26 = $desugar$11 is error
-    %26 ? bb53 : bb54;
-  }
-  bb53 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$11);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
-  }
-  bb54 {
-    sb = $desugar$11;
-    $desugar$12 = sb;
-    %29 = $default$9($desugar$12) -> bb55;
-  }
-  bb55 {
-    $desugar$13 = %29;
-    %31 = newObject ballerina/io:ReadableDataChannel
-    %32 = init(%31,$desugar$12,$desugar$13) -> bb56;
+    %19 = println(%18) -> bb56;
   }
   bb56 {
-    %34 = %32 is nil
-    %34 ? bb57 : bb58;
+    %21 = ConstantLoad 1
+    %22 = ConstantLoad 2
+    %23 = ConstantLoad 2
+    %24 = newArray [int:Unsigned8...][%23]{%21, %22}
+    %25 = createReadableChannel(%24) -> bb57;
   }
   bb57 {
-    %33 = %31;
-    GOTO bb59;
+    %26 = %25 is error
+    %26 ? bb58 : bb59;
   }
   bb58 {
-    %33 = %32;
-    GOTO bb59;
+    (3, %0) = %25;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb59 {
-    sd = %33;
-    %36 = readInt32(sd) -> bb60;
+    %20 = %25;
+    GOTO bb60;
   }
   bb60 {
-    $desugar$14 = %36;
-    %38 = $desugar$14 is error
-    %38 ? bb61 : bb62;
+    sb = %20;
+    $desugar$6 = sb;
+    %29 = $default$9($desugar$6) -> bb61;
   }
   bb61 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$14);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    $desugar$7 = %29;
+    %31 = newObject ballerina/io:ReadableDataChannel
+    %32 = init(%31,$desugar$6,$desugar$7) -> bb62;
   }
   bb62 {
-    %39 = println($desugar$14) -> bb63;
+    %34 = %32 is nil
+    %34 ? bb63 : bb64;
   }
   bb63 {
-    %40 = ConstantLoad 1
-    %41 = ConstantLoad 2
-    %42 = ConstantLoad 2
-    %43 = newArray [int:Unsigned8...][%42]{%40, %41}
-    %44 = createReadableChannel(%43) -> bb64;
+    %33 = %31;
+    GOTO bb65;
   }
   bb64 {
-    $desugar$15 = %44;
-    %46 = $desugar$15 is error
-    %46 ? bb65 : bb66;
+    %33 = %32;
+    GOTO bb65;
   }
   bb65 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$15);
-    PopScopeFrame
+    sd = %33;
+    %37 = readInt32(sd) -> bb66;
+  }
+  bb66 {
+    %38 = %37 is error
+    %38 ? bb67 : bb68;
+  }
+  bb67 {
+    (3, %0) = %37;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
-  bb66 {
-    lb = $desugar$15;
-    %48 = newObject ballerina/io:ReadableDataChannel
-    %49 = ConstantLoad LE
-    %50 = init(%48,lb,%49) -> bb67;
-  }
-  bb67 {
-    %52 = %50 is nil
-    %52 ? bb68 : bb69;
-  }
   bb68 {
-    %51 = %48;
-    GOTO bb70;
+    %36 = %37;
+    GOTO bb69;
   }
   bb69 {
-    %51 = %50;
-    GOTO bb70;
+    %39 = %36;
+    %40 = println(%39) -> bb70;
   }
   bb70 {
-    ld = %51;
-    %54 = readInt32(ld) -> bb71;
+    %42 = ConstantLoad 1
+    %43 = ConstantLoad 2
+    %44 = ConstantLoad 2
+    %45 = newArray [int:Unsigned8...][%44]{%42, %43}
+    %46 = createReadableChannel(%45) -> bb71;
   }
   bb71 {
-    $desugar$16 = %54;
-    %56 = $desugar$16 is error
-    %56 ? bb72 : bb73;
+    %47 = %46 is error
+    %47 ? bb72 : bb73;
   }
   bb72 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$16);
-    PopScopeFrame
+    (3, %0) = %46;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
   bb73 {
-    %57 = println($desugar$16) -> bb74;
+    %41 = %46;
+    GOTO bb74;
   }
   bb74 {
-    %58 = ConstantLoad /tmp/bal_io_dc_varint.bin
-    path = %58;
-    $desugar$17 = path;
-    %61 = $default$11($desugar$17) -> bb75;
+    lb = %41;
+    %49 = newObject ballerina/io:ReadableDataChannel
+    %50 = ConstantLoad LE
+    %51 = init(%49,lb,%50) -> bb75;
   }
   bb75 {
-    $desugar$18 = %61;
-    %63 = openWritableFile($desugar$17,$desugar$18) -> bb76;
+    %53 = %51 is nil
+    %53 ? bb76 : bb77;
   }
   bb76 {
-    $desugar$19 = %63;
-    %65 = $desugar$19 is error
-    %65 ? bb77 : bb78;
+    %52 = %49;
+    GOTO bb78;
   }
   bb77 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$19);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %52 = %51;
+    GOTO bb78;
   }
   bb78 {
-    wb = $desugar$19;
-    $desugar$20 = wb;
-    %68 = $default$10($desugar$20) -> bb79;
+    ld = %52;
+    %56 = readInt32(ld) -> bb79;
   }
   bb79 {
-    $desugar$21 = %68;
-    %70 = newObject ballerina/io:WritableDataChannel
-    %71 = init(%70,$desugar$20,$desugar$21) -> bb80;
+    %57 = %56 is error
+    %57 ? bb80 : bb81;
   }
   bb80 {
-    %73 = %71 is nil
-    %73 ? bb81 : bb82;
+    (3, %0) = %56;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb81 {
-    %72 = %70;
-    GOTO bb83;
+    %55 = %56;
+    GOTO bb82;
   }
   bb82 {
-    %72 = %71;
-    GOTO bb83;
+    %58 = %55;
+    %59 = println(%58) -> bb83;
   }
   bb83 {
-    wd = %72;
-    %75 = ConstantLoad 1
-    %76 = %75;
-    %77 = writeVarInt(wd,%76) -> bb84;
+    %60 = ConstantLoad /tmp/bal_io_dc_varint.bin
+    path = %60;
+    $desugar$8 = path;
+    %63 = $default$11($desugar$8) -> bb84;
   }
   bb84 {
-    $desugar$22 = %77;
-    %79 = $desugar$22 is error
-    %79 ? bb85 : bb86;
+    $desugar$9 = %63;
+    %66 = openWritableFile($desugar$8,$desugar$9) -> bb85;
   }
   bb85 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$22);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %67 = %66 is error
+    %67 ? bb86 : bb87;
   }
   bb86 {
-    %80 = ConstantLoad 1
-    %81 = unknown %80;
-    %82 = %81;
-    %83 = writeVarInt(wd,%82) -> bb87;
+    (3, %0) = %66;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb87 {
-    $desugar$23 = %83;
-    %85 = $desugar$23 is error
-    %85 ? bb88 : bb89;
+    %65 = %66;
+    GOTO bb88;
   }
   bb88 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$23);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    wb = %65;
+    $desugar$10 = wb;
+    %70 = $default$10($desugar$10) -> bb89;
   }
   bb89 {
-    %86 = ConstantLoad 9223372036854775807
-    %87 = %86;
-    %88 = writeVarInt(wd,%87) -> bb90;
+    $desugar$11 = %70;
+    %72 = newObject ballerina/io:WritableDataChannel
+    %73 = init(%72,$desugar$10,$desugar$11) -> bb90;
   }
   bb90 {
-    $desugar$24 = %88;
-    %90 = $desugar$24 is error
-    %90 ? bb91 : bb92;
+    %75 = %73 is nil
+    %75 ? bb91 : bb92;
   }
   bb91 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$24);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %74 = %72;
+    GOTO bb93;
   }
   bb92 {
-    %92 = ConstantLoad 9223372036854775807
-    %93 = unknown %92;
-    %94 = %93;
-    %95 = ConstantLoad 1
-    %96 = %95;
-    %91 = - %94 %96;
-    %97 = %91;
-    %98 = writeVarInt(wd,%97) -> bb93;
+    %74 = %73;
+    GOTO bb93;
   }
   bb93 {
-    $desugar$25 = %98;
-    %100 = $desugar$25 is error
-    %100 ? bb94 : bb95;
+    wd = %74;
+    %78 = ConstantLoad 1
+    %79 = %78;
+    %80 = writeVarInt(wd,%79) -> bb94;
   }
   bb94 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$25);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %81 = %80 is error
+    %81 ? bb95 : bb96;
   }
   bb95 {
-    %101 = close(wd) -> bb96;
+    (3, %0) = %80;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb96 {
-    $desugar$26 = %101;
-    %103 = $desugar$26 is error
-    %103 ? bb97 : bb98;
+    %77 = %80;
+    GOTO bb97;
   }
   bb97 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$26);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %83 = ConstantLoad 1
+    %84 = unknown %83;
+    %85 = %84;
+    %86 = writeVarInt(wd,%85) -> bb98;
   }
   bb98 {
-    %104 = openReadableFile(path) -> bb99;
+    %87 = %86 is error
+    %87 ? bb99 : bb100;
   }
   bb99 {
-    $desugar$27 = %104;
-    %106 = $desugar$27 is error
-    %106 ? bb100 : bb101;
+    (3, %0) = %86;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb100 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$27);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %82 = %86;
+    GOTO bb101;
   }
   bb101 {
-    rb = $desugar$27;
-    $desugar$28 = rb;
-    %109 = $default$9($desugar$28) -> bb102;
+    %89 = ConstantLoad 9223372036854775807
+    %90 = %89;
+    %91 = writeVarInt(wd,%90) -> bb102;
   }
   bb102 {
-    $desugar$29 = %109;
-    %111 = newObject ballerina/io:ReadableDataChannel
-    %112 = init(%111,$desugar$28,$desugar$29) -> bb103;
+    %92 = %91 is error
+    %92 ? bb103 : bb104;
   }
   bb103 {
-    %114 = %112 is nil
-    %114 ? bb104 : bb105;
+    (3, %0) = %91;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb104 {
-    %113 = %111;
-    GOTO bb106;
+    %88 = %91;
+    GOTO bb105;
   }
   bb105 {
-    %113 = %112;
-    GOTO bb106;
+    %95 = ConstantLoad 9223372036854775807
+    %96 = unknown %95;
+    %97 = %96;
+    %98 = ConstantLoad 1
+    %99 = %98;
+    %94 = - %97 %99;
+    %100 = %94;
+    %101 = writeVarInt(wd,%100) -> bb106;
   }
   bb106 {
-    rd = %113;
-    %116 = readVarInt(rd) -> bb107;
+    %102 = %101 is error
+    %102 ? bb107 : bb108;
   }
   bb107 {
-    $desugar$30 = %116;
-    %118 = $desugar$30 is error
-    %118 ? bb108 : bb109;
+    (3, %0) = %101;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb108 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$30);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %93 = %101;
+    GOTO bb109;
   }
   bb109 {
-    %119 = println($desugar$30) -> bb110;
+    %104 = close(wd) -> bb110;
   }
   bb110 {
-    %120 = readVarInt(rd) -> bb111;
+    %105 = %104 is error
+    %105 ? bb111 : bb112;
   }
   bb111 {
-    $desugar$31 = %120;
-    %122 = $desugar$31 is error
-    %122 ? bb112 : bb113;
+    (3, %0) = %104;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb112 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$31);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %103 = %104;
+    GOTO bb113;
   }
   bb113 {
-    %123 = println($desugar$31) -> bb114;
+    %107 = openReadableFile(path) -> bb114;
   }
   bb114 {
-    %124 = readVarInt(rd) -> bb115;
+    %108 = %107 is error
+    %108 ? bb115 : bb116;
   }
   bb115 {
-    $desugar$32 = %124;
-    %126 = $desugar$32 is error
-    %126 ? bb116 : bb117;
+    (3, %0) = %107;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb116 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$32);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %106 = %107;
+    GOTO bb117;
   }
   bb117 {
-    %127 = println($desugar$32) -> bb118;
+    rb = %106;
+    $desugar$12 = rb;
+    %111 = $default$9($desugar$12) -> bb118;
   }
   bb118 {
-    %128 = readVarInt(rd) -> bb119;
+    $desugar$13 = %111;
+    %113 = newObject ballerina/io:ReadableDataChannel
+    %114 = init(%113,$desugar$12,$desugar$13) -> bb119;
   }
   bb119 {
-    $desugar$33 = %128;
-    %130 = $desugar$33 is error
-    %130 ? bb120 : bb121;
+    %116 = %114 is nil
+    %116 ? bb120 : bb121;
   }
   bb120 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$33);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    %115 = %113;
+    GOTO bb122;
   }
   bb121 {
-    %131 = println($desugar$33) -> bb122;
+    %115 = %114;
+    GOTO bb122;
   }
   bb122 {
-    %132 = close(rd) -> bb123;
+    rd = %115;
+    %119 = readVarInt(rd) -> bb123;
   }
   bb123 {
-    $desugar$34 = %132;
-    %134 = $desugar$34 is error
-    %134 ? bb124 : bb125;
+    %120 = %119 is error
+    %120 ? bb124 : bb125;
   }
   bb124 {
-    PushScopeFrame 0
-    (4, %0) = (1, $desugar$34);
-    PopScopeFrame
+    (3, %0) = %119;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
   bb125 {
+    %118 = %119;
+    GOTO bb126;
+  }
+  bb126 {
+    %121 = %118;
+    %122 = println(%121) -> bb127;
+  }
+  bb127 {
+    %124 = readVarInt(rd) -> bb128;
+  }
+  bb128 {
+    %125 = %124 is error
+    %125 ? bb129 : bb130;
+  }
+  bb129 {
+    (3, %0) = %124;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb130 {
+    %123 = %124;
+    GOTO bb131;
+  }
+  bb131 {
+    %126 = %123;
+    %127 = println(%126) -> bb132;
+  }
+  bb132 {
+    %129 = readVarInt(rd) -> bb133;
+  }
+  bb133 {
+    %130 = %129 is error
+    %130 ? bb134 : bb135;
+  }
+  bb134 {
+    (3, %0) = %129;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb135 {
+    %128 = %129;
+    GOTO bb136;
+  }
+  bb136 {
+    %131 = %128;
+    %132 = println(%131) -> bb137;
+  }
+  bb137 {
+    %134 = readVarInt(rd) -> bb138;
+  }
+  bb138 {
+    %135 = %134 is error
+    %135 ? bb139 : bb140;
+  }
+  bb139 {
+    (3, %0) = %134;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb140 {
+    %133 = %134;
+    GOTO bb141;
+  }
+  bb141 {
+    %136 = %133;
+    %137 = println(%136) -> bb142;
+  }
+  bb142 {
+    %139 = close(rd) -> bb143;
+  }
+  bb143 {
+    %140 = %139 is error
+    %140 ? bb144 : bb145;
+  }
+  bb144 {
+    (3, %0) = %139;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  bb145 {
+    %138 = %139;
+    GOTO bb146;
+  }
+  bb146 {
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
@@ -659,6 +686,6 @@ main() -> nil|error{
   }
   
   error-table {
-    [bb48, bb49] -> bb50, %14
+    [bb53, bb54] -> bb55, %14
   }
 }

--- a/corpus/bir/library/subset3/io-data-channel-eof-p.txt
+++ b/corpus/bir/library/subset3/io-data-channel-eof-p.txt
@@ -1,64 +1,66 @@
 module $anon.. v 0.0.0;
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad 0
-    %2 = newArray [int:Unsigned8...][%1]{}
-    %3 = createReadableChannel(%2) -> bb1;
+    %2 = ConstantLoad 0
+    %3 = newArray [int:Unsigned8...][%2]{}
+    %4 = createReadableChannel(%3) -> bb1;
   }
   bb1 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
+    %5 = %4 is error
     %5 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %4;
     return;
   }
   bb3 {
-    rb = $desugar$0;
-    $desugar$1 = rb;
-    %8 = $default$9($desugar$1) -> bb4;
+    %1 = %4;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$2 = %8;
-    %10 = newObject ballerina/io:ReadableDataChannel
-    %11 = init(%10,$desugar$1,$desugar$2) -> bb5;
+    rb = %1;
+    $desugar$0 = rb;
+    %8 = $default$9($desugar$0) -> bb5;
   }
   bb5 {
-    %13 = %11 is nil
-    %13 ? bb6 : bb7;
+    $desugar$1 = %8;
+    %10 = newObject ballerina/io:ReadableDataChannel
+    %11 = init(%10,$desugar$0,$desugar$1) -> bb6;
   }
   bb6 {
-    %12 = %10;
-    GOTO bb8;
+    %13 = %11 is nil
+    %13 ? bb7 : bb8;
   }
   bb7 {
-    %12 = %11;
-    GOTO bb8;
+    %12 = %10;
+    GOTO bb9;
   }
   bb8 {
-    rd = %12;
-    %15 = readInt64(rd) -> bb9;
+    %12 = %11;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$3 = %15;
-    %17 = $desugar$3 is error
-    %17 ? bb10 : bb11;
+    rd = %12;
+    %16 = readInt64(rd) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %17 = %16 is error
+    %17 ? bb11 : bb12;
   }
   bb11 {
-    n = $desugar$3;
-    %19 = n;
-    %20 = println(%19) -> bb12;
+    %0 = %16;
+    return;
   }
   bb12 {
+    %15 = %16;
+    GOTO bb13;
+  }
+  bb13 {
+    n = %15;
+    %19 = n;
+    %20 = println(%19) -> bb14;
+  }
+  bb14 {
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-data-channel-rw-v.txt
+++ b/corpus/bir/library/subset3/io-data-channel-rw-v.txt
@@ -6,620 +6,668 @@ roundtrip("BE"|"LE",string) -> nil|error{
   }
   bb1 {
     $desugar$1 = %4;
-    %6 = openWritableFile($desugar$0,$desugar$1) -> bb2;
+    %7 = openWritableFile($desugar$0,$desugar$1) -> bb2;
   }
   bb2 {
-    $desugar$2 = %6;
-    %8 = $desugar$2 is error
+    %8 = %7 is error
     %8 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %7;
     return;
   }
   bb4 {
-    wb = $desugar$2;
-    %10 = newObject ballerina/io:WritableDataChannel
-    %11 = init(%10,wb,ord) -> bb5;
+    %6 = %7;
+    GOTO bb5;
   }
   bb5 {
-    %13 = %11 is nil
-    %13 ? bb6 : bb7;
+    wb = %6;
+    %10 = newObject ballerina/io:WritableDataChannel
+    %11 = init(%10,wb,ord) -> bb6;
   }
   bb6 {
-    %12 = %10;
-    GOTO bb8;
+    %13 = %11 is nil
+    %13 ? bb7 : bb8;
   }
   bb7 {
-    %12 = %11;
-    GOTO bb8;
+    %12 = %10;
+    GOTO bb9;
   }
   bb8 {
-    wd = %12;
-    %15 = ConstantLoad 4660
-    %16 = %15;
-    %17 = writeInt16(wd,%16) -> bb9;
+    %12 = %11;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$3 = %17;
-    %19 = $desugar$3 is error
-    %19 ? bb10 : bb11;
+    wd = %12;
+    %16 = ConstantLoad 4660
+    %17 = %16;
+    %18 = writeInt16(wd,%17) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %19 = %18 is error
+    %19 ? bb11 : bb12;
   }
   bb11 {
-    %20 = ConstantLoad 2
-    %21 = unknown %20;
-    %22 = %21;
-    %23 = writeInt16(wd,%22) -> bb12;
+    %0 = %18;
+    return;
   }
   bb12 {
-    $desugar$4 = %23;
-    %25 = $desugar$4 is error
-    %25 ? bb13 : bb14;
+    %15 = %18;
+    GOTO bb13;
   }
   bb13 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %21 = ConstantLoad 2
+    %22 = unknown %21;
+    %23 = %22;
+    %24 = writeInt16(wd,%23) -> bb14;
   }
   bb14 {
-    %26 = ConstantLoad 305419896
-    %27 = %26;
-    %28 = writeInt32(wd,%27) -> bb15;
+    %25 = %24 is error
+    %25 ? bb15 : bb16;
   }
   bb15 {
-    $desugar$5 = %28;
-    %30 = $desugar$5 is error
-    %30 ? bb16 : bb17;
-  }
-  bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %24;
     return;
   }
+  bb16 {
+    %20 = %24;
+    GOTO bb17;
+  }
   bb17 {
-    %31 = ConstantLoad 40000
-    %32 = unknown %31;
-    %33 = %32;
-    %34 = writeInt32(wd,%33) -> bb18;
+    %27 = ConstantLoad 305419896
+    %28 = %27;
+    %29 = writeInt32(wd,%28) -> bb18;
   }
   bb18 {
-    $desugar$6 = %34;
-    %36 = $desugar$6 is error
-    %36 ? bb19 : bb20;
+    %30 = %29 is error
+    %30 ? bb19 : bb20;
   }
   bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+    %0 = %29;
     return;
   }
   bb20 {
-    %37 = ConstantLoad 81985529216486895
-    %38 = %37;
-    %39 = writeInt64(wd,%38) -> bb21;
+    %26 = %29;
+    GOTO bb21;
   }
   bb21 {
-    $desugar$7 = %39;
-    %41 = $desugar$7 is error
-    %41 ? bb22 : bb23;
+    %32 = ConstantLoad 40000
+    %33 = unknown %32;
+    %34 = %33;
+    %35 = writeInt32(wd,%34) -> bb22;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    %36 = %35 is error
+    %36 ? bb23 : bb24;
   }
   bb23 {
-    %42 = ConstantLoad 5
-    %43 = unknown %42;
-    %44 = %43;
-    %45 = writeInt64(wd,%44) -> bb24;
+    %0 = %35;
+    return;
   }
   bb24 {
-    $desugar$8 = %45;
-    %47 = $desugar$8 is error
-    %47 ? bb25 : bb26;
+    %31 = %35;
+    GOTO bb25;
   }
   bb25 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    %38 = ConstantLoad 81985529216486895
+    %39 = %38;
+    %40 = writeInt64(wd,%39) -> bb26;
   }
   bb26 {
-    %48 = ConstantLoad 3.5
-    %49 = %48;
-    %50 = writeFloat32(wd,%49) -> bb27;
+    %41 = %40 is error
+    %41 ? bb27 : bb28;
   }
   bb27 {
-    $desugar$9 = %50;
-    %52 = $desugar$9 is error
-    %52 ? bb28 : bb29;
-  }
-  bb28 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %40;
     return;
   }
+  bb28 {
+    %37 = %40;
+    GOTO bb29;
+  }
   bb29 {
-    %53 = ConstantLoad 2.718281828459045
-    %54 = %53;
-    %55 = writeFloat64(wd,%54) -> bb30;
+    %43 = ConstantLoad 5
+    %44 = unknown %43;
+    %45 = %44;
+    %46 = writeInt64(wd,%45) -> bb30;
   }
   bb30 {
-    $desugar$10 = %55;
-    %57 = $desugar$10 is error
-    %57 ? bb31 : bb32;
+    %47 = %46 is error
+    %47 ? bb31 : bb32;
   }
   bb31 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
+    %0 = %46;
     return;
   }
   bb32 {
-    %58 = ConstantLoad true
-    %59 = %58;
-    %60 = writeBool(wd,%59) -> bb33;
+    %42 = %46;
+    GOTO bb33;
   }
   bb33 {
-    $desugar$11 = %60;
-    %62 = $desugar$11 is error
-    %62 ? bb34 : bb35;
+    %49 = ConstantLoad 3.5
+    %50 = %49;
+    %51 = writeFloat32(wd,%50) -> bb34;
   }
   bb34 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
-    return;
+    %52 = %51 is error
+    %52 ? bb35 : bb36;
   }
   bb35 {
-    %63 = ConstantLoad false
-    %64 = %63;
-    %65 = writeBool(wd,%64) -> bb36;
+    %0 = %51;
+    return;
   }
   bb36 {
-    $desugar$12 = %65;
-    %67 = $desugar$12 is error
-    %67 ? bb37 : bb38;
+    %48 = %51;
+    GOTO bb37;
   }
   bb37 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$12);
-    PopScopeFrame
-    return;
+    %54 = ConstantLoad 2.718281828459045
+    %55 = %54;
+    %56 = writeFloat64(wd,%55) -> bb38;
   }
   bb38 {
-    %68 = ConstantLoad héllo
-    %69 = ConstantLoad UTF-8
-    %70 = writeString(wd,%68,%69) -> bb39;
+    %57 = %56 is error
+    %57 ? bb39 : bb40;
   }
   bb39 {
-    $desugar$13 = %70;
-    %72 = $desugar$13 is error
-    %72 ? bb40 : bb41;
-  }
-  bb40 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
+    %0 = %56;
     return;
   }
+  bb40 {
+    %53 = %56;
+    GOTO bb41;
+  }
   bb41 {
-    %73 = ConstantLoad 0
-    %74 = %73;
-    %75 = writeVarInt(wd,%74) -> bb42;
+    %59 = ConstantLoad true
+    %60 = %59;
+    %61 = writeBool(wd,%60) -> bb42;
   }
   bb42 {
-    $desugar$14 = %75;
-    %77 = $desugar$14 is error
-    %77 ? bb43 : bb44;
+    %62 = %61 is error
+    %62 ? bb43 : bb44;
   }
   bb43 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
+    %0 = %61;
     return;
   }
   bb44 {
-    %78 = ConstantLoad 300
-    %79 = %78;
-    %80 = writeVarInt(wd,%79) -> bb45;
+    %58 = %61;
+    GOTO bb45;
   }
   bb45 {
-    $desugar$15 = %80;
-    %82 = $desugar$15 is error
-    %82 ? bb46 : bb47;
+    %64 = ConstantLoad false
+    %65 = %64;
+    %66 = writeBool(wd,%65) -> bb46;
   }
   bb46 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$15);
-    PopScopeFrame
-    return;
+    %67 = %66 is error
+    %67 ? bb47 : bb48;
   }
   bb47 {
-    %83 = ConstantLoad 300
-    %84 = unknown %83;
-    %85 = %84;
-    %86 = writeVarInt(wd,%85) -> bb48;
+    %0 = %66;
+    return;
   }
   bb48 {
-    $desugar$16 = %86;
-    %88 = $desugar$16 is error
-    %88 ? bb49 : bb50;
+    %63 = %66;
+    GOTO bb49;
   }
   bb49 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$16);
-    PopScopeFrame
-    return;
+    %69 = ConstantLoad héllo
+    %70 = ConstantLoad UTF-8
+    %71 = writeString(wd,%69,%70) -> bb50;
   }
   bb50 {
-    %89 = close(wd) -> bb51;
+    %72 = %71 is error
+    %72 ? bb51 : bb52;
   }
   bb51 {
-    $desugar$17 = %89;
-    %91 = $desugar$17 is error
-    %91 ? bb52 : bb53;
-  }
-  bb52 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$17);
-    PopScopeFrame
+    %0 = %71;
     return;
   }
+  bb52 {
+    %68 = %71;
+    GOTO bb53;
+  }
   bb53 {
-    %92 = openReadableFile(path) -> bb54;
+    %74 = ConstantLoad 0
+    %75 = %74;
+    %76 = writeVarInt(wd,%75) -> bb54;
   }
   bb54 {
-    $desugar$18 = %92;
-    %94 = $desugar$18 is error
-    %94 ? bb55 : bb56;
+    %77 = %76 is error
+    %77 ? bb55 : bb56;
   }
   bb55 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
+    %0 = %76;
     return;
   }
   bb56 {
-    rb = $desugar$18;
-    %96 = newObject ballerina/io:ReadableDataChannel
-    %97 = init(%96,rb,ord) -> bb57;
+    %73 = %76;
+    GOTO bb57;
   }
   bb57 {
-    %99 = %97 is nil
-    %99 ? bb58 : bb59;
+    %79 = ConstantLoad 300
+    %80 = %79;
+    %81 = writeVarInt(wd,%80) -> bb58;
   }
   bb58 {
-    %98 = %96;
-    GOTO bb60;
+    %82 = %81 is error
+    %82 ? bb59 : bb60;
   }
   bb59 {
-    %98 = %97;
-    GOTO bb60;
+    %0 = %81;
+    return;
   }
   bb60 {
-    rd = %98;
-    %101 = readInt16(rd) -> bb61;
+    %78 = %81;
+    GOTO bb61;
   }
   bb61 {
-    $desugar$19 = %101;
-    %103 = $desugar$19 is error
-    %103 ? bb62 : bb63;
+    %84 = ConstantLoad 300
+    %85 = unknown %84;
+    %86 = %85;
+    %87 = writeVarInt(wd,%86) -> bb62;
   }
   bb62 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$19);
-    PopScopeFrame
-    return;
+    %88 = %87 is error
+    %88 ? bb63 : bb64;
   }
   bb63 {
-    %104 = println($desugar$19) -> bb64;
+    %0 = %87;
+    return;
   }
   bb64 {
-    %105 = readInt16(rd) -> bb65;
+    %83 = %87;
+    GOTO bb65;
   }
   bb65 {
-    $desugar$20 = %105;
-    %107 = $desugar$20 is error
-    %107 ? bb66 : bb67;
+    %90 = close(wd) -> bb66;
   }
   bb66 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$20);
-    PopScopeFrame
-    return;
+    %91 = %90 is error
+    %91 ? bb67 : bb68;
   }
   bb67 {
-    %108 = println($desugar$20) -> bb68;
+    %0 = %90;
+    return;
   }
   bb68 {
-    %109 = readInt32(rd) -> bb69;
+    %89 = %90;
+    GOTO bb69;
   }
   bb69 {
-    $desugar$21 = %109;
-    %111 = $desugar$21 is error
-    %111 ? bb70 : bb71;
+    %93 = openReadableFile(path) -> bb70;
   }
   bb70 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$21);
-    PopScopeFrame
-    return;
+    %94 = %93 is error
+    %94 ? bb71 : bb72;
   }
   bb71 {
-    %112 = println($desugar$21) -> bb72;
+    %0 = %93;
+    return;
   }
   bb72 {
-    %113 = readInt32(rd) -> bb73;
+    %92 = %93;
+    GOTO bb73;
   }
   bb73 {
-    $desugar$22 = %113;
-    %115 = $desugar$22 is error
-    %115 ? bb74 : bb75;
+    rb = %92;
+    %96 = newObject ballerina/io:ReadableDataChannel
+    %97 = init(%96,rb,ord) -> bb74;
   }
   bb74 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$22);
-    PopScopeFrame
-    return;
+    %99 = %97 is nil
+    %99 ? bb75 : bb76;
   }
   bb75 {
-    %116 = println($desugar$22) -> bb76;
+    %98 = %96;
+    GOTO bb77;
   }
   bb76 {
-    %117 = readInt64(rd) -> bb77;
+    %98 = %97;
+    GOTO bb77;
   }
   bb77 {
-    $desugar$23 = %117;
-    %119 = $desugar$23 is error
-    %119 ? bb78 : bb79;
+    rd = %98;
+    %102 = readInt16(rd) -> bb78;
   }
   bb78 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$23);
-    PopScopeFrame
-    return;
+    %103 = %102 is error
+    %103 ? bb79 : bb80;
   }
   bb79 {
-    %120 = println($desugar$23) -> bb80;
+    %0 = %102;
+    return;
   }
   bb80 {
-    %121 = readInt64(rd) -> bb81;
+    %101 = %102;
+    GOTO bb81;
   }
   bb81 {
-    $desugar$24 = %121;
-    %123 = $desugar$24 is error
-    %123 ? bb82 : bb83;
+    %104 = %101;
+    %105 = println(%104) -> bb82;
   }
   bb82 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$24);
-    PopScopeFrame
-    return;
+    %107 = readInt16(rd) -> bb83;
   }
   bb83 {
-    %124 = println($desugar$24) -> bb84;
+    %108 = %107 is error
+    %108 ? bb84 : bb85;
   }
   bb84 {
-    %125 = readFloat32(rd) -> bb85;
+    %0 = %107;
+    return;
   }
   bb85 {
-    $desugar$25 = %125;
-    %127 = $desugar$25 is error
-    %127 ? bb86 : bb87;
+    %106 = %107;
+    GOTO bb86;
   }
   bb86 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$25);
-    PopScopeFrame
-    return;
+    %109 = %106;
+    %110 = println(%109) -> bb87;
   }
   bb87 {
-    %128 = println($desugar$25) -> bb88;
+    %112 = readInt32(rd) -> bb88;
   }
   bb88 {
-    %129 = readFloat64(rd) -> bb89;
+    %113 = %112 is error
+    %113 ? bb89 : bb90;
   }
   bb89 {
-    $desugar$26 = %129;
-    %131 = $desugar$26 is error
-    %131 ? bb90 : bb91;
-  }
-  bb90 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$26);
-    PopScopeFrame
+    %0 = %112;
     return;
   }
+  bb90 {
+    %111 = %112;
+    GOTO bb91;
+  }
   bb91 {
-    %132 = println($desugar$26) -> bb92;
+    %114 = %111;
+    %115 = println(%114) -> bb92;
   }
   bb92 {
-    %133 = readBool(rd) -> bb93;
+    %117 = readInt32(rd) -> bb93;
   }
   bb93 {
-    $desugar$27 = %133;
-    %135 = $desugar$27 is error
-    %135 ? bb94 : bb95;
+    %118 = %117 is error
+    %118 ? bb94 : bb95;
   }
   bb94 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$27);
-    PopScopeFrame
+    %0 = %117;
     return;
   }
   bb95 {
-    %136 = println($desugar$27) -> bb96;
+    %116 = %117;
+    GOTO bb96;
   }
   bb96 {
-    %137 = readBool(rd) -> bb97;
+    %119 = %116;
+    %120 = println(%119) -> bb97;
   }
   bb97 {
-    $desugar$28 = %137;
-    %139 = $desugar$28 is error
-    %139 ? bb98 : bb99;
+    %122 = readInt64(rd) -> bb98;
   }
   bb98 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$28);
-    PopScopeFrame
-    return;
+    %123 = %122 is error
+    %123 ? bb99 : bb100;
   }
   bb99 {
-    %140 = println($desugar$28) -> bb100;
+    %0 = %122;
+    return;
   }
   bb100 {
-    %141 = ConstantLoad 6
-    %142 = %141;
-    %143 = ConstantLoad UTF-8
-    %144 = readString(rd,%142,%143) -> bb101;
+    %121 = %122;
+    GOTO bb101;
   }
   bb101 {
-    $desugar$29 = %144;
-    %146 = $desugar$29 is error
-    %146 ? bb102 : bb103;
+    %124 = %121;
+    %125 = println(%124) -> bb102;
   }
   bb102 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$29);
-    PopScopeFrame
-    return;
+    %127 = readInt64(rd) -> bb103;
   }
   bb103 {
-    %147 = println($desugar$29) -> bb104;
+    %128 = %127 is error
+    %128 ? bb104 : bb105;
   }
   bb104 {
-    %148 = readVarInt(rd) -> bb105;
+    %0 = %127;
+    return;
   }
   bb105 {
-    $desugar$30 = %148;
-    %150 = $desugar$30 is error
-    %150 ? bb106 : bb107;
+    %126 = %127;
+    GOTO bb106;
   }
   bb106 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$30);
-    PopScopeFrame
-    return;
+    %129 = %126;
+    %130 = println(%129) -> bb107;
   }
   bb107 {
-    %151 = println($desugar$30) -> bb108;
+    %132 = readFloat32(rd) -> bb108;
   }
   bb108 {
-    %152 = readVarInt(rd) -> bb109;
+    %133 = %132 is error
+    %133 ? bb109 : bb110;
   }
   bb109 {
-    $desugar$31 = %152;
-    %154 = $desugar$31 is error
-    %154 ? bb110 : bb111;
-  }
-  bb110 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$31);
-    PopScopeFrame
+    %0 = %132;
     return;
   }
+  bb110 {
+    %131 = %132;
+    GOTO bb111;
+  }
   bb111 {
-    %155 = println($desugar$31) -> bb112;
+    %134 = %131;
+    %135 = println(%134) -> bb112;
   }
   bb112 {
-    %156 = readVarInt(rd) -> bb113;
+    %137 = readFloat64(rd) -> bb113;
   }
   bb113 {
-    $desugar$32 = %156;
-    %158 = $desugar$32 is error
-    %158 ? bb114 : bb115;
+    %138 = %137 is error
+    %138 ? bb114 : bb115;
   }
   bb114 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$32);
-    PopScopeFrame
+    %0 = %137;
     return;
   }
   bb115 {
-    %159 = println($desugar$32) -> bb116;
+    %136 = %137;
+    GOTO bb116;
   }
   bb116 {
-    %160 = close(rd) -> bb117;
+    %139 = %136;
+    %140 = println(%139) -> bb117;
   }
   bb117 {
-    $desugar$33 = %160;
-    %162 = $desugar$33 is error
-    %162 ? bb118 : bb119;
+    %142 = readBool(rd) -> bb118;
   }
   bb118 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$33);
-    PopScopeFrame
-    return;
+    %143 = %142 is error
+    %143 ? bb119 : bb120;
   }
   bb119 {
+    %0 = %142;
+    return;
+  }
+  bb120 {
+    %141 = %142;
+    GOTO bb121;
+  }
+  bb121 {
+    %144 = %141;
+    %145 = println(%144) -> bb122;
+  }
+  bb122 {
+    %147 = readBool(rd) -> bb123;
+  }
+  bb123 {
+    %148 = %147 is error
+    %148 ? bb124 : bb125;
+  }
+  bb124 {
+    %0 = %147;
+    return;
+  }
+  bb125 {
+    %146 = %147;
+    GOTO bb126;
+  }
+  bb126 {
+    %149 = %146;
+    %150 = println(%149) -> bb127;
+  }
+  bb127 {
+    %152 = ConstantLoad 6
+    %153 = %152;
+    %154 = ConstantLoad UTF-8
+    %155 = readString(rd,%153,%154) -> bb128;
+  }
+  bb128 {
+    %156 = %155 is error
+    %156 ? bb129 : bb130;
+  }
+  bb129 {
+    %0 = %155;
+    return;
+  }
+  bb130 {
+    %151 = %155;
+    GOTO bb131;
+  }
+  bb131 {
+    %157 = println(%151) -> bb132;
+  }
+  bb132 {
+    %159 = readVarInt(rd) -> bb133;
+  }
+  bb133 {
+    %160 = %159 is error
+    %160 ? bb134 : bb135;
+  }
+  bb134 {
+    %0 = %159;
+    return;
+  }
+  bb135 {
+    %158 = %159;
+    GOTO bb136;
+  }
+  bb136 {
+    %161 = %158;
+    %162 = println(%161) -> bb137;
+  }
+  bb137 {
+    %164 = readVarInt(rd) -> bb138;
+  }
+  bb138 {
+    %165 = %164 is error
+    %165 ? bb139 : bb140;
+  }
+  bb139 {
+    %0 = %164;
+    return;
+  }
+  bb140 {
+    %163 = %164;
+    GOTO bb141;
+  }
+  bb141 {
+    %166 = %163;
+    %167 = println(%166) -> bb142;
+  }
+  bb142 {
+    %169 = readVarInt(rd) -> bb143;
+  }
+  bb143 {
+    %170 = %169 is error
+    %170 ? bb144 : bb145;
+  }
+  bb144 {
+    %0 = %169;
+    return;
+  }
+  bb145 {
+    %168 = %169;
+    GOTO bb146;
+  }
+  bb146 {
+    %171 = %168;
+    %172 = println(%171) -> bb147;
+  }
+  bb147 {
+    %174 = close(rd) -> bb148;
+  }
+  bb148 {
+    %175 = %174 is error
+    %175 ? bb149 : bb150;
+  }
+  bb149 {
+    %0 = %174;
+    return;
+  }
+  bb150 {
+    %173 = %174;
+    GOTO bb151;
+  }
+  bb151 {
     return;
   }
 }
 main() -> nil|error{
   bb0 {
-    %1 = ConstantLoad BE
-    %2 = ConstantLoad /tmp/bal_io_dc_be.bin
-    %3 = roundtrip(%1,%2) -> bb1;
+    %2 = ConstantLoad BE
+    %3 = ConstantLoad /tmp/bal_io_dc_be.bin
+    %4 = roundtrip(%2,%3) -> bb1;
   }
   bb1 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
+    %5 = %4 is error
     %5 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %4;
     return;
   }
   bb3 {
-    %6 = ConstantLoad LE
-    %7 = ConstantLoad /tmp/bal_io_dc_le.bin
-    %8 = roundtrip(%6,%7) -> bb4;
+    %1 = %4;
+    GOTO bb4;
   }
   bb4 {
-    $desugar$1 = %8;
-    %10 = $desugar$1 is error
-    %10 ? bb5 : bb6;
+    %7 = ConstantLoad LE
+    %8 = ConstantLoad /tmp/bal_io_dc_le.bin
+    %9 = roundtrip(%7,%8) -> bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %10 = %9 is error
+    %10 ? bb6 : bb7;
   }
   bb6 {
-    %11 = ConstantLoad /tmp/bal_io_dc_be.bin
-    %12 = fileReadBytes(%11) -> bb7;
-  }
-  bb7 {
-    $desugar$2 = %12;
-    %14 = $desugar$2 is error
-    %14 ? bb8 : bb9;
-  }
-  bb8 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %9;
     return;
   }
+  bb7 {
+    %6 = %9;
+    GOTO bb8;
+  }
+  bb8 {
+    %12 = ConstantLoad /tmp/bal_io_dc_be.bin
+    %13 = fileReadBytes(%12) -> bb9;
+  }
   bb9 {
-    beBytes = $desugar$2;
+    %14 = %13 is error
+    %14 ? bb10 : bb11;
+  }
+  bb10 {
+    %0 = %13;
+    return;
+  }
+  bb11 {
+    %11 = %13;
+    GOTO bb12;
+  }
+  bb12 {
+    beBytes = %11;
     %16 = ConstantLoad 18
     %17 = ConstantLoad 52
     %18 = ConstantLoad 255
@@ -678,25 +726,26 @@ main() -> nil|error{
     beExpected = %70;
     %72 = == beBytes beExpected;
     %73 = %72;
-    %74 = println(%73) -> bb10;
-  }
-  bb10 {
-    %75 = ConstantLoad /tmp/bal_io_dc_le.bin
-    %76 = fileReadBytes(%75) -> bb11;
-  }
-  bb11 {
-    $desugar$3 = %76;
-    %78 = $desugar$3 is error
-    %78 ? bb12 : bb13;
-  }
-  bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    %74 = println(%73) -> bb13;
   }
   bb13 {
-    leBytes = $desugar$3;
+    %76 = ConstantLoad /tmp/bal_io_dc_le.bin
+    %77 = fileReadBytes(%76) -> bb14;
+  }
+  bb14 {
+    %78 = %77 is error
+    %78 ? bb15 : bb16;
+  }
+  bb15 {
+    %0 = %77;
+    return;
+  }
+  bb16 {
+    %75 = %77;
+    GOTO bb17;
+  }
+  bb17 {
+    leBytes = %75;
     %80 = ConstantLoad 52
     %81 = ConstantLoad 18
     %82 = ConstantLoad 254
@@ -755,9 +804,9 @@ main() -> nil|error{
     leExpected = %134;
     %136 = == leBytes leExpected;
     %137 = %136;
-    %138 = println(%137) -> bb14;
+    %138 = println(%137) -> bb18;
   }
-  bb14 {
+  bb18 {
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-stream-errors-v.txt
+++ b/corpus/bir/library/subset3/io-stream-errors-v.txt
@@ -137,131 +137,132 @@ main() -> nil|error{
   }
   bb6 {
     $desugar$4 = %24;
-    %26 = fileWriteBytes($desugar$2,$desugar$3,$desugar$4) -> bb7;
+    %27 = fileWriteBytes($desugar$2,$desugar$3,$desugar$4) -> bb7;
   }
   bb7 {
-    $desugar$5 = %26;
-    %28 = $desugar$5 is error
+    %28 = %27 is error
     %28 ? bb8 : bb9;
   }
   bb8 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %27;
     return;
   }
   bb9 {
-    %29 = ConstantLoad 0
-    %30 = %29;
-    %31 = fileReadBlocksAsStream(existing,%30) -> bb10;
+    %26 = %27;
+    GOTO bb10;
   }
   bb10 {
-    %32 = %31 is error
-    %33 = %32;
-    %34 = println(%33) -> bb11;
+    %29 = ConstantLoad 0
+    %30 = %29;
+    %31 = fileReadBlocksAsStream(existing,%30) -> bb11;
   }
   bb11 {
+    %32 = %31 is error
+    %33 = %32;
+    %34 = println(%33) -> bb12;
+  }
+  bb12 {
     %35 = ConstantLoad /tmp/bal_io_stream_write_lines_err1.txt
     linesPath = %35;
     %37 = newObject $anon/.:FailingLineProvider
-    %38 = init(%37) -> bb12;
-  }
-  bb12 {
-    %40 = %38 is nil
-    %40 ? bb13 : bb14;
+    %38 = init(%37) -> bb13;
   }
   bb13 {
-    %39 = %37;
-    GOTO bb15;
+    %40 = %38 is nil
+    %40 ? bb14 : bb15;
   }
   bb14 {
-    %39 = %38;
-    GOTO bb15;
+    %39 = %37;
+    GOTO bb16;
   }
   bb15 {
-    %41 = newStream stream %39
-    lineStream = %41;
-    $desugar$6 = linesPath;
-    $desugar$7 = lineStream;
-    %45 = $default$3($desugar$6,$desugar$7) -> bb16;
+    %39 = %38;
+    GOTO bb16;
   }
   bb16 {
-    $desugar$8 = %45;
-    %47 = fileWriteLinesFromStream($desugar$6,$desugar$7,$desugar$8) -> bb17;
+    %41 = newStream stream %39
+    lineStream = %41;
+    $desugar$5 = linesPath;
+    $desugar$6 = lineStream;
+    %45 = $default$3($desugar$5,$desugar$6) -> bb17;
   }
   bb17 {
+    $desugar$7 = %45;
+    %47 = fileWriteLinesFromStream($desugar$5,$desugar$6,$desugar$7) -> bb18;
+  }
+  bb18 {
     lineResult = %47;
     %49 = lineResult is error
     %50 = %49;
-    %51 = println(%50) -> bb18;
-  }
-  bb18 {
-    %52 = lineResult is error
-    %52 ? bb19 : bb22;
+    %51 = println(%50) -> bb19;
   }
   bb19 {
-    PushScopeFrame 2
-    %0 = message((1, lineResult)) -> bb20;
+    %52 = lineResult is error
+    %52 ? bb20 : bb23;
   }
   bb20 {
-    %1 = println(%0) -> bb21;
+    PushScopeFrame 2
+    %0 = message((1, lineResult)) -> bb21;
   }
   bb21 {
-    PopScopeFrame
-    GOTO bb22;
+    %1 = println(%0) -> bb22;
   }
   bb22 {
+    PopScopeFrame
+    GOTO bb23;
+  }
+  bb23 {
     PushScopeFrame 18
     %0 = ConstantLoad /tmp/bal_io_stream_write_blocks_err1.bin
     blocksPath = %0;
     %2 = newObject $anon/.:FailingBlockProvider
-    %3 = init(%2) -> bb23;
-  }
-  bb23 {
-    %5 = %3 is nil
-    %5 ? bb24 : bb25;
+    %3 = init(%2) -> bb24;
   }
   bb24 {
-    %4 = %2;
-    GOTO bb26;
+    %5 = %3 is nil
+    %5 ? bb25 : bb26;
   }
   bb25 {
-    %4 = %3;
-    GOTO bb26;
+    %4 = %2;
+    GOTO bb27;
   }
   bb26 {
-    %6 = newStream stream %4
-    blockStream = %6;
-    $desugar$9 = blocksPath;
-    $desugar$10 = blockStream;
-    %10 = $default$5($desugar$9,$desugar$10) -> bb27;
+    %4 = %3;
+    GOTO bb27;
   }
   bb27 {
-    $desugar$11 = %10;
-    %12 = fileWriteBlocksFromStream($desugar$9,$desugar$10,$desugar$11) -> bb28;
+    %6 = newStream stream %4
+    blockStream = %6;
+    $desugar$8 = blocksPath;
+    $desugar$9 = blockStream;
+    %10 = $default$5($desugar$8,$desugar$9) -> bb28;
   }
   bb28 {
+    $desugar$10 = %10;
+    %12 = fileWriteBlocksFromStream($desugar$8,$desugar$9,$desugar$10) -> bb29;
+  }
+  bb29 {
     blockResult = %12;
     %14 = blockResult is error
     %15 = %14;
-    %16 = println(%15) -> bb29;
-  }
-  bb29 {
-    %17 = blockResult is error
-    %17 ? bb30 : bb33;
+    %16 = println(%15) -> bb30;
   }
   bb30 {
-    PushScopeFrame 2
-    %0 = message((1, blockResult)) -> bb31;
+    %17 = blockResult is error
+    %17 ? bb31 : bb34;
   }
   bb31 {
-    %1 = println(%0) -> bb32;
+    PushScopeFrame 2
+    %0 = message((1, blockResult)) -> bb32;
   }
   bb32 {
-    PopScopeFrame
-    GOTO bb33;
+    %1 = println(%0) -> bb33;
   }
   bb33 {
+    PopScopeFrame
+    GOTO bb34;
+  }
+  bb34 {
     PushScopeFrame 0
     PopScopeFrame
     PopScopeFrame

--- a/corpus/bir/library/subset3/io-stream-generic-completion1-v.txt
+++ b/corpus/bir/library/subset3/io-stream-generic-completion1-v.txt
@@ -18,163 +18,171 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %14;
-    %16 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %17 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %16;
-    %18 = $desugar$3 is error
+    %18 = %17 is error
     %18 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %17;
     return;
   }
   bb4 {
-    %19 = ConstantLoad 2
-    %20 = %19;
-    %21 = fileReadBlocksAsStream(inPath,%20) -> bb5;
+    %16 = %17;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %21;
-    %23 = $desugar$4 is error
-    %23 ? bb6 : bb7;
+    %20 = ConstantLoad 2
+    %21 = %20;
+    %22 = fileReadBlocksAsStream(inPath,%21) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %23 = %22 is error
+    %23 ? bb7 : bb8;
   }
   bb7 {
-    blocks = $desugar$4;
-    $desugar$5 = outPath;
-    $desugar$6 = blocks;
-    %27 = $default$5($desugar$5,$desugar$6) -> bb8;
+    %0 = %22;
+    return;
   }
   bb8 {
-    $desugar$7 = %27;
-    %29 = fileWriteBlocksFromStream($desugar$5,$desugar$6,$desugar$7) -> bb9;
+    %19 = %22;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$8 = %29;
-    %31 = $desugar$8 is error
-    %31 ? bb10 : bb11;
+    blocks = %19;
+    $desugar$3 = outPath;
+    $desugar$4 = blocks;
+    %27 = $default$5($desugar$3,$desugar$4) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
+    $desugar$5 = %27;
+    %30 = fileWriteBlocksFromStream($desugar$3,$desugar$4,$desugar$5) -> bb11;
   }
   bb11 {
-    %32 = fileReadBytes(outPath) -> bb12;
+    %31 = %30 is error
+    %31 ? bb12 : bb13;
   }
   bb12 {
-    $desugar$9 = %32;
-    %34 = $desugar$9 is error
-    %34 ? bb13 : bb14;
-  }
-  bb13 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+    %0 = %30;
     return;
   }
+  bb13 {
+    %29 = %30;
+    GOTO bb14;
+  }
   bb14 {
-    outBytes = $desugar$9;
-    %36 = length(outBytes) -> bb15;
+    %33 = fileReadBytes(outPath) -> bb15;
   }
   bb15 {
-    %37 = %36;
-    %38 = println(%37) -> bb16;
+    %34 = %33 is error
+    %34 ? bb16 : bb17;
   }
   bb16 {
-    $desugar$10 = inPath;
+    %0 = %33;
+    return;
+  }
+  bb17 {
+    %32 = %33;
+    GOTO bb18;
+  }
+  bb18 {
+    outBytes = %32;
+    %36 = length(outBytes) -> bb19;
+  }
+  bb19 {
+    %37 = %36;
+    %38 = println(%37) -> bb20;
+  }
+  bb20 {
+    $desugar$6 = inPath;
     %40 = ConstantLoad Alpha
     %41 = ConstantLoad Beta
     %42 = ConstantLoad 2
     %43 = newArray [string...][%42]{%40, %41}
-    $desugar$11 = %43;
-    %45 = $default$2($desugar$10,$desugar$11) -> bb17;
-  }
-  bb17 {
-    $desugar$12 = %45;
-    %47 = fileWriteLines($desugar$10,$desugar$11,$desugar$12) -> bb18;
-  }
-  bb18 {
-    $desugar$13 = %47;
-    %49 = $desugar$13 is error
-    %49 ? bb19 : bb20;
-  }
-  bb19 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
-    return;
-  }
-  bb20 {
-    %50 = fileReadLinesAsStream(inPath) -> bb21;
+    $desugar$7 = %43;
+    %45 = $default$2($desugar$6,$desugar$7) -> bb21;
   }
   bb21 {
-    $desugar$14 = %50;
-    %52 = $desugar$14 is error
-    %52 ? bb22 : bb23;
+    $desugar$8 = %45;
+    %48 = fileWriteLines($desugar$6,$desugar$7,$desugar$8) -> bb22;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
-    return;
+    %49 = %48 is error
+    %49 ? bb23 : bb24;
   }
   bb23 {
-    lines = $desugar$14;
-    $desugar$15 = outPath;
-    $desugar$16 = lines;
-    %56 = $default$3($desugar$15,$desugar$16) -> bb24;
+    %0 = %48;
+    return;
   }
   bb24 {
-    $desugar$17 = %56;
-    %58 = fileWriteLinesFromStream($desugar$15,$desugar$16,$desugar$17) -> bb25;
+    %47 = %48;
+    GOTO bb25;
   }
   bb25 {
-    $desugar$18 = %58;
-    %60 = $desugar$18 is error
-    %60 ? bb26 : bb27;
+    %51 = fileReadLinesAsStream(inPath) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$18);
-    PopScopeFrame
-    return;
+    %52 = %51 is error
+    %52 ? bb27 : bb28;
   }
   bb27 {
-    %61 = fileReadLines(outPath) -> bb28;
-  }
-  bb28 {
-    $desugar$19 = %61;
-    %63 = $desugar$19 is error
-    %63 ? bb29 : bb30;
-  }
-  bb29 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$19);
-    PopScopeFrame
+    %0 = %51;
     return;
   }
+  bb28 {
+    %50 = %51;
+    GOTO bb29;
+  }
+  bb29 {
+    lines = %50;
+    $desugar$9 = outPath;
+    $desugar$10 = lines;
+    %56 = $default$3($desugar$9,$desugar$10) -> bb30;
+  }
   bb30 {
-    outLines = $desugar$19;
-    %66 = ConstantLoad 0
-    %65 = outLines[%66];
-    %67 = println(%65) -> bb31;
+    $desugar$11 = %56;
+    %59 = fileWriteLinesFromStream($desugar$9,$desugar$10,$desugar$11) -> bb31;
   }
   bb31 {
-    %69 = ConstantLoad 1
-    %68 = outLines[%69];
-    %70 = println(%68) -> bb32;
+    %60 = %59 is error
+    %60 ? bb32 : bb33;
   }
   bb32 {
+    %0 = %59;
+    return;
+  }
+  bb33 {
+    %58 = %59;
+    GOTO bb34;
+  }
+  bb34 {
+    %62 = fileReadLines(outPath) -> bb35;
+  }
+  bb35 {
+    %63 = %62 is error
+    %63 ? bb36 : bb37;
+  }
+  bb36 {
+    %0 = %62;
+    return;
+  }
+  bb37 {
+    %61 = %62;
+    GOTO bb38;
+  }
+  bb38 {
+    outLines = %61;
+    %66 = ConstantLoad 0
+    %65 = outLines[%66];
+    %67 = println(%65) -> bb39;
+  }
+  bb39 {
+    %69 = ConstantLoad 1
+    %68 = outLines[%69];
+    %70 = println(%68) -> bb40;
+  }
+  bb40 {
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-stream-read-blocks1-v.txt
+++ b/corpus/bir/library/subset3/io-stream-read-blocks1-v.txt
@@ -19,208 +19,212 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %15;
-    %17 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %18 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %17;
-    %19 = $desugar$3 is error
+    %19 = %18 is error
     %19 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %18;
     return;
   }
   bb4 {
-    %20 = ConstantLoad 3
-    %21 = %20;
-    %22 = fileReadBlocksAsStream(blockPath,%21) -> bb5;
+    %17 = %18;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %22;
-    %24 = $desugar$4 is error
-    %24 ? bb6 : bb7;
+    %21 = ConstantLoad 3
+    %22 = %21;
+    %23 = fileReadBlocksAsStream(blockPath,%22) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %24 = %23 is error
+    %24 ? bb7 : bb8;
   }
   bb7 {
-    s = $desugar$4;
+    %0 = %23;
+    return;
+  }
+  bb8 {
+    %20 = %23;
+    GOTO bb9;
+  }
+  bb9 {
+    s = %20;
     %26 = streamNext s
     r1 = %26;
     %28 = r1 is {| value: readonly&[int:Unsigned8...], never... |}
-    %28 ? bb8 : bb12;
+    %28 ? bb10 : bb14;
   }
-  bb8 {
+  bb10 {
     PushScopeFrame 11
     %1 = ConstantLoad value
     %0 = (1, r1)[%1];
-    %2 = length(%0) -> bb9;
+    %2 = length(%0) -> bb11;
   }
-  bb9 {
+  bb11 {
     %3 = %2;
-    %4 = println(%3) -> bb10;
+    %4 = println(%3) -> bb12;
   }
-  bb10 {
+  bb12 {
     %6 = ConstantLoad 0
     %8 = ConstantLoad value
     %7 = (1, r1)[%8];
     %5 = %7[%6];
     %9 = %5;
-    %10 = println(%9) -> bb11;
+    %10 = println(%9) -> bb13;
   }
-  bb11 {
+  bb13 {
     PopScopeFrame
-    GOTO bb12;
+    GOTO bb14;
   }
-  bb12 {
+  bb14 {
     PushScopeFrame 3
     %0 = streamNext (1, s)
     r2 = %0;
     %2 = r2 is {| value: readonly&[int:Unsigned8...], never... |}
-    %2 ? bb13 : bb16;
+    %2 ? bb15 : bb18;
   }
-  bb13 {
+  bb15 {
     PushScopeFrame 5
     %1 = ConstantLoad value
     %0 = (1, r2)[%1];
-    %2 = length(%0) -> bb14;
-  }
-  bb14 {
-    %3 = %2;
-    %4 = println(%3) -> bb15;
-  }
-  bb15 {
-    PopScopeFrame
-    GOTO bb16;
+    %2 = length(%0) -> bb16;
   }
   bb16 {
+    %3 = %2;
+    %4 = println(%3) -> bb17;
+  }
+  bb17 {
+    PopScopeFrame
+    GOTO bb18;
+  }
+  bb18 {
     PushScopeFrame 3
     %0 = streamNext (2, s)
     r3 = %0;
     %2 = r3 is {| value: readonly&[int:Unsigned8...], never... |}
-    %2 ? bb17 : bb21;
+    %2 ? bb19 : bb23;
   }
-  bb17 {
+  bb19 {
     PushScopeFrame 11
     %1 = ConstantLoad value
     %0 = (1, r3)[%1];
-    %2 = length(%0) -> bb18;
+    %2 = length(%0) -> bb20;
   }
-  bb18 {
+  bb20 {
     %3 = %2;
-    %4 = println(%3) -> bb19;
+    %4 = println(%3) -> bb21;
   }
-  bb19 {
+  bb21 {
     %6 = ConstantLoad 0
     %8 = ConstantLoad value
     %7 = (1, r3)[%8];
     %5 = %7[%6];
     %9 = %5;
-    %10 = println(%9) -> bb20;
+    %10 = println(%9) -> bb22;
   }
-  bb20 {
+  bb22 {
     PopScopeFrame
-    GOTO bb21;
+    GOTO bb23;
   }
-  bb21 {
+  bb23 {
     PushScopeFrame 3
     %0 = streamNext (3, s)
     r4 = %0;
     %2 = r4 is nil
-    %2 ? bb22 : bb24;
-  }
-  bb22 {
-    PushScopeFrame 2
-    %0 = ConstantLoad done
-    %1 = println(%0) -> bb23;
-  }
-  bb23 {
-    PopScopeFrame
-    GOTO bb24;
+    %2 ? bb24 : bb26;
   }
   bb24 {
+    PushScopeFrame 2
+    %0 = ConstantLoad done
+    %1 = println(%0) -> bb25;
+  }
+  bb25 {
+    PopScopeFrame
+    GOTO bb26;
+  }
+  bb26 {
     PushScopeFrame 25
     %0 = ConstantLoad /tmp/bal_io_stream_read_blocks_default.bin
     defaultPath = %0;
-    $desugar$5 = defaultPath;
+    $desugar$3 = defaultPath;
     %3 = ConstantLoad 9
     %4 = ConstantLoad 8
     %5 = ConstantLoad 7
     %6 = ConstantLoad 3
     %7 = newArray [int:Unsigned8...][%6]{%3, %4, %5}
-    $desugar$6 = %7;
-    %9 = $default$4($desugar$5,$desugar$6) -> bb25;
-  }
-  bb25 {
-    $desugar$7 = %9;
-    %11 = fileWriteBytes($desugar$5,$desugar$6,$desugar$7) -> bb26;
-  }
-  bb26 {
-    $desugar$8 = %11;
-    %13 = $desugar$8 is error
-    %13 ? bb27 : bb28;
+    $desugar$4 = %7;
+    %9 = $default$4($desugar$3,$desugar$4) -> bb27;
   }
   bb27 {
-    PushScopeFrame 0
-    (5, %0) = (1, $desugar$8);
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    PopScopeFrame
-    return;
+    $desugar$5 = %9;
+    %12 = fileWriteBytes($desugar$3,$desugar$4,$desugar$5) -> bb28;
   }
   bb28 {
-    $desugar$9 = defaultPath;
-    %15 = $default$0($desugar$9) -> bb29;
+    %13 = %12 is error
+    %13 ? bb29 : bb30;
   }
   bb29 {
-    $desugar$10 = %15;
-    %17 = $desugar$10;
-    %18 = fileReadBlocksAsStream($desugar$9,%17) -> bb30;
-  }
-  bb30 {
-    $desugar$11 = %18;
-    %20 = $desugar$11 is error
-    %20 ? bb31 : bb32;
-  }
-  bb31 {
-    PushScopeFrame 0
-    (5, %0) = (1, $desugar$11);
-    PopScopeFrame
+    (4, %0) = %12;
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame
     return;
   }
+  bb30 {
+    %11 = %12;
+    GOTO bb31;
+  }
+  bb31 {
+    $desugar$6 = defaultPath;
+    %15 = $default$0($desugar$6) -> bb32;
+  }
   bb32 {
-    defaultStream = $desugar$11;
-    %22 = streamNext defaultStream
-    d1 = %22;
-    %24 = d1 is {| value: readonly&[int:Unsigned8...], never... |}
-    %24 ? bb33 : bb36;
+    $desugar$7 = %15;
+    %18 = $desugar$7;
+    %19 = fileReadBlocksAsStream($desugar$6,%18) -> bb33;
   }
   bb33 {
-    PushScopeFrame 5
-    %1 = ConstantLoad value
-    %0 = (1, d1)[%1];
-    %2 = length(%0) -> bb34;
+    %20 = %19 is error
+    %20 ? bb34 : bb35;
   }
   bb34 {
-    %3 = %2;
-    %4 = println(%3) -> bb35;
+    (4, %0) = %19;
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
   }
   bb35 {
-    PopScopeFrame
+    %17 = %19;
     GOTO bb36;
   }
   bb36 {
+    defaultStream = %17;
+    %22 = streamNext defaultStream
+    d1 = %22;
+    %24 = d1 is {| value: readonly&[int:Unsigned8...], never... |}
+    %24 ? bb37 : bb40;
+  }
+  bb37 {
+    PushScopeFrame 5
+    %1 = ConstantLoad value
+    %0 = (1, d1)[%1];
+    %2 = length(%0) -> bb38;
+  }
+  bb38 {
+    %3 = %2;
+    %4 = println(%3) -> bb39;
+  }
+  bb39 {
+    PopScopeFrame
+    GOTO bb40;
+  }
+  bb40 {
     PushScopeFrame 0
     PopScopeFrame
     PopScopeFrame

--- a/corpus/bir/library/subset3/io-stream-read-lines1-v.txt
+++ b/corpus/bir/library/subset3/io-stream-read-lines1-v.txt
@@ -14,107 +14,109 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %10;
-    %12 = fileWriteLines($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %13 = fileWriteLines($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %12;
-    %14 = $desugar$3 is error
+    %14 = %13 is error
     %14 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %13;
     return;
   }
   bb4 {
-    %15 = fileReadLinesAsStream(path) -> bb5;
+    %12 = %13;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %15;
-    %17 = $desugar$4 is error
-    %17 ? bb6 : bb7;
+    %16 = fileReadLinesAsStream(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %17 = %16 is error
+    %17 ? bb7 : bb8;
   }
   bb7 {
-    s = $desugar$4;
+    %0 = %16;
+    return;
+  }
+  bb8 {
+    %15 = %16;
+    GOTO bb9;
+  }
+  bb9 {
+    s = %15;
     %19 = streamNext s
     r1 = %19;
     %21 = r1 is {| value: string, never... |}
-    %21 ? bb8 : bb10;
+    %21 ? bb10 : bb12;
   }
-  bb8 {
+  bb10 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, r1)[%1];
-    %2 = println(%0) -> bb9;
+    %2 = println(%0) -> bb11;
   }
-  bb9 {
+  bb11 {
     PopScopeFrame
-    GOTO bb10;
+    GOTO bb12;
   }
-  bb10 {
+  bb12 {
     PushScopeFrame 3
     %0 = streamNext (1, s)
     r2 = %0;
     %2 = r2 is {| value: string, never... |}
-    %2 ? bb11 : bb13;
+    %2 ? bb13 : bb15;
   }
-  bb11 {
+  bb13 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, r2)[%1];
-    %2 = println(%0) -> bb12;
+    %2 = println(%0) -> bb14;
   }
-  bb12 {
+  bb14 {
     PopScopeFrame
-    GOTO bb13;
+    GOTO bb15;
   }
-  bb13 {
+  bb15 {
     PushScopeFrame 3
     %0 = streamNext (2, s)
     r3 = %0;
     %2 = r3 is {| value: string, never... |}
-    %2 ? bb14 : bb16;
+    %2 ? bb16 : bb18;
   }
-  bb14 {
+  bb16 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, r3)[%1];
-    %2 = println(%0) -> bb15;
+    %2 = println(%0) -> bb17;
   }
-  bb15 {
+  bb17 {
     PopScopeFrame
-    GOTO bb16;
+    GOTO bb18;
   }
-  bb16 {
+  bb18 {
     PushScopeFrame 3
     %0 = streamNext (3, s)
     r4 = %0;
     %2 = r4 is nil
-    %2 ? bb17 : bb19;
-  }
-  bb17 {
-    PushScopeFrame 2
-    %0 = ConstantLoad done
-    %1 = println(%0) -> bb18;
-  }
-  bb18 {
-    PopScopeFrame
-    GOTO bb19;
+    %2 ? bb19 : bb21;
   }
   bb19 {
+    PushScopeFrame 2
+    %0 = ConstantLoad done
+    %1 = println(%0) -> bb20;
+  }
+  bb20 {
+    PopScopeFrame
+    GOTO bb21;
+  }
+  bb21 {
     PushScopeFrame 3
     %0 = streamClose (4, s)
     closeResult = %0;
-    %2 = println(closeResult) -> bb20;
+    %2 = println(closeResult) -> bb22;
   }
-  bb20 {
+  bb22 {
     PopScopeFrame
     PopScopeFrame
     PopScopeFrame

--- a/corpus/bir/library/subset3/io-stream-read-lines2-v.txt
+++ b/corpus/bir/library/subset3/io-stream-read-lines2-v.txt
@@ -17,101 +17,103 @@ main() -> nil|error{
   }
   bb1 {
     $desugar$2 = %13;
-    %15 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
+    %16 = fileWriteBytes($desugar$0,$desugar$1,$desugar$2) -> bb2;
   }
   bb2 {
-    $desugar$3 = %15;
-    %17 = $desugar$3 is error
+    %17 = %16 is error
     %17 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %16;
     return;
   }
   bb4 {
-    %18 = fileReadLinesAsStream(path) -> bb5;
+    %15 = %16;
+    GOTO bb5;
   }
   bb5 {
-    $desugar$4 = %18;
-    %20 = $desugar$4 is error
-    %20 ? bb6 : bb7;
+    %19 = fileReadLinesAsStream(path) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %20 = %19 is error
+    %20 ? bb7 : bb8;
   }
   bb7 {
-    s = $desugar$4;
+    %0 = %19;
+    return;
+  }
+  bb8 {
+    %18 = %19;
+    GOTO bb9;
+  }
+  bb9 {
+    s = %18;
     %22 = streamNext s
     r1 = %22;
     %24 = r1 is {| value: string, never... |}
-    %24 ? bb8 : bb10;
+    %24 ? bb10 : bb12;
   }
-  bb8 {
+  bb10 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, r1)[%1];
-    %2 = println(%0) -> bb9;
+    %2 = println(%0) -> bb11;
   }
-  bb9 {
+  bb11 {
     PopScopeFrame
-    GOTO bb10;
+    GOTO bb12;
   }
-  bb10 {
+  bb12 {
     PushScopeFrame 3
     %0 = streamNext (1, s)
     r2 = %0;
     %2 = r2 is {| value: string, never... |}
-    %2 ? bb11 : bb13;
+    %2 ? bb13 : bb15;
   }
-  bb11 {
+  bb13 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, r2)[%1];
-    %2 = println(%0) -> bb12;
+    %2 = println(%0) -> bb14;
   }
-  bb12 {
+  bb14 {
     PopScopeFrame
-    GOTO bb13;
+    GOTO bb15;
   }
-  bb13 {
+  bb15 {
     PushScopeFrame 3
     %0 = streamNext (2, s)
     r3 = %0;
     %2 = r3 is {| value: string, never... |}
-    %2 ? bb14 : bb16;
+    %2 ? bb16 : bb18;
   }
-  bb14 {
+  bb16 {
     PushScopeFrame 3
     %1 = ConstantLoad value
     %0 = (1, r3)[%1];
-    %2 = println(%0) -> bb15;
+    %2 = println(%0) -> bb17;
   }
-  bb15 {
+  bb17 {
     PopScopeFrame
-    GOTO bb16;
+    GOTO bb18;
   }
-  bb16 {
+  bb18 {
     PushScopeFrame 3
     %0 = streamNext (3, s)
     r4 = %0;
     %2 = r4 is nil
-    %2 ? bb17 : bb19;
-  }
-  bb17 {
-    PushScopeFrame 2
-    %0 = ConstantLoad done
-    %1 = println(%0) -> bb18;
-  }
-  bb18 {
-    PopScopeFrame
-    GOTO bb19;
+    %2 ? bb19 : bb21;
   }
   bb19 {
+    PushScopeFrame 2
+    %0 = ConstantLoad done
+    %1 = println(%0) -> bb20;
+  }
+  bb20 {
+    PopScopeFrame
+    GOTO bb21;
+  }
+  bb21 {
     PushScopeFrame 0
     PopScopeFrame
     PopScopeFrame

--- a/corpus/bir/library/subset3/io-stream-write-blocks1-v.txt
+++ b/corpus/bir/library/subset3/io-stream-write-blocks1-v.txt
@@ -100,54 +100,56 @@ main() -> nil|error{
   }
   bb5 {
     $desugar$2 = %25;
-    %27 = fileWriteBlocksFromStream($desugar$0,$desugar$1,$desugar$2) -> bb6;
+    %28 = fileWriteBlocksFromStream($desugar$0,$desugar$1,$desugar$2) -> bb6;
   }
   bb6 {
-    $desugar$3 = %27;
-    %29 = $desugar$3 is error
+    %29 = %28 is error
     %29 ? bb7 : bb8;
   }
   bb7 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %28;
     return;
   }
   bb8 {
-    %30 = fileReadBytes(path) -> bb9;
+    %27 = %28;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$4 = %30;
-    %32 = $desugar$4 is error
-    %32 ? bb10 : bb11;
+    %31 = fileReadBytes(path) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %32 = %31 is error
+    %32 ? bb11 : bb12;
   }
   bb11 {
-    readBack = $desugar$4;
-    %34 = length(readBack) -> bb12;
+    %0 = %31;
+    return;
   }
   bb12 {
-    %35 = %34;
-    %36 = println(%35) -> bb13;
+    %30 = %31;
+    GOTO bb13;
   }
   bb13 {
+    readBack = %30;
+    %34 = length(readBack) -> bb14;
+  }
+  bb14 {
+    %35 = %34;
+    %36 = println(%35) -> bb15;
+  }
+  bb15 {
     %38 = ConstantLoad 0
     %37 = readBack[%38];
     %39 = %37;
-    %40 = println(%39) -> bb14;
+    %40 = println(%39) -> bb16;
   }
-  bb14 {
+  bb16 {
     %42 = ConstantLoad 5
     %41 = readBack[%42];
     %43 = %41;
-    %44 = println(%43) -> bb15;
+    %44 = println(%43) -> bb17;
   }
-  bb15 {
+  bb17 {
     %45 = newObject $anon/.:BlockProvider
     %46 = ConstantLoad 7
     %47 = ConstantLoad 8
@@ -155,66 +157,68 @@ main() -> nil|error{
     %49 = newArray [int:Unsigned8...][%48]{%46, %47}
     %50 = ConstantLoad 1
     %51 = newArray [[int:Unsigned8...]...][%50]{%49}
-    %52 = init(%45,%51) -> bb16;
-  }
-  bb16 {
-    %54 = %52 is nil
-    %54 ? bb17 : bb18;
-  }
-  bb17 {
-    %53 = %45;
-    GOTO bb19;
+    %52 = init(%45,%51) -> bb18;
   }
   bb18 {
-    %53 = %52;
-    GOTO bb19;
+    %54 = %52 is nil
+    %54 ? bb19 : bb20;
   }
   bb19 {
-    %55 = newStream stream %53
-    appendStream = %55;
-    %57 = ConstantLoad APPEND
-    %58 = fileWriteBlocksFromStream(path,appendStream,%57) -> bb20;
+    %53 = %45;
+    GOTO bb21;
   }
   bb20 {
-    $desugar$5 = %58;
-    %60 = $desugar$5 is error
-    %60 ? bb21 : bb22;
+    %53 = %52;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
-    return;
+    %55 = newStream stream %53
+    appendStream = %55;
+    %58 = ConstantLoad APPEND
+    %59 = fileWriteBlocksFromStream(path,appendStream,%58) -> bb22;
   }
   bb22 {
-    %61 = fileReadBytes(path) -> bb23;
+    %60 = %59 is error
+    %60 ? bb23 : bb24;
   }
   bb23 {
-    $desugar$6 = %61;
-    %63 = $desugar$6 is error
-    %63 ? bb24 : bb25;
-  }
-  bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+    %0 = %59;
     return;
   }
+  bb24 {
+    %57 = %59;
+    GOTO bb25;
+  }
   bb25 {
-    combined = $desugar$6;
-    %65 = length(combined) -> bb26;
+    %62 = fileReadBytes(path) -> bb26;
   }
   bb26 {
-    %66 = %65;
-    %67 = println(%66) -> bb27;
+    %63 = %62 is error
+    %63 ? bb27 : bb28;
   }
   bb27 {
+    %0 = %62;
+    return;
+  }
+  bb28 {
+    %61 = %62;
+    GOTO bb29;
+  }
+  bb29 {
+    combined = %61;
+    %65 = length(combined) -> bb30;
+  }
+  bb30 {
+    %66 = %65;
+    %67 = println(%66) -> bb31;
+  }
+  bb31 {
     %69 = ConstantLoad 7
     %68 = combined[%69];
     %70 = %68;
-    %71 = println(%70) -> bb28;
+    %71 = println(%70) -> bb32;
   }
-  bb28 {
+  bb32 {
     return;
   }
 }

--- a/corpus/bir/library/subset3/io-stream-write-lines1-v.txt
+++ b/corpus/bir/library/subset3/io-stream-write-lines1-v.txt
@@ -91,148 +91,152 @@ main() -> nil|error{
   }
   bb5 {
     $desugar$2 = %16;
-    %18 = fileWriteLinesFromStream($desugar$0,$desugar$1,$desugar$2) -> bb6;
+    %19 = fileWriteLinesFromStream($desugar$0,$desugar$1,$desugar$2) -> bb6;
   }
   bb6 {
-    $desugar$3 = %18;
-    %20 = $desugar$3 is error
+    %20 = %19 is error
     %20 ? bb7 : bb8;
   }
   bb7 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %19;
     return;
   }
   bb8 {
-    %21 = fileReadLines(path) -> bb9;
+    %18 = %19;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$4 = %21;
-    %23 = $desugar$4 is error
-    %23 ? bb10 : bb11;
+    %22 = fileReadLines(path) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
-    return;
+    %23 = %22 is error
+    %23 ? bb11 : bb12;
   }
   bb11 {
-    lines = $desugar$4;
-    $desugar$5 = lines;
-    %26 = ConstantLoad 0
-    $desugar$6 = %26;
-    %28 = length($desugar$5) -> bb12;
+    %0 = %22;
+    return;
   }
   bb12 {
-    $desugar$7 = %28;
+    %21 = %22;
     GOTO bb13;
   }
   bb13 {
-    %31 = $desugar$6;
-    %32 = $desugar$7;
-    %30 = < %31 %32;
-    %30 ? bb14 : bb15;
+    lines = %21;
+    $desugar$3 = lines;
+    %26 = ConstantLoad 0
+    $desugar$4 = %26;
+    %28 = length($desugar$3) -> bb14;
   }
   bb14 {
-    PushScopeFrame 7
-    %0 = (1, $desugar$5)[(1, $desugar$6)];
-    line = %0;
-    %2 = println(line) -> bb16;
+    $desugar$5 = %28;
+    GOTO bb15;
   }
   bb15 {
+    %31 = $desugar$4;
+    %32 = $desugar$5;
+    %30 = < %31 %32;
+    %30 ? bb16 : bb17;
+  }
+  bb16 {
+    PushScopeFrame 7
+    %0 = (1, $desugar$3)[(1, $desugar$4)];
+    line = %0;
+    %2 = println(line) -> bb18;
+  }
+  bb17 {
     %33 = newObject $anon/.:LineProvider
     %34 = ConstantLoad Four
     %35 = ConstantLoad 1
     %36 = newArray [string...][%35]{%34}
-    %37 = init(%33,%36) -> bb17;
-  }
-  bb16 {
-    %4 = (1, $desugar$6);
-    %5 = ConstantLoad 1
-    %6 = %5;
-    %3 = + %4 %6;
-    (1, $desugar$6) = %3;
-    PopScopeFrame
-    GOTO bb13;
-  }
-  bb17 {
-    %39 = %37 is nil
-    %39 ? bb18 : bb19;
+    %37 = init(%33,%36) -> bb19;
   }
   bb18 {
-    %38 = %33;
-    GOTO bb20;
-  }
-  bb19 {
-    %38 = %37;
-    GOTO bb20;
-  }
-  bb20 {
-    %40 = newStream stream %38
-    appendStream = %40;
-    %42 = ConstantLoad APPEND
-    %43 = fileWriteLinesFromStream(path,appendStream,%42) -> bb21;
-  }
-  bb21 {
-    $desugar$8 = %43;
-    %45 = $desugar$8 is error
-    %45 ? bb22 : bb23;
-  }
-  bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
-    return;
-  }
-  bb23 {
-    %46 = fileReadLines(path) -> bb24;
-  }
-  bb24 {
-    $desugar$9 = %46;
-    %48 = $desugar$9 is error
-    %48 ? bb25 : bb26;
-  }
-  bb25 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
-    return;
-  }
-  bb26 {
-    allLines = $desugar$9;
-    $desugar$10 = allLines;
-    %51 = ConstantLoad 0
-    $desugar$11 = %51;
-    %53 = length($desugar$10) -> bb27;
-  }
-  bb27 {
-    $desugar$12 = %53;
-    GOTO bb28;
-  }
-  bb28 {
-    %56 = $desugar$11;
-    %57 = $desugar$12;
-    %55 = < %56 %57;
-    %55 ? bb29 : bb30;
-  }
-  bb29 {
-    PushScopeFrame 7
-    %0 = (1, $desugar$10)[(1, $desugar$11)];
-    line = %0;
-    %2 = println(line) -> bb31;
-  }
-  bb30 {
-    return;
-  }
-  bb31 {
-    %4 = (1, $desugar$11);
+    %4 = (1, $desugar$4);
     %5 = ConstantLoad 1
     %6 = %5;
     %3 = + %4 %6;
-    (1, $desugar$11) = %3;
+    (1, $desugar$4) = %3;
     PopScopeFrame
-    GOTO bb28;
+    GOTO bb15;
+  }
+  bb19 {
+    %39 = %37 is nil
+    %39 ? bb20 : bb21;
+  }
+  bb20 {
+    %38 = %33;
+    GOTO bb22;
+  }
+  bb21 {
+    %38 = %37;
+    GOTO bb22;
+  }
+  bb22 {
+    %40 = newStream stream %38
+    appendStream = %40;
+    %43 = ConstantLoad APPEND
+    %44 = fileWriteLinesFromStream(path,appendStream,%43) -> bb23;
+  }
+  bb23 {
+    %45 = %44 is error
+    %45 ? bb24 : bb25;
+  }
+  bb24 {
+    %0 = %44;
+    return;
+  }
+  bb25 {
+    %42 = %44;
+    GOTO bb26;
+  }
+  bb26 {
+    %47 = fileReadLines(path) -> bb27;
+  }
+  bb27 {
+    %48 = %47 is error
+    %48 ? bb28 : bb29;
+  }
+  bb28 {
+    %0 = %47;
+    return;
+  }
+  bb29 {
+    %46 = %47;
+    GOTO bb30;
+  }
+  bb30 {
+    allLines = %46;
+    $desugar$6 = allLines;
+    %51 = ConstantLoad 0
+    $desugar$7 = %51;
+    %53 = length($desugar$6) -> bb31;
+  }
+  bb31 {
+    $desugar$8 = %53;
+    GOTO bb32;
+  }
+  bb32 {
+    %56 = $desugar$7;
+    %57 = $desugar$8;
+    %55 = < %56 %57;
+    %55 ? bb33 : bb34;
+  }
+  bb33 {
+    PushScopeFrame 7
+    %0 = (1, $desugar$6)[(1, $desugar$7)];
+    line = %0;
+    %2 = println(line) -> bb35;
+  }
+  bb34 {
+    return;
+  }
+  bb35 {
+    %4 = (1, $desugar$7);
+    %5 = ConstantLoad 1
+    %6 = %5;
+    %3 = + %4 %6;
+    (1, $desugar$7) = %3;
+    PopScopeFrame
+    GOTO bb32;
   }
 }

--- a/corpus/bir/subset5/05-error/check-v.txt
+++ b/corpus/bir/subset5/05-error/check-v.txt
@@ -20,25 +20,26 @@ foo() -> int|error{
 }
 bar() -> error{
   bb0 {
-    %1 = foo() -> bb1;
+    %2 = foo() -> bb1;
   }
   bb1 {
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
+    %3 = %2 is error
     %3 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %2;
     return;
   }
   bb3 {
-    a = $desugar$0;
-    %5 = a;
-    %6 = println(%5) -> bb4;
+    %1 = %2;
+    GOTO bb4;
   }
   bb4 {
+    a = %1;
+    %5 = a;
+    %6 = println(%5) -> bb5;
+  }
+  bb5 {
     %7 = ConstantLoad unexpected
     %8 = newError error(%7)
     panic %8;

--- a/corpus/bir/subset5/05-error/check1-v.txt
+++ b/corpus/bir/subset5/05-error/check1-v.txt
@@ -26,24 +26,26 @@ main() -> nil{
 }
 div(int,int) -> int|error{
   bb0 {
-    %3 = y;
-    %4 = nonZero(%3) -> bb1;
+    %4 = x;
+    %6 = y;
+    %7 = nonZero(%6) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
-    %6 ? bb2 : bb3;
+    %8 = %7 is error
+    %8 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %7;
     return;
   }
   bb3 {
-    %8 = x;
-    %7 = / %8 $desugar$0;
-    %0 = %7;
+    %5 = %7;
+    GOTO bb4;
+  }
+  bb4 {
+    %9 = %5;
+    %3 = / %4 %9;
+    %0 = %3;
     return;
   }
 }

--- a/corpus/bir/subset5/05-error/check2-v.txt
+++ b/corpus/bir/subset5/05-error/check2-v.txt
@@ -1,22 +1,23 @@
 module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
-    %1 = ConstantLoad 1
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
+    %2 = ConstantLoad 1
+    %3 = %2 is error
     %3 ? bb1 : bb2;
   }
   bb1 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %2;
     return;
   }
   bb2 {
-    %4 = $desugar$0;
-    %5 = println(%4) -> bb3;
+    %1 = %2;
+    GOTO bb3;
   }
   bb3 {
+    %4 = %1;
+    %5 = println(%4) -> bb4;
+  }
+  bb4 {
     return;
   }
 }

--- a/corpus/bir/subset5/05-error/check3-p.txt
+++ b/corpus/bir/subset5/05-error/check3-p.txt
@@ -17,24 +17,25 @@ main() -> nil{
 }
 div(int,int) -> int{
   bb0 {
-    %3 = y;
-    %4 = nonZero(%3) -> bb1;
+    %4 = x;
+    %6 = y;
+    %7 = nonZero(%6) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
-    %6 ? bb2 : bb3;
+    %8 = %7 is error
+    %8 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %7) = (1, $desugar$0);
-    PopScopeFrame
     panic %7;
   }
   bb3 {
-    %9 = x;
-    %8 = / %9 $desugar$0;
-    %0 = %8;
+    %5 = %7;
+    GOTO bb4;
+  }
+  bb4 {
+    %9 = %5;
+    %3 = / %4 %9;
+    %0 = %3;
     return;
   }
 }

--- a/corpus/bir/subset5/05-error/check4-p.txt
+++ b/corpus/bir/subset5/05-error/check4-p.txt
@@ -5,28 +5,28 @@ main() -> nil{
     %2 = ConstantLoad 1
     %3 = newMap {| int... |}{%1=%2}
     m = %3;
-    %6 = ConstantLoad y
-    %5 = m[%6];
-    %7 = %5;
-    %8 = nonNil(%7) -> bb1;
+    %7 = ConstantLoad y
+    %6 = m[%7];
+    %8 = %6;
+    %9 = nonNil(%8) -> bb1;
   }
   bb1 {
-    $desugar$0 = %8;
-    %10 = $desugar$0 is error
+    %10 = %9 is error
     %10 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %11) = (1, $desugar$0);
-    PopScopeFrame
-    panic %11;
+    panic %9;
   }
   bb3 {
-    %12 = unknown $desugar$0;
-    %13 = %12;
-    %14 = println(%13) -> bb4;
+    %5 = %9;
+    GOTO bb4;
   }
   bb4 {
+    %11 = unknown %5;
+    %12 = %11;
+    %13 = println(%12) -> bb5;
+  }
+  bb5 {
     return;
   }
 }

--- a/corpus/bir/subset5/05-error/check5-v.txt
+++ b/corpus/bir/subset5/05-error/check5-v.txt
@@ -5,28 +5,28 @@ main() -> nil{
     %2 = ConstantLoad 3
     %3 = newMap {| int... |}{%1=%2}
     m = %3;
-    %6 = ConstantLoad x
-    %5 = m[%6];
-    %7 = %5;
-    %8 = nonNil(%7) -> bb1;
+    %7 = ConstantLoad x
+    %6 = m[%7];
+    %8 = %6;
+    %9 = nonNil(%8) -> bb1;
   }
   bb1 {
-    $desugar$0 = %8;
-    %10 = $desugar$0 is error
+    %10 = %9 is error
     %10 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %11) = (1, $desugar$0);
-    PopScopeFrame
-    panic %11;
+    panic %9;
   }
   bb3 {
-    %12 = unknown $desugar$0;
-    %13 = %12;
-    %14 = println(%13) -> bb4;
+    %5 = %9;
+    GOTO bb4;
   }
   bb4 {
+    %11 = unknown %5;
+    %12 = %11;
+    %13 = println(%12) -> bb5;
+  }
+  bb5 {
     return;
   }
 }

--- a/corpus/bir/subset6/06-object/implicit-new-check-v.txt
+++ b/corpus/bir/subset6/06-object/implicit-new-check-v.txt
@@ -41,42 +41,43 @@ class Counter {
 }
 main() -> nil|error{
   bb0 {
-    %1 = newObject $anon/.:Counter
-    %2 = ConstantLoad 5
-    %3 = init(%1,%2) -> bb1;
+    %2 = newObject $anon/.:Counter
+    %3 = ConstantLoad 5
+    %4 = init(%2,%3) -> bb1;
   }
   bb1 {
-    %5 = %3 is nil
-    %5 ? bb2 : bb3;
+    %6 = %4 is nil
+    %6 ? bb2 : bb3;
   }
   bb2 {
-    %4 = %1;
+    %5 = %2;
     GOTO bb4;
   }
   bb3 {
-    %4 = %3;
+    %5 = %4;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %4;
-    %7 = $desugar$0 is error
+    %7 = %5 is error
     %7 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb6 {
-    c = $desugar$0;
-    %9 = get(c) -> bb7;
+    %1 = %5;
+    GOTO bb7;
   }
   bb7 {
-    %10 = %9;
-    %11 = println(%10) -> bb8;
+    c = %1;
+    %9 = get(c) -> bb8;
   }
   bb8 {
+    %10 = %9;
+    %11 = println(%10) -> bb9;
+  }
+  bb9 {
     %12 = ConstantLoad <nil>
     %0 = %12;
     return;

--- a/corpus/bir/subset6/06-object/init-error-check-v.txt
+++ b/corpus/bir/subset6/06-object/init-error-check-v.txt
@@ -41,37 +41,38 @@ class Foo {
 }
 createFoo(int) -> int|error{
   bb0 {
-    %2 = newObject $anon/.:Foo
-    %3 = init(%2,v) -> bb1;
+    %3 = newObject $anon/.:Foo
+    %4 = init(%3,v) -> bb1;
   }
   bb1 {
-    %5 = %3 is nil
-    %5 ? bb2 : bb3;
+    %6 = %4 is nil
+    %6 ? bb2 : bb3;
   }
   bb2 {
-    %4 = %2;
+    %5 = %3;
     GOTO bb4;
   }
   bb3 {
-    %4 = %3;
+    %5 = %4;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %4;
-    %7 = $desugar$0 is error
+    %7 = %5 is error
     %7 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb6 {
-    f = $desugar$0;
-    %9 = getVal(f) -> bb7;
+    %2 = %5;
+    GOTO bb7;
   }
   bb7 {
+    f = %2;
+    %9 = getVal(f) -> bb8;
+  }
+  bb8 {
     %0 = %9;
     return;
   }

--- a/corpus/bir/subset7/07-function/error2-p.txt
+++ b/corpus/bir/subset7/07-function/error2-p.txt
@@ -21,27 +21,27 @@ main() -> nil{
 }
 bar([int...]...) -> int{
   bb0 {
-    %3 = ConstantLoad 0
-    %2 = vals[%3];
-    %4 = %2;
-    %6 = ConstantLoad 1
-    %5 = vals[%6];
-    %7 = %5;
-    %8 = foo(%4,%7) -> bb1;
+    %4 = ConstantLoad 0
+    %3 = vals[%4];
+    %5 = %3;
+    %7 = ConstantLoad 1
+    %6 = vals[%7];
+    %8 = %6;
+    %9 = foo(%5,%8) -> bb1;
   }
   bb1 {
-    $desugar$0 = %8;
-    %10 = $desugar$0 is error
+    %10 = %9 is error
     %10 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %11) = (1, $desugar$0);
-    PopScopeFrame
-    panic %11;
+    panic %9;
   }
   bb3 {
-    %0 = $desugar$0;
+    %2 = %9;
+    GOTO bb4;
+  }
+  bb4 {
+    %0 = %2;
     return;
   }
 }

--- a/corpus/bir/subset8/08-error/check1-v.txt
+++ b/corpus/bir/subset8/08-error/check1-v.txt
@@ -12,20 +12,21 @@ main() -> nil{
 }
 errorViaCheck() -> nil|error{
   bb0 {
-    %1 = newError() -> bb1;
+    %2 = newError() -> bb1;
   }
   bb1 {
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
+    %3 = %2 is error
     %3 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %2;
     return;
   }
   bb3 {
+    %1 = %2;
+    GOTO bb4;
+  }
+  bb4 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-error/check10-v.txt
+++ b/corpus/bir/subset8/08-error/check10-v.txt
@@ -12,31 +12,32 @@ main() -> nil{
 }
 passAlong() -> nil|error{
   bb0 {
-    %1 = alwaysErr() -> bb1;
+    %3 = alwaysErr() -> bb1;
   }
   bb1 {
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
-    %3 ? bb2 : bb3;
+    %4 = %3 is error
+    %4 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %3;
     return;
   }
   bb3 {
-    $desugar$1 = $desugar$0;
-    %5 = $desugar$1 is error
-    %5 ? bb4 : bb5;
+    %2 = %3;
+    GOTO bb4;
   }
   bb4 {
-    PushScopeFrame 0
-    (1, %6) = (1, $desugar$1);
-    PopScopeFrame
-    panic %6;
+    %5 = %2 is error
+    %5 ? bb5 : bb6;
   }
   bb5 {
+    panic %2;
+  }
+  bb6 {
+    %1 = %2;
+    GOTO bb7;
+  }
+  bb7 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-error/check11-p.txt
+++ b/corpus/bir/subset8/08-error/check11-p.txt
@@ -13,31 +13,32 @@ main() -> nil{
 }
 doPanic() -> nil{
   bb0 {
-    %1 = alwaysErr() -> bb1;
+    %3 = alwaysErr() -> bb1;
   }
   bb1 {
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
-    %3 ? bb2 : bb3;
+    %4 = %3 is error
+    %4 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %4) = (1, $desugar$0);
-    PopScopeFrame
-    panic %4;
+    panic %3;
   }
   bb3 {
-    $desugar$1 = $desugar$0;
-    %6 = $desugar$1 is error
-    %6 ? bb4 : bb5;
+    %2 = %3;
+    GOTO bb4;
   }
   bb4 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %5 = %2 is error
+    %5 ? bb5 : bb6;
   }
   bb5 {
+    %0 = %2;
+    return;
+  }
+  bb6 {
+    %1 = %2;
+    GOTO bb7;
+  }
+  bb7 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-error/check15-v.txt
+++ b/corpus/bir/subset8/08-error/check15-v.txt
@@ -1,0 +1,76 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    GOTO bb1;
+  }
+  bb1 {
+    %2 = nestedScopeCheckpanic() -> bb2;
+  }
+  bb2 {
+    %1 = %2;
+    GOTO bb3;
+  }
+  bb3 {
+    result = %1;
+    %4 = println(result) -> bb4;
+  }
+  bb4 {
+    return;
+  }
+  
+  error-table {
+    [bb1, bb2] -> bb3, %1
+  }
+}
+nestedScopeCheckpanic() -> nil{
+  bb0 {
+    %1 = ConstantLoad true
+    %1 ? bb1 : bb8;
+  }
+  bb1 {
+    PushScopeFrame 1
+    %0 = ConstantLoad true
+    %0 ? bb2 : bb7;
+  }
+  bb2 {
+    PushScopeFrame 3
+    %1 = alwaysErr() -> bb3;
+  }
+  bb3 {
+    %2 = %1 is error
+    %2 ? bb4 : bb5;
+  }
+  bb4 {
+    (2, %2) = %1;
+    PopScopeFrame
+    PopScopeFrame
+    panic %2;
+  }
+  bb5 {
+    %0 = %1;
+    GOTO bb6;
+  }
+  bb6 {
+    PopScopeFrame
+    GOTO bb7;
+  }
+  bb7 {
+    PushScopeFrame 0
+    PopScopeFrame
+    PopScopeFrame
+    GOTO bb8;
+  }
+  bb8 {
+    PushScopeFrame 0
+    PopScopeFrame
+    return;
+  }
+}
+alwaysErr() -> nil|error{
+  bb0 {
+    %1 = ConstantLoad original error
+    %2 = newError error(%1)
+    %0 = %2;
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-error/check2-v.txt
+++ b/corpus/bir/subset8/08-error/check2-v.txt
@@ -12,20 +12,21 @@ main() -> nil{
 }
 catch() -> int|error{
   bb0 {
-    %1 = neverErr() -> bb1;
+    %2 = neverErr() -> bb1;
   }
   bb1 {
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
+    %3 = %2 is error
     %3 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %2;
     return;
   }
   bb3 {
+    %1 = %2;
+    GOTO bb4;
+  }
+  bb4 {
     %4 = ConstantLoad 22
     %0 = %4;
     return;

--- a/corpus/bir/subset8/08-error/check3-v.txt
+++ b/corpus/bir/subset8/08-error/check3-v.txt
@@ -12,20 +12,21 @@ main() -> nil{
 }
 errorViaCheck() -> error{
   bb0 {
-    %1 = newError() -> bb1;
+    %2 = newError() -> bb1;
   }
   bb1 {
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
+    %3 = %2 is error
     %3 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %2;
     return;
   }
   bb3 {
+    %1 = %2;
+    GOTO bb4;
+  }
+  bb4 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-error/check5-v.txt
+++ b/corpus/bir/subset8/08-error/check5-v.txt
@@ -5,35 +5,37 @@ main() -> nil{
     %2 = println(%1) -> bb1;
   }
   bb1 {
-    %3 = noOp() -> bb2;
+    %5 = noOp() -> bb2;
   }
   bb2 {
-    $desugar$0 = %3;
-    %5 = $desugar$0 is error
-    %5 ? bb3 : bb4;
+    %6 = %5 is error
+    %6 ? bb3 : bb4;
   }
   bb3 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb4 {
-    $desugar$1 = $desugar$0;
-    %7 = $desugar$1 is error
-    %7 ? bb5 : bb6;
+    %4 = %5;
+    GOTO bb5;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %7 = %4 is error
+    %7 ? bb6 : bb7;
   }
   bb6 {
-    %8 = ConstantLoad after
-    %9 = println(%8) -> bb7;
+    %0 = %4;
+    return;
   }
   bb7 {
+    %3 = %4;
+    GOTO bb8;
+  }
+  bb8 {
+    %8 = ConstantLoad after
+    %9 = println(%8) -> bb9;
+  }
+  bb9 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-error/check6-p.txt
+++ b/corpus/bir/subset8/08-error/check6-p.txt
@@ -1,24 +1,24 @@
 module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
-    %1 = newError() -> bb1;
+    %2 = newError() -> bb1;
   }
   bb1 {
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
+    %3 = %2 is error
     %3 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %4) = (1, $desugar$0);
-    PopScopeFrame
-    panic %4;
+    panic %2;
   }
   bb3 {
-    %5 = ConstantLoad may not reach
-    %6 = println(%5) -> bb4;
+    %1 = %2;
+    GOTO bb4;
   }
   bb4 {
+    %4 = ConstantLoad may not reach
+    %5 = println(%4) -> bb5;
+  }
+  bb5 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-error/check7-p.txt
+++ b/corpus/bir/subset8/08-error/check7-p.txt
@@ -1,20 +1,20 @@
 module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
-    %1 = newError() -> bb1;
+    %2 = newError() -> bb1;
   }
   bb1 {
-    $desugar$0 = %1;
-    %3 = $desugar$0 is error
+    %3 = %2 is error
     %3 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %4) = (1, $desugar$0);
-    PopScopeFrame
-    panic %4;
+    panic %2;
   }
   bb3 {
+    %1 = %2;
+    GOTO bb4;
+  }
+  bb4 {
     return;
   }
 }

--- a/corpus/bir/subset9/09-bug/listener-union-attach-point1-v.txt
+++ b/corpus/bir/subset9/09-bug/listener-union-attach-point1-v.txt
@@ -84,24 +84,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -132,24 +133,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -180,24 +182,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-bug/string-literal-service-attach-point-v.txt
+++ b/corpus/bir/subset9/09-bug/string-literal-service-attach-point-v.txt
@@ -143,24 +143,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -191,24 +192,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -239,24 +241,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-langlibs/boolean-from-string-v.txt
+++ b/corpus/bir/subset9/09-langlibs/boolean-from-string-v.txt
@@ -1,144 +1,150 @@
 module $anon.. v 0.0.0;
 main() -> nil{
   bb0 {
-    %1 = ConstantLoad true
-    %2 = fromString(%1) -> bb1;
+    %2 = ConstantLoad true
+    %3 = fromString(%2) -> bb1;
   }
   bb1 {
-    $desugar$0 = %2;
-    %4 = $desugar$0 is error
+    %4 = %3 is error
     %4 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %5) = (1, $desugar$0);
-    PopScopeFrame
-    panic %5;
+    panic %3;
   }
   bb3 {
-    %6 = println($desugar$0) -> bb4;
+    %1 = %3;
+    GOTO bb4;
   }
   bb4 {
-    %7 = ConstantLoad false
-    %8 = fromString(%7) -> bb5;
+    %5 = %1;
+    %6 = println(%5) -> bb5;
   }
   bb5 {
-    $desugar$1 = %8;
-    %10 = $desugar$1 is error
-    %10 ? bb6 : bb7;
+    %8 = ConstantLoad false
+    %9 = fromString(%8) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %11) = (1, $desugar$1);
-    PopScopeFrame
-    panic %11;
+    %10 = %9 is error
+    %10 ? bb7 : bb8;
   }
   bb7 {
-    %12 = println($desugar$1) -> bb8;
+    panic %9;
   }
   bb8 {
-    %13 = ConstantLoad TRUE
-    %14 = fromString(%13) -> bb9;
+    %7 = %9;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$2 = %14;
-    %16 = $desugar$2 is error
-    %16 ? bb10 : bb11;
+    %11 = %7;
+    %12 = println(%11) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %17) = (1, $desugar$2);
-    PopScopeFrame
-    panic %17;
+    %14 = ConstantLoad TRUE
+    %15 = fromString(%14) -> bb11;
   }
   bb11 {
-    %18 = println($desugar$2) -> bb12;
+    %16 = %15 is error
+    %16 ? bb12 : bb13;
   }
   bb12 {
-    %19 = ConstantLoad False
-    %20 = fromString(%19) -> bb13;
+    panic %15;
   }
   bb13 {
-    $desugar$3 = %20;
-    %22 = $desugar$3 is error
-    %22 ? bb14 : bb15;
+    %13 = %15;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %23) = (1, $desugar$3);
-    PopScopeFrame
-    panic %23;
+    %17 = %13;
+    %18 = println(%17) -> bb15;
   }
   bb15 {
-    %24 = println($desugar$3) -> bb16;
+    %20 = ConstantLoad False
+    %21 = fromString(%20) -> bb16;
   }
   bb16 {
-    %25 = ConstantLoad 1
-    %26 = fromString(%25) -> bb17;
+    %22 = %21 is error
+    %22 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %26;
-    %28 = $desugar$4 is error
-    %28 ? bb18 : bb19;
+    panic %21;
   }
   bb18 {
-    PushScopeFrame 0
-    (1, %29) = (1, $desugar$4);
-    PopScopeFrame
-    panic %29;
+    %19 = %21;
+    GOTO bb19;
   }
   bb19 {
-    %30 = println($desugar$4) -> bb20;
+    %23 = %19;
+    %24 = println(%23) -> bb20;
   }
   bb20 {
-    %31 = ConstantLoad 0
-    %32 = fromString(%31) -> bb21;
+    %26 = ConstantLoad 1
+    %27 = fromString(%26) -> bb21;
   }
   bb21 {
-    $desugar$5 = %32;
-    %34 = $desugar$5 is error
-    %34 ? bb22 : bb23;
+    %28 = %27 is error
+    %28 ? bb22 : bb23;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %35) = (1, $desugar$5);
-    PopScopeFrame
-    panic %35;
+    panic %27;
   }
   bb23 {
-    %36 = println($desugar$5) -> bb24;
+    %25 = %27;
+    GOTO bb24;
   }
   bb24 {
-    %37 = ConstantLoad yes
-    %38 = fromString(%37) -> bb25;
+    %29 = %25;
+    %30 = println(%29) -> bb25;
   }
   bb25 {
-    invalidWord = %38;
-    %40 = ConstantLoad  true 
-    %41 = fromString(%40) -> bb26;
+    %32 = ConstantLoad 0
+    %33 = fromString(%32) -> bb26;
   }
   bb26 {
-    invalidWhitespace = %41;
-    %43 = ConstantLoad 
-    %44 = fromString(%43) -> bb27;
+    %34 = %33 is error
+    %34 ? bb27 : bb28;
   }
   bb27 {
+    panic %33;
+  }
+  bb28 {
+    %31 = %33;
+    GOTO bb29;
+  }
+  bb29 {
+    %35 = %31;
+    %36 = println(%35) -> bb30;
+  }
+  bb30 {
+    %37 = ConstantLoad yes
+    %38 = fromString(%37) -> bb31;
+  }
+  bb31 {
+    invalidWord = %38;
+    %40 = ConstantLoad  true 
+    %41 = fromString(%40) -> bb32;
+  }
+  bb32 {
+    invalidWhitespace = %41;
+    %43 = ConstantLoad 
+    %44 = fromString(%43) -> bb33;
+  }
+  bb33 {
     invalidEmpty = %44;
     %46 = invalidWord is error
     %47 = %46;
-    %48 = println(%47) -> bb28;
+    %48 = println(%47) -> bb34;
   }
-  bb28 {
+  bb34 {
     %49 = invalidWhitespace is error
     %50 = %49;
-    %51 = println(%50) -> bb29;
+    %51 = println(%50) -> bb35;
   }
-  bb29 {
+  bb35 {
     %52 = invalidEmpty is error
     %53 = %52;
-    %54 = println(%53) -> bb30;
+    %54 = println(%53) -> bb36;
   }
-  bb30 {
+  bb36 {
     return;
   }
 }

--- a/corpus/bir/subset9/09-langlibs/string-from-to-bytes-v.txt
+++ b/corpus/bir/subset9/09-langlibs/string-from-to-bytes-v.txt
@@ -9,40 +9,41 @@ main() -> nil|error{
     %6 = ConstantLoad 5
     %7 = newArray [int:Unsigned8...][%6]{%1, %2, %3, %4, %5}
     bytes = %7;
-    %9 = fromBytes(bytes) -> bb1;
+    %10 = fromBytes(bytes) -> bb1;
   }
   bb1 {
-    $desugar$0 = %9;
-    %11 = $desugar$0 is error
+    %11 = %10 is error
     %11 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %10;
     return;
   }
   bb3 {
-    %12 = println($desugar$0) -> bb4;
+    %9 = %10;
+    GOTO bb4;
   }
   bb4 {
-    %13 = ConstantLoad Hello
-    %14 = toBytes(%13) -> bb5;
+    %12 = println(%9) -> bb5;
   }
   bb5 {
-    %15 = println(%14) -> bb6;
+    %13 = ConstantLoad Hello
+    %14 = toBytes(%13) -> bb6;
   }
   bb6 {
+    %15 = println(%14) -> bb7;
+  }
+  bb7 {
     %16 = ConstantLoad 255
     %17 = ConstantLoad 1
     %18 = newArray [int:Unsigned8...][%17]{%16}
     bad = %18;
-    %20 = fromBytes(bad) -> bb7;
-  }
-  bb7 {
-    %21 = println(%20) -> bb8;
+    %20 = fromBytes(bad) -> bb8;
   }
   bb8 {
+    %21 = println(%20) -> bb9;
+  }
+  bb9 {
     return;
   }
 }

--- a/corpus/bir/subset9/09-object/attach-error1-p.txt
+++ b/corpus/bir/subset9/09-object/attach-error1-p.txt
@@ -86,24 +86,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -134,24 +135,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -182,24 +184,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/documented-listener-service1-v.txt
+++ b/corpus/bir/subset9/09-object/documented-listener-service1-v.txt
@@ -83,24 +83,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -131,24 +132,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -179,24 +181,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/init-incl-record-named-args-v.txt
+++ b/corpus/bir/subset9/09-object/init-incl-record-named-args-v.txt
@@ -31,45 +31,46 @@ class Listener {
 }
 main() -> nil|error{
   bb0 {
-    %1 = newObject $anon/.:Listener
-    %2 = ConstantLoad path
-    %3 = ConstantLoad /tmp
-    %4 = ConstantLoad recursive
-    %5 = ConstantLoad true
-    %6 = newMap {| path: string, recursive: boolean, never... |}{%2=%3, %4=%5} defaults{recursive=$anon/.:$desugar$0}
-    %7 = init(%1,%6) -> bb1;
+    %2 = newObject $anon/.:Listener
+    %3 = ConstantLoad path
+    %4 = ConstantLoad /tmp
+    %5 = ConstantLoad recursive
+    %6 = ConstantLoad true
+    %7 = newMap {| path: string, recursive: boolean, never... |}{%3=%4, %5=%6} defaults{recursive=$anon/.:$desugar$0}
+    %8 = init(%2,%7) -> bb1;
   }
   bb1 {
-    %9 = %7 is nil
-    %9 ? bb2 : bb3;
+    %10 = %8 is nil
+    %10 ? bb2 : bb3;
   }
   bb2 {
-    %8 = %1;
+    %9 = %2;
     GOTO bb4;
   }
   bb3 {
-    %8 = %7;
+    %9 = %8;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %8;
-    %11 = $desugar$0 is error
+    %11 = %9 is error
     %11 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %9;
     return;
   }
   bb6 {
-    instance = $desugar$0;
-    %13 = describe(instance) -> bb7;
+    %1 = %9;
+    GOTO bb7;
   }
   bb7 {
-    %14 = println(%13) -> bb8;
+    instance = %1;
+    %13 = describe(instance) -> bb8;
   }
   bb8 {
+    %14 = println(%13) -> bb9;
+  }
+  bb9 {
     return;
   }
 }

--- a/corpus/bir/subset9/09-object/init-named-args-v.txt
+++ b/corpus/bir/subset9/09-object/init-named-args-v.txt
@@ -27,118 +27,121 @@ class Listener {
 }
 main() -> nil|error{
   bb0 {
-    %1 = newObject $anon/.:Listener
-    %2 = ConstantLoad /tmp
-    %3 = ConstantLoad true
-    %4 = init(%1,%2,%3) -> bb1;
+    %2 = newObject $anon/.:Listener
+    %3 = ConstantLoad /tmp
+    %4 = ConstantLoad true
+    %5 = init(%2,%3,%4) -> bb1;
   }
   bb1 {
-    %6 = %4 is nil
-    %6 ? bb2 : bb3;
+    %7 = %5 is nil
+    %7 ? bb2 : bb3;
   }
   bb2 {
-    %5 = %1;
+    %6 = %2;
     GOTO bb4;
   }
   bb3 {
-    %5 = %4;
+    %6 = %5;
     GOTO bb4;
   }
   bb4 {
-    $desugar$0 = %5;
-    %8 = $desugar$0 is error
+    %8 = %6 is error
     %8 ? bb5 : bb6;
   }
   bb5 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %6;
     return;
   }
   bb6 {
-    named = $desugar$0;
-    %10 = describe(named) -> bb7;
+    %1 = %6;
+    GOTO bb7;
   }
   bb7 {
-    %11 = println(%10) -> bb8;
+    named = %1;
+    %10 = describe(named) -> bb8;
   }
   bb8 {
-    %12 = newObject $anon/.:Listener
-    %13 = ConstantLoad /var
-    %14 = ConstantLoad true
-    %15 = init(%12,%13,%14) -> bb9;
+    %11 = println(%10) -> bb9;
   }
   bb9 {
-    %17 = %15 is nil
-    %17 ? bb10 : bb11;
+    %13 = newObject $anon/.:Listener
+    %14 = ConstantLoad /var
+    %15 = ConstantLoad true
+    %16 = init(%13,%14,%15) -> bb10;
   }
   bb10 {
-    %16 = %12;
-    GOTO bb12;
+    %18 = %16 is nil
+    %18 ? bb11 : bb12;
   }
   bb11 {
-    %16 = %15;
-    GOTO bb12;
+    %17 = %13;
+    GOTO bb13;
   }
   bb12 {
-    $desugar$1 = %16;
-    %19 = $desugar$1 is error
-    %19 ? bb13 : bb14;
+    %17 = %16;
+    GOTO bb13;
   }
   bb13 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %19 = %17 is error
+    %19 ? bb14 : bb15;
   }
   bb14 {
-    mixed = $desugar$1;
-    %21 = describe(mixed) -> bb15;
-  }
-  bb15 {
-    %22 = println(%21) -> bb16;
-  }
-  bb16 {
-    %23 = ConstantLoad /etc
-    $desugar$2 = %23;
-    %25 = $default$0($desugar$2) -> bb17;
-  }
-  bb17 {
-    $desugar$3 = %25;
-    %27 = newObject $anon/.:Listener
-    %28 = init(%27,$desugar$2,$desugar$3) -> bb18;
-  }
-  bb18 {
-    %30 = %28 is nil
-    %30 ? bb19 : bb20;
-  }
-  bb19 {
-    %29 = %27;
-    GOTO bb21;
-  }
-  bb20 {
-    %29 = %28;
-    GOTO bb21;
-  }
-  bb21 {
-    $desugar$4 = %29;
-    %32 = $desugar$4 is error
-    %32 ? bb22 : bb23;
-  }
-  bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %17;
     return;
   }
+  bb15 {
+    %12 = %17;
+    GOTO bb16;
+  }
+  bb16 {
+    mixed = %12;
+    %21 = describe(mixed) -> bb17;
+  }
+  bb17 {
+    %22 = println(%21) -> bb18;
+  }
+  bb18 {
+    %23 = ConstantLoad /etc
+    $desugar$0 = %23;
+    %25 = $default$0($desugar$0) -> bb19;
+  }
+  bb19 {
+    $desugar$1 = %25;
+    %28 = newObject $anon/.:Listener
+    %29 = init(%28,$desugar$0,$desugar$1) -> bb20;
+  }
+  bb20 {
+    %31 = %29 is nil
+    %31 ? bb21 : bb22;
+  }
+  bb21 {
+    %30 = %28;
+    GOTO bb23;
+  }
+  bb22 {
+    %30 = %29;
+    GOTO bb23;
+  }
   bb23 {
-    defaulted = $desugar$4;
-    %34 = describe(defaulted) -> bb24;
+    %32 = %30 is error
+    %32 ? bb24 : bb25;
   }
   bb24 {
-    %35 = println(%34) -> bb25;
+    %0 = %30;
+    return;
   }
   bb25 {
+    %27 = %30;
+    GOTO bb26;
+  }
+  bb26 {
+    defaulted = %27;
+    %34 = describe(defaulted) -> bb27;
+  }
+  bb27 {
+    %35 = println(%34) -> bb28;
+  }
+  bb28 {
     return;
   }
 }

--- a/corpus/bir/subset9/09-object/listener-init-error1-p.txt
+++ b/corpus/bir/subset9/09-object/listener-init-error1-p.txt
@@ -91,24 +91,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -139,24 +140,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -187,24 +189,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/listener-lifecycle1-v.txt
+++ b/corpus/bir/subset9/09-object/listener-lifecycle1-v.txt
@@ -100,24 +100,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -148,24 +149,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -196,24 +198,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/listener-new-init-error1-p.txt
+++ b/corpus/bir/subset9/09-object/listener-new-init-error1-p.txt
@@ -86,24 +86,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -134,24 +135,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -182,24 +184,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/listener-new-init1-v.txt
+++ b/corpus/bir/subset9/09-object/listener-new-init1-v.txt
@@ -89,24 +89,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -137,24 +138,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -185,24 +187,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/listener-two-services1-v.txt
+++ b/corpus/bir/subset9/09-object/listener-two-services1-v.txt
@@ -103,24 +103,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -151,24 +152,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -199,24 +201,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/listener-without-service1-v.txt
+++ b/corpus/bir/subset9/09-object/listener-without-service1-v.txt
@@ -83,24 +83,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -131,24 +132,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -179,24 +181,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/listener1-v.txt
+++ b/corpus/bir/subset9/09-object/listener1-v.txt
@@ -87,24 +87,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -135,24 +136,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -183,24 +185,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-distinct-type1-v.txt
+++ b/corpus/bir/subset9/09-object/service-distinct-type1-v.txt
@@ -216,24 +216,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -264,24 +265,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -312,24 +314,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-init-error1-p.txt
+++ b/corpus/bir/subset9/09-object/service-init-error1-p.txt
@@ -86,24 +86,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -134,24 +135,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -182,24 +184,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-init-multiple-listeners1-v.txt
+++ b/corpus/bir/subset9/09-object/service-init-multiple-listeners1-v.txt
@@ -97,24 +97,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -145,24 +146,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -193,24 +195,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-init1-v.txt
+++ b/corpus/bir/subset9/09-object/service-init1-v.txt
@@ -89,24 +89,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -137,24 +138,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -185,24 +187,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-isolated-final-field-access-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-isolated-final-field-access-1-v.txt
@@ -141,24 +141,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -189,24 +190,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -237,24 +239,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
@@ -130,24 +130,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -178,24 +179,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -226,24 +228,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
@@ -211,24 +211,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -259,24 +260,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -307,24 +309,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-on-call-listener1-v.txt
+++ b/corpus/bir/subset9/09-object/service-on-call-listener1-v.txt
@@ -113,24 +113,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -161,24 +162,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -209,24 +211,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/bir/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -150,24 +150,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -198,24 +199,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -246,24 +248,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-on-listener-type-alias1-v.txt
+++ b/corpus/bir/subset9/09-object/service-on-listener-type-alias1-v.txt
@@ -90,24 +90,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -138,24 +139,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -186,24 +188,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-on-multiple-listeners1-v.txt
+++ b/corpus/bir/subset9/09-object/service-on-multiple-listeners1-v.txt
@@ -116,24 +116,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -164,24 +165,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -212,24 +214,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-on-new-listener-attach-error1-p.txt
+++ b/corpus/bir/subset9/09-object/service-on-new-listener-attach-error1-p.txt
@@ -86,24 +86,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -134,24 +135,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -182,24 +184,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-on-new-listener-init-error1-p.txt
+++ b/corpus/bir/subset9/09-object/service-on-new-listener-init-error1-p.txt
@@ -86,24 +86,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -134,24 +135,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -182,24 +184,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service-on-new-listener1-v.txt
+++ b/corpus/bir/subset9/09-object/service-on-new-listener1-v.txt
@@ -93,24 +93,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -141,24 +142,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -189,24 +191,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-object/service1-v.txt
+++ b/corpus/bir/subset9/09-object/service1-v.txt
@@ -174,24 +174,25 @@ $start() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = start($listener) -> bb5;
+    %3 = start($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -222,24 +223,25 @@ $gracefulStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = gracefulStop($listener) -> bb5;
+    %3 = gracefulStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;
@@ -270,24 +272,25 @@ $immediateStop() -> nil|error{
     PushScopeFrame 9
     %0 = (1, $desugar$0)[(1, $desugar$1)];
     $listener = %0;
-    %2 = immediateStop($listener) -> bb5;
+    %3 = immediateStop($listener) -> bb5;
   }
   bb4 {
     return;
   }
   bb5 {
-    $desugar$3 = %2;
-    %4 = $desugar$3 is error
+    %4 = %3 is error
     %4 ? bb6 : bb7;
   }
   bb6 {
-    PushScopeFrame 0
-    (2, %0) = (1, $desugar$3);
-    PopScopeFrame
+    (1, %0) = %3;
     PopScopeFrame
     return;
   }
   bb7 {
+    %2 = %3;
+    GOTO bb8;
+  }
+  bb8 {
     %6 = (1, $desugar$1);
     %7 = ConstantLoad 1
     %8 = %7;

--- a/corpus/bir/subset9/09-template-expr/check-v.txt
+++ b/corpus/bir/subset9/09-template-expr/check-v.txt
@@ -20,21 +20,22 @@ main() -> nil{
 }
 build(string) -> string|error{
   bb0 {
-    %2 = validate(s) -> bb1;
+    %3 = validate(s) -> bb1;
   }
   bb1 {
-    $desugar$0 = %2;
-    %4 = $desugar$0 is error
+    %4 = %3 is error
     %4 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %3;
     return;
   }
   bb3 {
-    %5 = evalTemplate[string]("hello ", $desugar$0, "")
+    %2 = %3;
+    GOTO bb4;
+  }
+  bb4 {
+    %5 = evalTemplate[string]("hello ", %2, "")
     %0 = %5;
     return;
   }

--- a/corpus/bir/subset9/09-value/clonewithtype-numeric-v.txt
+++ b/corpus/bir/subset9/09-value/clonewithtype-numeric-v.txt
@@ -3,321 +3,335 @@ main() -> nil|error{
   bb0 {
     %1 = ConstantLoad 1234
     i = %1;
-    %3 = ConstantLoad typedesc
-    %4 = cloneWithType(i,%3) -> bb1;
+    %4 = ConstantLoad typedesc
+    %5 = cloneWithType(i,%4) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
+    %6 = %5 is error
     %6 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb3 {
-    f = $desugar$0;
-    %8 = f;
-    %9 = println(%8) -> bb4;
+    %3 = %5;
+    GOTO bb4;
   }
   bb4 {
-    %10 = ConstantLoad 1234.6
-    fv = %10;
-    %12 = ConstantLoad typedesc
-    %13 = cloneWithType(fv,%12) -> bb5;
+    f = %3;
+    %8 = f;
+    %9 = println(%8) -> bb5;
   }
   bb5 {
-    $desugar$1 = %13;
-    %15 = $desugar$1 is error
-    %15 ? bb6 : bb7;
+    %10 = ConstantLoad 1234.6
+    fv = %10;
+    %13 = ConstantLoad typedesc
+    %14 = cloneWithType(fv,%13) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %15 = %14 is error
+    %15 ? bb7 : bb8;
   }
   bb7 {
-    iv = $desugar$1;
-    %17 = iv;
-    %18 = println(%17) -> bb8;
+    %0 = %14;
+    return;
   }
   bb8 {
-    %19 = ConstantLoad 2.5
-    half = %19;
-    %21 = ConstantLoad typedesc
-    %22 = cloneWithType(half,%21) -> bb9;
+    %12 = %14;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$2 = %22;
-    %24 = $desugar$2 is error
-    %24 ? bb10 : bb11;
+    iv = %12;
+    %17 = iv;
+    %18 = println(%17) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %19 = ConstantLoad 2.5
+    half = %19;
+    %22 = ConstantLoad typedesc
+    %23 = cloneWithType(half,%22) -> bb11;
   }
   bb11 {
-    halfInt = $desugar$2;
-    %26 = halfInt;
-    %27 = println(%26) -> bb12;
+    %24 = %23 is error
+    %24 ? bb12 : bb13;
   }
   bb12 {
-    %28 = ConstantLoad 7
-    di = %28;
-    %30 = ConstantLoad typedesc
-    %31 = cloneWithType(di,%30) -> bb13;
+    %0 = %23;
+    return;
   }
   bb13 {
-    $desugar$3 = %31;
-    %33 = $desugar$3 is error
-    %33 ? bb14 : bb15;
+    %21 = %23;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    halfInt = %21;
+    %26 = halfInt;
+    %27 = println(%26) -> bb15;
   }
   bb15 {
-    d = $desugar$3;
-    %35 = d;
-    %36 = println(%35) -> bb16;
+    %28 = ConstantLoad 7
+    di = %28;
+    %31 = ConstantLoad typedesc
+    %32 = cloneWithType(di,%31) -> bb16;
   }
   bb16 {
-    %37 = ConstantLoad 1.5
-    fdv = %37;
-    %39 = ConstantLoad typedesc
-    %40 = cloneWithType(fdv,%39) -> bb17;
+    %33 = %32 is error
+    %33 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %40;
-    %42 = $desugar$4 is error
-    %42 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %32;
     return;
   }
+  bb18 {
+    %30 = %32;
+    GOTO bb19;
+  }
   bb19 {
-    fd = $desugar$4;
-    %44 = fd;
-    %45 = println(%44) -> bb20;
+    d = %30;
+    %35 = d;
+    %36 = println(%35) -> bb20;
   }
   bb20 {
-    %46 = ConstantLoad 12.3456
-    decVal = %46;
-    decAny = decVal;
-    %49 = ConstantLoad typedesc
-    %50 = cloneWithType(decAny,%49) -> bb21;
+    %37 = ConstantLoad 1.5
+    fdv = %37;
+    %40 = ConstantLoad typedesc
+    %41 = cloneWithType(fdv,%40) -> bb21;
   }
   bb21 {
-    $desugar$5 = %50;
-    %52 = $desugar$5 is error
-    %52 ? bb22 : bb23;
+    %42 = %41 is error
+    %42 ? bb22 : bb23;
   }
   bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %41;
     return;
   }
   bb23 {
-    fromDec = $desugar$5;
-    %54 = fromDec;
-    %55 = println(%54) -> bb24;
+    %39 = %41;
+    GOTO bb24;
   }
   bb24 {
+    fd = %39;
+    %44 = fd;
+    %45 = println(%44) -> bb25;
+  }
+  bb25 {
+    %46 = ConstantLoad 12.3456
+    decVal = %46;
+    decAny = decVal;
+    %50 = ConstantLoad typedesc
+    %51 = cloneWithType(decAny,%50) -> bb26;
+  }
+  bb26 {
+    %52 = %51 is error
+    %52 ? bb27 : bb28;
+  }
+  bb27 {
+    %0 = %51;
+    return;
+  }
+  bb28 {
+    %49 = %51;
+    GOTO bb29;
+  }
+  bb29 {
+    fromDec = %49;
+    %54 = fromDec;
+    %55 = println(%54) -> bb30;
+  }
+  bb30 {
     %56 = ConstantLoad 3.5
     decF = %56;
     decFAny = decF;
-    %59 = ConstantLoad typedesc
-    %60 = cloneWithType(decFAny,%59) -> bb25;
-  }
-  bb25 {
-    $desugar$6 = %60;
-    %62 = $desugar$6 is error
-    %62 ? bb26 : bb27;
-  }
-  bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
-    return;
-  }
-  bb27 {
-    floatFromDec = $desugar$6;
-    %64 = floatFromDec;
-    %65 = println(%64) -> bb28;
-  }
-  bb28 {
-    %66 = ConstantLoad 200
-    bv = %66;
-    %68 = ConstantLoad typedesc
-    %69 = cloneWithType(bv,%68) -> bb29;
-  }
-  bb29 {
-    $desugar$7 = %69;
-    %71 = $desugar$7 is error
-    %71 ? bb30 : bb31;
-  }
-  bb30 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
-    return;
+    %60 = ConstantLoad typedesc
+    %61 = cloneWithType(decFAny,%60) -> bb31;
   }
   bb31 {
-    b = $desugar$7;
-    %73 = b;
-    %74 = println(%73) -> bb32;
+    %62 = %61 is error
+    %62 ? bb32 : bb33;
   }
   bb32 {
-    %75 = ConstantLoad 200
-    fbv = %75;
-    %77 = ConstantLoad typedesc
-    %78 = cloneWithType(fbv,%77) -> bb33;
-  }
-  bb33 {
-    $desugar$8 = %78;
-    %80 = $desugar$8 is error
-    %80 ? bb34 : bb35;
-  }
-  bb34 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
+    %0 = %61;
     return;
   }
+  bb33 {
+    %59 = %61;
+    GOTO bb34;
+  }
+  bb34 {
+    floatFromDec = %59;
+    %64 = floatFromDec;
+    %65 = println(%64) -> bb35;
+  }
   bb35 {
-    fb = $desugar$8;
-    %82 = fb;
-    %83 = println(%82) -> bb36;
+    %66 = ConstantLoad 200
+    bv = %66;
+    %69 = ConstantLoad typedesc
+    %70 = cloneWithType(bv,%69) -> bb36;
   }
   bb36 {
+    %71 = %70 is error
+    %71 ? bb37 : bb38;
+  }
+  bb37 {
+    %0 = %70;
+    return;
+  }
+  bb38 {
+    %68 = %70;
+    GOTO bb39;
+  }
+  bb39 {
+    b = %68;
+    %73 = b;
+    %74 = println(%73) -> bb40;
+  }
+  bb40 {
+    %75 = ConstantLoad 200
+    fbv = %75;
+    %78 = ConstantLoad typedesc
+    %79 = cloneWithType(fbv,%78) -> bb41;
+  }
+  bb41 {
+    %80 = %79 is error
+    %80 ? bb42 : bb43;
+  }
+  bb42 {
+    %0 = %79;
+    return;
+  }
+  bb43 {
+    %77 = %79;
+    GOTO bb44;
+  }
+  bb44 {
+    fb = %77;
+    %82 = fb;
+    %83 = println(%82) -> bb45;
+  }
+  bb45 {
     %84 = ConstantLoad 42.9
     decByte = %84;
     decByteAny = decByte;
-    %87 = ConstantLoad typedesc
-    %88 = cloneWithType(decByteAny,%87) -> bb37;
+    %88 = ConstantLoad typedesc
+    %89 = cloneWithType(decByteAny,%88) -> bb46;
   }
-  bb37 {
-    $desugar$9 = %88;
-    %90 = $desugar$9 is error
-    %90 ? bb38 : bb39;
+  bb46 {
+    %90 = %89 is error
+    %90 ? bb47 : bb48;
   }
-  bb38 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+  bb47 {
+    %0 = %89;
     return;
   }
-  bb39 {
-    dby = $desugar$9;
-    %92 = dby;
-    %93 = println(%92) -> bb40;
+  bb48 {
+    %87 = %89;
+    GOTO bb49;
   }
-  bb40 {
+  bb49 {
+    dby = %87;
+    %92 = dby;
+    %93 = println(%92) -> bb50;
+  }
+  bb50 {
     %94 = ConstantLoad 1
     %95 = ConstantLoad 2
     %96 = ConstantLoad 3
     %97 = ConstantLoad 3
     %98 = newArray [anydata...][%97]{%94, %95, %96}
     ints = %98;
-    %100 = ConstantLoad typedesc
-    %101 = cloneWithType(ints,%100) -> bb41;
+    %101 = ConstantLoad typedesc
+    %102 = cloneWithType(ints,%101) -> bb51;
   }
-  bb41 {
-    $desugar$10 = %101;
-    %103 = $desugar$10 is error
-    %103 ? bb42 : bb43;
+  bb51 {
+    %103 = %102 is error
+    %103 ? bb52 : bb53;
   }
-  bb42 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
+  bb52 {
+    %0 = %102;
     return;
   }
-  bb43 {
-    fa = $desugar$10;
-    %105 = println(fa) -> bb44;
+  bb53 {
+    %100 = %102;
+    GOTO bb54;
   }
-  bb44 {
-    %106 = ConstantLoad typedesc
-    %107 = cloneWithType(ints,%106) -> bb45;
+  bb54 {
+    fa = %100;
+    %105 = println(fa) -> bb55;
   }
-  bb45 {
-    $desugar$11 = %107;
-    %109 = $desugar$11 is error
-    %109 ? bb46 : bb47;
+  bb55 {
+    %107 = ConstantLoad typedesc
+    %108 = cloneWithType(ints,%107) -> bb56;
   }
-  bb46 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$11);
-    PopScopeFrame
+  bb56 {
+    %109 = %108 is error
+    %109 ? bb57 : bb58;
+  }
+  bb57 {
+    %0 = %108;
     return;
   }
-  bb47 {
-    da = $desugar$11;
-    %111 = println(da) -> bb48;
+  bb58 {
+    %106 = %108;
+    GOTO bb59;
   }
-  bb48 {
+  bb59 {
+    da = %106;
+    %111 = println(da) -> bb60;
+  }
+  bb60 {
     %112 = ConstantLoad 1
     %113 = ConstantLoad 2
     %114 = ConstantLoad 3
     %115 = ConstantLoad 3
     %116 = newArray [anydata...][%115]{%112, %113, %114}
     floats = %116;
-    %118 = ConstantLoad typedesc
-    %119 = cloneWithType(floats,%118) -> bb49;
+    %119 = ConstantLoad typedesc
+    %120 = cloneWithType(floats,%119) -> bb61;
   }
-  bb49 {
-    $desugar$12 = %119;
-    %121 = $desugar$12 is error
-    %121 ? bb50 : bb51;
+  bb61 {
+    %121 = %120 is error
+    %121 ? bb62 : bb63;
   }
-  bb50 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$12);
-    PopScopeFrame
+  bb62 {
+    %0 = %120;
     return;
   }
-  bb51 {
-    ia = $desugar$12;
-    %123 = println(ia) -> bb52;
+  bb63 {
+    %118 = %120;
+    GOTO bb64;
   }
-  bb52 {
+  bb64 {
+    ia = %118;
+    %123 = println(ia) -> bb65;
+  }
+  bb65 {
     %124 = ConstantLoad 1
     %125 = ConstantLoad 200
     %126 = ConstantLoad 255
     %127 = ConstantLoad 3
     %128 = newArray [anydata...][%127]{%124, %125, %126}
     floatBytes = %128;
-    %130 = ConstantLoad typedesc
-    %131 = cloneWithType(floatBytes,%130) -> bb53;
+    %131 = ConstantLoad typedesc
+    %132 = cloneWithType(floatBytes,%131) -> bb66;
   }
-  bb53 {
-    $desugar$13 = %131;
-    %133 = $desugar$13 is error
-    %133 ? bb54 : bb55;
+  bb66 {
+    %133 = %132 is error
+    %133 ? bb67 : bb68;
   }
-  bb54 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$13);
-    PopScopeFrame
+  bb67 {
+    %0 = %132;
     return;
   }
-  bb55 {
-    ba = $desugar$13;
-    %135 = println(ba) -> bb56;
+  bb68 {
+    %130 = %132;
+    GOTO bb69;
   }
-  bb56 {
+  bb69 {
+    ba = %130;
+    %135 = println(ba) -> bb70;
+  }
+  bb70 {
     %136 = ConstantLoad 1.6
     %137 = ConstantLoad 2.5
     %138 = ConstantLoad 3.5
@@ -325,50 +339,52 @@ main() -> nil|error{
     %140 = newArray [decimal...][%139]{%136, %137, %138}
     decArr = %140;
     decArrAny = decArr;
-    %143 = ConstantLoad typedesc
-    %144 = cloneWithType(decArrAny,%143) -> bb57;
+    %144 = ConstantLoad typedesc
+    %145 = cloneWithType(decArrAny,%144) -> bb71;
   }
-  bb57 {
-    $desugar$14 = %144;
-    %146 = $desugar$14 is error
-    %146 ? bb58 : bb59;
+  bb71 {
+    %146 = %145 is error
+    %146 ? bb72 : bb73;
   }
-  bb58 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$14);
-    PopScopeFrame
+  bb72 {
+    %0 = %145;
     return;
   }
-  bb59 {
-    fromDecArr = $desugar$14;
-    %148 = println(fromDecArr) -> bb60;
+  bb73 {
+    %143 = %145;
+    GOTO bb74;
   }
-  bb60 {
+  bb74 {
+    fromDecArr = %143;
+    %148 = println(fromDecArr) -> bb75;
+  }
+  bb75 {
     %149 = ConstantLoad a
     %150 = ConstantLoad 1.2
     %151 = ConstantLoad b
     %152 = ConstantLoad 2.7
     %153 = newMap {| anydata... |}{%149=%150, %151=%152}
     mf = %153;
-    %155 = ConstantLoad typedesc
-    %156 = cloneWithType(mf,%155) -> bb61;
+    %156 = ConstantLoad typedesc
+    %157 = cloneWithType(mf,%156) -> bb76;
   }
-  bb61 {
-    $desugar$15 = %156;
-    %158 = $desugar$15 is error
-    %158 ? bb62 : bb63;
+  bb76 {
+    %158 = %157 is error
+    %158 ? bb77 : bb78;
   }
-  bb62 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$15);
-    PopScopeFrame
+  bb77 {
+    %0 = %157;
     return;
   }
-  bb63 {
-    mi = $desugar$15;
-    %160 = println(mi) -> bb64;
+  bb78 {
+    %155 = %157;
+    GOTO bb79;
   }
-  bb64 {
+  bb79 {
+    mi = %155;
+    %160 = println(mi) -> bb80;
+  }
+  bb80 {
     %161 = ConstantLoad a
     %162 = ConstantLoad 21
     %163 = ConstantLoad b
@@ -377,48 +393,49 @@ main() -> nil|error{
     %166 = ConstantLoad 1000
     %167 = newMap {| anydata... |}{%161=%162, %163=%164, %165=%166}
     r = %167;
-    %169 = ConstantLoad typedesc
-    %170 = cloneWithType(r,%169) -> bb65;
+    %170 = ConstantLoad typedesc
+    %171 = cloneWithType(r,%170) -> bb81;
   }
-  bb65 {
-    $desugar$16 = %170;
-    %172 = $desugar$16 is error
-    %172 ? bb66 : bb67;
+  bb81 {
+    %172 = %171 is error
+    %172 ? bb82 : bb83;
   }
-  bb66 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$16);
-    PopScopeFrame
+  bb82 {
+    %0 = %171;
     return;
   }
-  bb67 {
-    fr = $desugar$16;
-    %174 = println(fr) -> bb68;
+  bb83 {
+    %169 = %171;
+    GOTO bb84;
   }
-  bb68 {
+  bb84 {
+    fr = %169;
+    %174 = println(fr) -> bb85;
+  }
+  bb85 {
     %175 = ConstantLoad 256
     over = %175;
     %177 = ConstantLoad typedesc
-    %178 = cloneWithType(over,%177) -> bb69;
+    %178 = cloneWithType(over,%177) -> bb86;
   }
-  bb69 {
+  bb86 {
     %179 = %178 is error
     %180 = %179;
-    %181 = println(%180) -> bb70;
+    %181 = println(%180) -> bb87;
   }
-  bb70 {
+  bb87 {
     %182 = ConstantLoad 1
     %183 = unknown %182;
     neg = %183;
     %185 = ConstantLoad typedesc
-    %186 = cloneWithType(neg,%185) -> bb71;
+    %186 = cloneWithType(neg,%185) -> bb88;
   }
-  bb71 {
+  bb88 {
     %187 = %186 is error
     %188 = %187;
-    %189 = println(%188) -> bb72;
+    %189 = println(%188) -> bb89;
   }
-  bb72 {
+  bb89 {
     %191 = ConstantLoad 0
     %192 = %191;
     %193 = ConstantLoad 0
@@ -427,14 +444,14 @@ main() -> nil|error{
     nan = %190;
     nanAny = nan;
     %197 = ConstantLoad typedesc
-    %198 = cloneWithType(nanAny,%197) -> bb73;
+    %198 = cloneWithType(nanAny,%197) -> bb90;
   }
-  bb73 {
+  bb90 {
     %199 = %198 is error
     %200 = %199;
-    %201 = println(%200) -> bb74;
+    %201 = println(%200) -> bb91;
   }
-  bb74 {
+  bb91 {
     %203 = ConstantLoad 1
     %204 = %203;
     %205 = ConstantLoad 0
@@ -443,14 +460,14 @@ main() -> nil|error{
     inf = %202;
     infAny = inf;
     %209 = ConstantLoad typedesc
-    %210 = cloneWithType(infAny,%209) -> bb75;
+    %210 = cloneWithType(infAny,%209) -> bb92;
   }
-  bb75 {
+  bb92 {
     %211 = %210 is error
     %212 = %211;
-    %213 = println(%212) -> bb76;
+    %213 = println(%212) -> bb93;
   }
-  bb76 {
+  bb93 {
     %214 = ConstantLoad <nil>
     %0 = %214;
     return;

--- a/corpus/bir/subset9/09-value/clonewithtype-p.txt
+++ b/corpus/bir/subset9/09-value/clonewithtype-p.txt
@@ -6,22 +6,22 @@ main() -> nil{
     cyclic = m;
     %4 = ConstantLoad self
     m[%4] = cyclic;
-    %5 = ConstantLoad typedesc
-    %6 = cloneWithType(cyclic,%5) -> bb1;
+    %6 = ConstantLoad typedesc
+    %7 = cloneWithType(cyclic,%6) -> bb1;
   }
   bb1 {
-    $desugar$0 = %6;
-    %8 = $desugar$0 is error
+    %8 = %7 is error
     %8 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %9) = (1, $desugar$0);
-    PopScopeFrame
-    panic %9;
+    panic %7;
   }
   bb3 {
-    _ = $desugar$0;
+    %5 = %7;
+    GOTO bb4;
+  }
+  bb4 {
+    _ = %5;
     return;
   }
 }

--- a/corpus/bir/subset9/09-value/clonewithtype-union-order-v.txt
+++ b/corpus/bir/subset9/09-value/clonewithtype-union-order-v.txt
@@ -8,68 +8,71 @@ main() -> nil|error{
     %5 = newMap {| anydata... |}{%4=d}
     %6 = newMap {| anydata... |}{%3=%5}
     v1 = %6;
-    %8 = ConstantLoad typedesc
-    %9 = cloneWithType(v1,%8) -> bb1;
+    %9 = ConstantLoad typedesc
+    %10 = cloneWithType(v1,%9) -> bb1;
   }
   bb1 {
-    $desugar$0 = %9;
-    %11 = $desugar$0 is error
+    %11 = %10 is error
     %11 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %10;
     return;
   }
   bb3 {
-    r1 = $desugar$0;
-    %13 = println(r1) -> bb4;
+    %8 = %10;
+    GOTO bb4;
   }
   bb4 {
-    %14 = ConstantLoad typedesc
-    %15 = cloneWithType(v1,%14) -> bb5;
+    r1 = %8;
+    %13 = println(r1) -> bb5;
   }
   bb5 {
-    $desugar$1 = %15;
-    %17 = $desugar$1 is error
-    %17 ? bb6 : bb7;
+    %15 = ConstantLoad typedesc
+    %16 = cloneWithType(v1,%15) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %17 = %16 is error
+    %17 ? bb7 : bb8;
   }
   bb7 {
-    r1b = $desugar$1;
-    %19 = println(r1b) -> bb8;
+    %0 = %16;
+    return;
   }
   bb8 {
+    %14 = %16;
+    GOTO bb9;
+  }
+  bb9 {
+    r1b = %14;
+    %19 = println(r1b) -> bb10;
+  }
+  bb10 {
     %20 = ConstantLoad f2
     %21 = ConstantLoad f3
     %22 = newMap {| anydata... |}{%21=d}
     %23 = newMap {| anydata... |}{%20=%22}
     v2 = %23;
-    %25 = ConstantLoad typedesc
-    %26 = cloneWithType(v2,%25) -> bb9;
-  }
-  bb9 {
-    $desugar$2 = %26;
-    %28 = $desugar$2 is error
-    %28 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %26 = ConstantLoad typedesc
+    %27 = cloneWithType(v2,%26) -> bb11;
   }
   bb11 {
-    r2 = $desugar$2;
-    %30 = println(r2) -> bb12;
+    %28 = %27 is error
+    %28 ? bb12 : bb13;
   }
   bb12 {
+    %0 = %27;
+    return;
+  }
+  bb13 {
+    %25 = %27;
+    GOTO bb14;
+  }
+  bb14 {
+    r2 = %25;
+    %30 = println(r2) -> bb15;
+  }
+  bb15 {
     %31 = ConstantLoad f1
     %32 = ConstantLoad f3
     %33 = ConstantLoad true
@@ -77,31 +80,31 @@ main() -> nil|error{
     %35 = newMap {| anydata... |}{%31=%34}
     v3 = %35;
     %37 = ConstantLoad typedesc
-    %38 = cloneWithType(v3,%37) -> bb13;
-  }
-  bb13 {
-    r3 = %38;
-    %40 = r3 is error
-    %40 ? bb14 : bb16;
-  }
-  bb14 {
-    PushScopeFrame 2
-    %0 = ConstantLoad error
-    %1 = println(%0) -> bb15;
-  }
-  bb15 {
-    PopScopeFrame
-    GOTO bb18;
+    %38 = cloneWithType(v3,%37) -> bb16;
   }
   bb16 {
-    PushScopeFrame 1
-    %0 = println((1, r3)) -> bb17;
+    r3 = %38;
+    %40 = r3 is error
+    %40 ? bb17 : bb19;
   }
   bb17 {
-    PopScopeFrame
-    GOTO bb18;
+    PushScopeFrame 2
+    %0 = ConstantLoad error
+    %1 = println(%0) -> bb18;
   }
   bb18 {
+    PopScopeFrame
+    GOTO bb21;
+  }
+  bb19 {
+    PushScopeFrame 1
+    %0 = println((1, r3)) -> bb20;
+  }
+  bb20 {
+    PopScopeFrame
+    GOTO bb21;
+  }
+  bb21 {
     %41 = ConstantLoad <nil>
     %0 = %41;
     return;

--- a/corpus/bir/subset9/09-value/clonewithtype-union-v.txt
+++ b/corpus/bir/subset9/09-value/clonewithtype-union-v.txt
@@ -3,262 +3,273 @@ main() -> nil|error{
   bb0 {
     %1 = ConstantLoad <nil>
     nilVal = %1;
-    %3 = ConstantLoad typedesc
-    %4 = cloneWithType(nilVal,%3) -> bb1;
+    %4 = ConstantLoad typedesc
+    %5 = cloneWithType(nilVal,%4) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
+    %6 = %5 is error
     %6 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb3 {
-    n = $desugar$0;
-    %8 = n is nil
-    %9 = %8;
-    %10 = println(%9) -> bb4;
+    %3 = %5;
+    GOTO bb4;
   }
   bb4 {
-    %11 = ConstantLoad typedesc
-    %12 = cloneWithType(nilVal,%11) -> bb5;
+    n = %3;
+    %8 = n is nil
+    %9 = %8;
+    %10 = println(%9) -> bb5;
   }
   bb5 {
-    %13 = %12 is error
-    %14 = %13;
-    %15 = println(%14) -> bb6;
+    %11 = ConstantLoad typedesc
+    %12 = cloneWithType(nilVal,%11) -> bb6;
   }
   bb6 {
-    %16 = ConstantLoad 42
-    num = %16;
-    %18 = ConstantLoad typedesc
-    %19 = cloneWithType(num,%18) -> bb7;
+    %13 = %12 is error
+    %14 = %13;
+    %15 = println(%14) -> bb7;
   }
   bb7 {
-    $desugar$1 = %19;
-    %21 = $desugar$1 is error
-    %21 ? bb8 : bb9;
+    %16 = ConstantLoad 42
+    num = %16;
+    %19 = ConstantLoad typedesc
+    %20 = cloneWithType(num,%19) -> bb8;
   }
   bb8 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %21 = %20 is error
+    %21 ? bb9 : bb10;
   }
   bb9 {
-    asInt = $desugar$1;
-    %23 = println(asInt) -> bb10;
+    %0 = %20;
+    return;
   }
   bb10 {
-    %24 = ConstantLoad hello
-    str = %24;
-    %26 = ConstantLoad typedesc
-    %27 = cloneWithType(str,%26) -> bb11;
+    %18 = %20;
+    GOTO bb11;
   }
   bb11 {
-    $desugar$2 = %27;
-    %29 = $desugar$2 is error
-    %29 ? bb12 : bb13;
+    asInt = %18;
+    %23 = println(asInt) -> bb12;
   }
   bb12 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %24 = ConstantLoad hello
+    str = %24;
+    %27 = ConstantLoad typedesc
+    %28 = cloneWithType(str,%27) -> bb13;
   }
   bb13 {
-    asStr = $desugar$2;
-    %31 = println(asStr) -> bb14;
+    %29 = %28 is error
+    %29 ? bb14 : bb15;
   }
   bb14 {
-    %32 = ConstantLoad 2
-    fv = %32;
-    %34 = ConstantLoad typedesc
-    %35 = cloneWithType(fv,%34) -> bb15;
+    %0 = %28;
+    return;
   }
   bb15 {
-    $desugar$3 = %35;
-    %37 = $desugar$3 is error
-    %37 ? bb16 : bb17;
+    %26 = %28;
+    GOTO bb16;
   }
   bb16 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    asStr = %26;
+    %31 = println(asStr) -> bb17;
   }
   bb17 {
-    coerced = $desugar$3;
-    %39 = println(coerced) -> bb18;
+    %32 = ConstantLoad 2
+    fv = %32;
+    %35 = ConstantLoad typedesc
+    %36 = cloneWithType(fv,%35) -> bb18;
   }
   bb18 {
-    %40 = ConstantLoad 3
-    iv = %40;
-    %42 = ConstantLoad typedesc
-    %43 = cloneWithType(iv,%42) -> bb19;
+    %37 = %36 is error
+    %37 ? bb19 : bb20;
   }
   bb19 {
-    $desugar$4 = %43;
-    %45 = $desugar$4 is error
-    %45 ? bb20 : bb21;
-  }
-  bb20 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %36;
     return;
   }
+  bb20 {
+    %34 = %36;
+    GOTO bb21;
+  }
   bb21 {
-    optF = $desugar$4;
-    %47 = optF;
-    %48 = println(%47) -> bb22;
+    coerced = %34;
+    %39 = println(coerced) -> bb22;
   }
   bb22 {
-    %49 = ConstantLoad 10
-    dv = %49;
-    %51 = ConstantLoad typedesc
-    %52 = cloneWithType(dv,%51) -> bb23;
+    %40 = ConstantLoad 3
+    iv = %40;
+    %43 = ConstantLoad typedesc
+    %44 = cloneWithType(iv,%43) -> bb23;
   }
   bb23 {
-    $desugar$5 = %52;
-    %54 = $desugar$5 is error
-    %54 ? bb24 : bb25;
+    %45 = %44 is error
+    %45 ? bb24 : bb25;
   }
   bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+    %0 = %44;
     return;
   }
   bb25 {
-    ds = $desugar$5;
-    %56 = println(ds) -> bb26;
+    %42 = %44;
+    GOTO bb26;
   }
   bb26 {
+    optF = %42;
+    %47 = optF;
+    %48 = println(%47) -> bb27;
+  }
+  bb27 {
+    %49 = ConstantLoad 10
+    dv = %49;
+    %52 = ConstantLoad typedesc
+    %53 = cloneWithType(dv,%52) -> bb28;
+  }
+  bb28 {
+    %54 = %53 is error
+    %54 ? bb29 : bb30;
+  }
+  bb29 {
+    %0 = %53;
+    return;
+  }
+  bb30 {
+    %51 = %53;
+    GOTO bb31;
+  }
+  bb31 {
+    ds = %51;
+    %56 = println(ds) -> bb32;
+  }
+  bb32 {
     %57 = ConstantLoad name
     %58 = ConstantLoad Alice
     %59 = ConstantLoad age
     %60 = ConstantLoad 30
     %61 = newMap {| anydata... |}{%57=%58, %59=%60}
     pMap = %61;
-    %63 = ConstantLoad typedesc
-    %64 = cloneWithType(pMap,%63) -> bb27;
+    %64 = ConstantLoad typedesc
+    %65 = cloneWithType(pMap,%64) -> bb33;
   }
-  bb27 {
-    $desugar$6 = %64;
-    %66 = $desugar$6 is error
-    %66 ? bb28 : bb29;
+  bb33 {
+    %66 = %65 is error
+    %66 ? bb34 : bb35;
   }
-  bb28 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+  bb34 {
+    %0 = %65;
     return;
   }
-  bb29 {
-    pu = $desugar$6;
-    %68 = println(pu) -> bb30;
+  bb35 {
+    %63 = %65;
+    GOTO bb36;
   }
-  bb30 {
+  bb36 {
+    pu = %63;
+    %68 = println(pu) -> bb37;
+  }
+  bb37 {
     %69 = ConstantLoad name
     %70 = ConstantLoad Bob
     %71 = ConstantLoad role
     %72 = ConstantLoad admin
     %73 = newMap {| anydata... |}{%69=%70, %71=%72}
     pMap2 = %73;
-    %75 = ConstantLoad typedesc
-    %76 = cloneWithType(pMap2,%75) -> bb31;
+    %76 = ConstantLoad typedesc
+    %77 = cloneWithType(pMap2,%76) -> bb38;
   }
-  bb31 {
-    $desugar$7 = %76;
-    %78 = $desugar$7 is error
-    %78 ? bb32 : bb33;
+  bb38 {
+    %78 = %77 is error
+    %78 ? bb39 : bb40;
   }
-  bb32 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
+  bb39 {
+    %0 = %77;
     return;
   }
-  bb33 {
-    pu2 = $desugar$7;
-    %80 = println(pu2) -> bb34;
+  bb40 {
+    %75 = %77;
+    GOTO bb41;
   }
-  bb34 {
+  bb41 {
+    pu2 = %75;
+    %80 = println(pu2) -> bb42;
+  }
+  bb42 {
     %81 = ConstantLoad 1
     %82 = ConstantLoad 2
     %83 = ConstantLoad 3
     %84 = ConstantLoad 3
     %85 = newArray [anydata...][%84]{%81, %82, %83}
     intArr = %85;
-    %87 = ConstantLoad typedesc
-    %88 = cloneWithType(intArr,%87) -> bb35;
+    %88 = ConstantLoad typedesc
+    %89 = cloneWithType(intArr,%88) -> bb43;
   }
-  bb35 {
-    $desugar$8 = %88;
-    %90 = $desugar$8 is error
-    %90 ? bb36 : bb37;
+  bb43 {
+    %90 = %89 is error
+    %90 ? bb44 : bb45;
   }
-  bb36 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
+  bb44 {
+    %0 = %89;
     return;
   }
-  bb37 {
-    arrVal = $desugar$8;
-    %92 = println(arrVal) -> bb38;
+  bb45 {
+    %87 = %89;
+    GOTO bb46;
   }
-  bb38 {
+  bb46 {
+    arrVal = %87;
+    %92 = println(arrVal) -> bb47;
+  }
+  bb47 {
     %93 = ConstantLoad a
     %94 = ConstantLoad b
     %95 = ConstantLoad 2
     %96 = newArray [anydata...][%95]{%93, %94}
     strArr = %96;
-    %98 = ConstantLoad typedesc
-    %99 = cloneWithType(strArr,%98) -> bb39;
+    %99 = ConstantLoad typedesc
+    %100 = cloneWithType(strArr,%99) -> bb48;
   }
-  bb39 {
-    $desugar$9 = %99;
-    %101 = $desugar$9 is error
-    %101 ? bb40 : bb41;
+  bb48 {
+    %101 = %100 is error
+    %101 ? bb49 : bb50;
   }
-  bb40 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+  bb49 {
+    %0 = %100;
     return;
   }
-  bb41 {
-    strArrVal = $desugar$9;
-    %103 = println(strArrVal) -> bb42;
+  bb50 {
+    %98 = %100;
+    GOTO bb51;
   }
-  bb42 {
+  bb51 {
+    strArrVal = %98;
+    %103 = println(strArrVal) -> bb52;
+  }
+  bb52 {
     %104 = ConstantLoad 200
     bv = %104;
-    %106 = ConstantLoad typedesc
-    %107 = cloneWithType(bv,%106) -> bb43;
+    %107 = ConstantLoad typedesc
+    %108 = cloneWithType(bv,%107) -> bb53;
   }
-  bb43 {
-    $desugar$10 = %107;
-    %109 = $desugar$10 is error
-    %109 ? bb44 : bb45;
+  bb53 {
+    %109 = %108 is error
+    %109 ? bb54 : bb55;
   }
-  bb44 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
+  bb54 {
+    %0 = %108;
     return;
   }
-  bb45 {
-    asByte = $desugar$10;
-    %111 = println(asByte) -> bb46;
+  bb55 {
+    %106 = %108;
+    GOTO bb56;
   }
-  bb46 {
+  bb56 {
+    asByte = %106;
+    %111 = println(asByte) -> bb57;
+  }
+  bb57 {
     %112 = ConstantLoad <nil>
     %0 = %112;
     return;

--- a/corpus/bir/subset9/09-value/clonewithtype-v.txt
+++ b/corpus/bir/subset9/09-value/clonewithtype-v.txt
@@ -3,169 +3,176 @@ main() -> nil|error{
   bb0 {
     %1 = ConstantLoad 42
     n = %1;
-    %3 = ConstantLoad typedesc
-    %4 = cloneWithType(n,%3) -> bb1;
+    %4 = ConstantLoad typedesc
+    %5 = cloneWithType(n,%4) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
+    %6 = %5 is error
     %6 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb3 {
-    i = $desugar$0;
-    %8 = i;
-    %9 = println(%8) -> bb4;
+    %3 = %5;
+    GOTO bb4;
   }
   bb4 {
-    %10 = ConstantLoad hello
-    s = %10;
-    %12 = ConstantLoad typedesc
-    %13 = cloneWithType(s,%12) -> bb5;
+    i = %3;
+    %8 = i;
+    %9 = println(%8) -> bb5;
   }
   bb5 {
-    $desugar$1 = %13;
-    %15 = $desugar$1 is error
-    %15 ? bb6 : bb7;
+    %10 = ConstantLoad hello
+    s = %10;
+    %13 = ConstantLoad typedesc
+    %14 = cloneWithType(s,%13) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %15 = %14 is error
+    %15 ? bb7 : bb8;
   }
   bb7 {
-    str = $desugar$1;
-    %17 = println(str) -> bb8;
-  }
-  bb8 {
-    %18 = ConstantLoad 7
-    intVal = %18;
-    %20 = ConstantLoad typedesc
-    %21 = cloneWithType(intVal,%20) -> bb9;
-  }
-  bb9 {
-    $desugar$2 = %21;
-    %23 = $desugar$2 is error
-    %23 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %14;
     return;
   }
+  bb8 {
+    %12 = %14;
+    GOTO bb9;
+  }
+  bb9 {
+    str = %12;
+    %17 = println(str) -> bb10;
+  }
+  bb10 {
+    %18 = ConstantLoad 7
+    intVal = %18;
+    %21 = ConstantLoad typedesc
+    %22 = cloneWithType(intVal,%21) -> bb11;
+  }
   bb11 {
-    f = $desugar$2;
-    %25 = f;
-    %26 = println(%25) -> bb12;
+    %23 = %22 is error
+    %23 ? bb12 : bb13;
   }
   bb12 {
+    %0 = %22;
+    return;
+  }
+  bb13 {
+    %20 = %22;
+    GOTO bb14;
+  }
+  bb14 {
+    f = %20;
+    %25 = f;
+    %26 = println(%25) -> bb15;
+  }
+  bb15 {
     %27 = ConstantLoad name
     %28 = ConstantLoad Alice
     %29 = ConstantLoad age
     %30 = ConstantLoad 30
     %31 = newMap {| anydata... |}{%27=%28, %29=%30}
     raw = %31;
-    %33 = ConstantLoad typedesc
-    %34 = cloneWithType(raw,%33) -> bb13;
-  }
-  bb13 {
-    $desugar$3 = %34;
-    %36 = $desugar$3 is error
-    %36 ? bb14 : bb15;
-  }
-  bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
-  }
-  bb15 {
-    p = $desugar$3;
-    %38 = println(p) -> bb16;
+    %34 = ConstantLoad typedesc
+    %35 = cloneWithType(raw,%34) -> bb16;
   }
   bb16 {
+    %36 = %35 is error
+    %36 ? bb17 : bb18;
+  }
+  bb17 {
+    %0 = %35;
+    return;
+  }
+  bb18 {
+    %33 = %35;
+    GOTO bb19;
+  }
+  bb19 {
+    p = %33;
+    %38 = println(p) -> bb20;
+  }
+  bb20 {
     %39 = ConstantLoad 1
     %40 = ConstantLoad 2
     %41 = ConstantLoad 3
     %42 = ConstantLoad 3
     %43 = newArray [anydata...][%42]{%39, %40, %41}
     nums = %43;
-    %45 = ConstantLoad typedesc
-    %46 = cloneWithType(nums,%45) -> bb17;
+    %46 = ConstantLoad typedesc
+    %47 = cloneWithType(nums,%46) -> bb21;
   }
-  bb17 {
-    $desugar$4 = %46;
-    %48 = $desugar$4 is error
-    %48 ? bb18 : bb19;
+  bb21 {
+    %48 = %47 is error
+    %48 ? bb22 : bb23;
   }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+  bb22 {
+    %0 = %47;
     return;
   }
-  bb19 {
-    ia = $desugar$4;
-    %50 = println(ia) -> bb20;
+  bb23 {
+    %45 = %47;
+    GOTO bb24;
   }
-  bb20 {
+  bb24 {
+    ia = %45;
+    %50 = println(ia) -> bb25;
+  }
+  bb25 {
     %51 = ConstantLoad 10
     %52 = ConstantLoad 20
     %53 = ConstantLoad 30
     %54 = ConstantLoad 3
     %55 = newArray [anydata...][%54]{%51, %52, %53}
     ints = %55;
-    %57 = ConstantLoad typedesc
-    %58 = cloneWithType(ints,%57) -> bb21;
+    %58 = ConstantLoad typedesc
+    %59 = cloneWithType(ints,%58) -> bb26;
   }
-  bb21 {
-    $desugar$5 = %58;
-    %60 = $desugar$5 is error
-    %60 ? bb22 : bb23;
+  bb26 {
+    %60 = %59 is error
+    %60 ? bb27 : bb28;
   }
-  bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+  bb27 {
+    %0 = %59;
     return;
   }
-  bb23 {
-    fa = $desugar$5;
-    %62 = println(fa) -> bb24;
+  bb28 {
+    %57 = %59;
+    GOTO bb29;
   }
-  bb24 {
+  bb29 {
+    fa = %57;
+    %62 = println(fa) -> bb30;
+  }
+  bb30 {
     %63 = ConstantLoad x
     %64 = ConstantLoad 3
     %65 = ConstantLoad y
     %66 = ConstantLoad 4
     %67 = newMap {| anydata... |}{%63=%64, %65=%66}
     coords = %67;
-    %69 = ConstantLoad typedesc
-    %70 = cloneWithType(coords,%69) -> bb25;
+    %70 = ConstantLoad typedesc
+    %71 = cloneWithType(coords,%70) -> bb31;
   }
-  bb25 {
-    $desugar$6 = %70;
-    %72 = $desugar$6 is error
-    %72 ? bb26 : bb27;
+  bb31 {
+    %72 = %71 is error
+    %72 ? bb32 : bb33;
   }
-  bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+  bb32 {
+    %0 = %71;
     return;
   }
-  bb27 {
-    pt = $desugar$6;
-    %74 = println(pt) -> bb28;
+  bb33 {
+    %69 = %71;
+    GOTO bb34;
   }
-  bb28 {
+  bb34 {
+    pt = %69;
+    %74 = println(pt) -> bb35;
+  }
+  bb35 {
     %75 = ConstantLoad label
     %76 = ConstantLoad origin
     %77 = ConstantLoad origin
@@ -176,98 +183,102 @@ main() -> nil|error{
     %82 = newMap {| anydata... |}{%78=%79, %80=%81}
     %83 = newMap {| anydata... |}{%75=%76, %77=%82}
     shapeRaw = %83;
-    %85 = ConstantLoad typedesc
-    %86 = cloneWithType(shapeRaw,%85) -> bb29;
+    %86 = ConstantLoad typedesc
+    %87 = cloneWithType(shapeRaw,%86) -> bb36;
   }
-  bb29 {
-    $desugar$7 = %86;
-    %88 = $desugar$7 is error
-    %88 ? bb30 : bb31;
+  bb36 {
+    %88 = %87 is error
+    %88 ? bb37 : bb38;
   }
-  bb30 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
+  bb37 {
+    %0 = %87;
     return;
   }
-  bb31 {
-    sh = $desugar$7;
-    %90 = println(sh) -> bb32;
+  bb38 {
+    %85 = %87;
+    GOTO bb39;
   }
-  bb32 {
+  bb39 {
+    sh = %85;
+    %90 = println(sh) -> bb40;
+  }
+  bb40 {
     %91 = ConstantLoad name
     %92 = ConstantLoad Bob
     %93 = ConstantLoad age
     %94 = ConstantLoad 25
     %95 = newMap {| anydata... |}{%91=%92, %93=%94}
     personMap = %95;
-    %97 = ConstantLoad typedesc
-    %98 = cloneWithType(personMap,%97) -> bb33;
+    %98 = ConstantLoad typedesc
+    %99 = cloneWithType(personMap,%98) -> bb41;
   }
-  bb33 {
-    $desugar$8 = %98;
-    %100 = $desugar$8 is error
-    %100 ? bb34 : bb35;
+  bb41 {
+    %100 = %99 is error
+    %100 ? bb42 : bb43;
   }
-  bb34 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$8);
-    PopScopeFrame
+  bb42 {
+    %0 = %99;
     return;
   }
-  bb35 {
-    poi = $desugar$8;
-    %102 = println(poi) -> bb36;
+  bb43 {
+    %97 = %99;
+    GOTO bb44;
   }
-  bb36 {
+  bb44 {
+    poi = %97;
+    %102 = println(poi) -> bb45;
+  }
+  bb45 {
     %103 = ConstantLoad name
     %104 = ConstantLoad Carol
     %105 = ConstantLoad age
     %106 = ConstantLoad <nil>
     %107 = newMap {| anydata... |}{%103=%104, %105=%106}
     withNull = %107;
-    %109 = ConstantLoad typedesc
-    %110 = cloneWithType(withNull,%109) -> bb37;
+    %110 = ConstantLoad typedesc
+    %111 = cloneWithType(withNull,%110) -> bb46;
   }
-  bb37 {
-    $desugar$9 = %110;
-    %112 = $desugar$9 is error
-    %112 ? bb38 : bb39;
+  bb46 {
+    %112 = %111 is error
+    %112 ? bb47 : bb48;
   }
-  bb38 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$9);
-    PopScopeFrame
+  bb47 {
+    %0 = %111;
     return;
   }
-  bb39 {
-    nilAge = $desugar$9;
-    %114 = println(nilAge) -> bb40;
+  bb48 {
+    %109 = %111;
+    GOTO bb49;
   }
-  bb40 {
+  bb49 {
+    nilAge = %109;
+    %114 = println(nilAge) -> bb50;
+  }
+  bb50 {
     %115 = ConstantLoad name
     %116 = ConstantLoad Dave
     %117 = newMap {| anydata... |}{%115=%116}
     partial = %117;
-    %119 = ConstantLoad typedesc
-    %120 = cloneWithType(partial,%119) -> bb41;
+    %120 = ConstantLoad typedesc
+    %121 = cloneWithType(partial,%120) -> bb51;
   }
-  bb41 {
-    $desugar$10 = %120;
-    %122 = $desugar$10 is error
-    %122 ? bb42 : bb43;
+  bb51 {
+    %122 = %121 is error
+    %122 ? bb52 : bb53;
   }
-  bb42 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$10);
-    PopScopeFrame
+  bb52 {
+    %0 = %121;
     return;
   }
-  bb43 {
-    optAge = $desugar$10;
-    %124 = println(optAge) -> bb44;
+  bb53 {
+    %119 = %121;
+    GOTO bb54;
   }
-  bb44 {
+  bb54 {
+    optAge = %119;
+    %124 = println(optAge) -> bb55;
+  }
+  bb55 {
     %125 = ConstantLoad <nil>
     %0 = %125;
     return;

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-closed-union-v.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-closed-union-v.txt
@@ -5,61 +5,63 @@ main() -> nil|error{
     %2 = ConstantLoad 5
     %3 = newMap {| json... |}{%1=%2}
     ageOnly = %3;
-    %5 = ConstantLoad typedesc
-    %6 = fromJsonWithType(ageOnly,%5) -> bb1;
+    %6 = ConstantLoad typedesc
+    %7 = fromJsonWithType(ageOnly,%6) -> bb1;
   }
   bb1 {
-    $desugar$0 = %6;
-    %8 = $desugar$0 is error
+    %8 = %7 is error
     %8 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %7;
     return;
   }
   bb3 {
-    ageOnlyPet = $desugar$0;
-    %10 = println(ageOnlyPet) -> bb4;
+    %5 = %7;
+    GOTO bb4;
   }
   bb4 {
+    ageOnlyPet = %5;
+    %10 = println(ageOnlyPet) -> bb5;
+  }
+  bb5 {
     %11 = ConstantLoad pet_type
     %12 = ConstantLoad Cat
     %13 = newMap {| json... |}{%11=%12}
     typeOnly = %13;
-    %15 = ConstantLoad typedesc
-    %16 = fromJsonWithType(typeOnly,%15) -> bb5;
-  }
-  bb5 {
-    $desugar$1 = %16;
-    %18 = $desugar$1 is error
-    %18 ? bb6 : bb7;
+    %16 = ConstantLoad typedesc
+    %17 = fromJsonWithType(typeOnly,%16) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %18 = %17 is error
+    %18 ? bb7 : bb8;
   }
   bb7 {
-    typeOnlyPet = $desugar$1;
-    %20 = println(typeOnlyPet) -> bb8;
+    %0 = %17;
+    return;
   }
   bb8 {
+    %15 = %17;
+    GOTO bb9;
+  }
+  bb9 {
+    typeOnlyPet = %15;
+    %20 = println(typeOnlyPet) -> bb10;
+  }
+  bb10 {
     %21 = ConstantLoad nickname
     %22 = ConstantLoad Fido
     %23 = newMap {| json... |}{%21=%22}
     petJson = %23;
     %25 = ConstantLoad typedesc
-    %26 = fromJsonWithType(petJson,%25) -> bb9;
+    %26 = fromJsonWithType(petJson,%25) -> bb11;
   }
-  bb9 {
+  bb11 {
     %27 = %26 is error
     %28 = %27;
-    %29 = println(%28) -> bb10;
+    %29 = println(%28) -> bb12;
   }
-  bb10 {
+  bb12 {
     %30 = ConstantLoad <nil>
     %0 = %30;
     return;

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-json-v.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-json-v.txt
@@ -3,117 +3,122 @@ main() -> nil|error{
   bb0 {
     %1 = ConstantLoad hello
     strJson = %1;
-    %3 = ConstantLoad typedesc
-    %4 = fromJsonWithType(strJson,%3) -> bb1;
+    %4 = ConstantLoad typedesc
+    %5 = fromJsonWithType(strJson,%4) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
+    %6 = %5 is error
     %6 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb3 {
-    strOut = $desugar$0;
-    %8 = println(strOut) -> bb4;
+    %3 = %5;
+    GOTO bb4;
   }
   bb4 {
-    %9 = ConstantLoad 42
-    intJson = %9;
-    %11 = ConstantLoad typedesc
-    %12 = fromJsonWithType(intJson,%11) -> bb5;
+    strOut = %3;
+    %8 = println(strOut) -> bb5;
   }
   bb5 {
-    $desugar$1 = %12;
-    %14 = $desugar$1 is error
-    %14 ? bb6 : bb7;
+    %9 = ConstantLoad 42
+    intJson = %9;
+    %12 = ConstantLoad typedesc
+    %13 = fromJsonWithType(intJson,%12) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %14 = %13 is error
+    %14 ? bb7 : bb8;
   }
   bb7 {
-    intOut = $desugar$1;
-    %16 = println(intOut) -> bb8;
-  }
-  bb8 {
-    %17 = ConstantLoad true
-    boolJson = %17;
-    %19 = ConstantLoad typedesc
-    %20 = fromJsonWithType(boolJson,%19) -> bb9;
-  }
-  bb9 {
-    $desugar$2 = %20;
-    %22 = $desugar$2 is error
-    %22 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
+    %0 = %13;
     return;
   }
+  bb8 {
+    %11 = %13;
+    GOTO bb9;
+  }
+  bb9 {
+    intOut = %11;
+    %16 = println(intOut) -> bb10;
+  }
+  bb10 {
+    %17 = ConstantLoad true
+    boolJson = %17;
+    %20 = ConstantLoad typedesc
+    %21 = fromJsonWithType(boolJson,%20) -> bb11;
+  }
   bb11 {
-    boolOut = $desugar$2;
-    %24 = println(boolOut) -> bb12;
+    %22 = %21 is error
+    %22 ? bb12 : bb13;
   }
   bb12 {
+    %0 = %21;
+    return;
+  }
+  bb13 {
+    %19 = %21;
+    GOTO bb14;
+  }
+  bb14 {
+    boolOut = %19;
+    %24 = println(boolOut) -> bb15;
+  }
+  bb15 {
     %25 = ConstantLoad 1
     %26 = ConstantLoad <nil>
     %27 = ConstantLoad 3
     %28 = ConstantLoad 3
     %29 = newArray [json...][%28]{%25, %26, %27}
     arr = %29;
-    %31 = ConstantLoad typedesc
-    %32 = fromJsonWithType(arr,%31) -> bb13;
-  }
-  bb13 {
-    $desugar$3 = %32;
-    %34 = $desugar$3 is error
-    %34 ? bb14 : bb15;
-  }
-  bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
-  }
-  bb15 {
-    arrOut = $desugar$3;
-    %36 = println(arrOut) -> bb16;
+    %32 = ConstantLoad typedesc
+    %33 = fromJsonWithType(arr,%32) -> bb16;
   }
   bb16 {
+    %34 = %33 is error
+    %34 ? bb17 : bb18;
+  }
+  bb17 {
+    %0 = %33;
+    return;
+  }
+  bb18 {
+    %31 = %33;
+    GOTO bb19;
+  }
+  bb19 {
+    arrOut = %31;
+    %36 = println(arrOut) -> bb20;
+  }
+  bb20 {
     %37 = ConstantLoad a
     %38 = ConstantLoad 1
     %39 = ConstantLoad b
     %40 = ConstantLoad <nil>
     %41 = newMap {| json... |}{%37=%38, %39=%40}
     m = %41;
-    %43 = ConstantLoad typedesc
-    %44 = fromJsonWithType(m,%43) -> bb17;
+    %44 = ConstantLoad typedesc
+    %45 = fromJsonWithType(m,%44) -> bb21;
   }
-  bb17 {
-    $desugar$4 = %44;
-    %46 = $desugar$4 is error
-    %46 ? bb18 : bb19;
+  bb21 {
+    %46 = %45 is error
+    %46 ? bb22 : bb23;
   }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+  bb22 {
+    %0 = %45;
     return;
   }
-  bb19 {
-    mapOut = $desugar$4;
-    %48 = println(mapOut) -> bb20;
+  bb23 {
+    %43 = %45;
+    GOTO bb24;
   }
-  bb20 {
+  bb24 {
+    mapOut = %43;
+    %48 = println(mapOut) -> bb25;
+  }
+  bb25 {
     %49 = ConstantLoad 1
     %50 = ConstantLoad 2
     %51 = ConstantLoad 2
@@ -125,25 +130,26 @@ main() -> nil|error{
     %57 = ConstantLoad 2
     %58 = newArray [json...][%57]{%52, %56}
     nested = %58;
-    %60 = ConstantLoad typedesc
-    %61 = fromJsonWithType(nested,%60) -> bb21;
+    %61 = ConstantLoad typedesc
+    %62 = fromJsonWithType(nested,%61) -> bb26;
   }
-  bb21 {
-    $desugar$5 = %61;
-    %63 = $desugar$5 is error
-    %63 ? bb22 : bb23;
+  bb26 {
+    %63 = %62 is error
+    %63 ? bb27 : bb28;
   }
-  bb22 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+  bb27 {
+    %0 = %62;
     return;
   }
-  bb23 {
-    nestedOut = $desugar$5;
-    %65 = println(nestedOut) -> bb24;
+  bb28 {
+    %60 = %62;
+    GOTO bb29;
   }
-  bb24 {
+  bb29 {
+    nestedOut = %60;
+    %65 = println(nestedOut) -> bb30;
+  }
+  bb30 {
     %66 = ConstantLoad items
     %67 = ConstantLoad 1
     %68 = ConstantLoad 2
@@ -155,25 +161,26 @@ main() -> nil|error{
     %74 = newMap {| json... |}{%72=%73}
     %75 = newMap {| json... |}{%66=%70, %71=%74}
     rec = %75;
-    %77 = ConstantLoad typedesc
-    %78 = fromJsonWithType(rec,%77) -> bb25;
+    %78 = ConstantLoad typedesc
+    %79 = fromJsonWithType(rec,%78) -> bb31;
   }
-  bb25 {
-    $desugar$6 = %78;
-    %80 = $desugar$6 is error
-    %80 ? bb26 : bb27;
+  bb31 {
+    %80 = %79 is error
+    %80 ? bb32 : bb33;
   }
-  bb26 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+  bb32 {
+    %0 = %79;
     return;
   }
-  bb27 {
-    recOut = $desugar$6;
-    %82 = println(recOut) -> bb28;
+  bb33 {
+    %77 = %79;
+    GOTO bb34;
   }
-  bb28 {
+  bb34 {
+    recOut = %77;
+    %82 = println(recOut) -> bb35;
+  }
+  bb35 {
     %83 = ConstantLoad <nil>
     %0 = %83;
     return;

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-numeric-v.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-numeric-v.txt
@@ -3,72 +3,73 @@ main() -> nil|error{
   bb0 {
     %1 = ConstantLoad 255
     maxByte = %1;
-    %3 = ConstantLoad typedesc
-    %4 = fromJsonWithType(maxByte,%3) -> bb1;
+    %4 = ConstantLoad typedesc
+    %5 = fromJsonWithType(maxByte,%4) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
+    %6 = %5 is error
     %6 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb3 {
-    b = $desugar$0;
-    %8 = b;
-    %9 = println(%8) -> bb4;
+    %3 = %5;
+    GOTO bb4;
   }
   bb4 {
+    b = %3;
+    %8 = b;
+    %9 = println(%8) -> bb5;
+  }
+  bb5 {
     %10 = ConstantLoad 255.6
     roundedOutOfRange = %10;
     %12 = ConstantLoad typedesc
-    %13 = fromJsonWithType(roundedOutOfRange,%12) -> bb5;
-  }
-  bb5 {
-    %14 = %13 is error
-    %15 = %14;
-    %16 = println(%15) -> bb6;
+    %13 = fromJsonWithType(roundedOutOfRange,%12) -> bb6;
   }
   bb6 {
+    %14 = %13 is error
+    %15 = %14;
+    %16 = println(%15) -> bb7;
+  }
+  bb7 {
     %17 = ConstantLoad 1e+100
     hugeFloat = %17;
     %19 = ConstantLoad typedesc
-    %20 = fromJsonWithType(hugeFloat,%19) -> bb7;
-  }
-  bb7 {
-    %21 = %20 is error
-    %22 = %21;
-    %23 = println(%22) -> bb8;
+    %20 = fromJsonWithType(hugeFloat,%19) -> bb8;
   }
   bb8 {
+    %21 = %20 is error
+    %22 = %21;
+    %23 = println(%22) -> bb9;
+  }
+  bb9 {
     %24 = ConstantLoad 9.223372036854776e+18
     maxIntOverflow = %24;
     maxIntOverflowJson = maxIntOverflow;
     %27 = ConstantLoad typedesc
-    %28 = fromJsonWithType(maxIntOverflowJson,%27) -> bb9;
-  }
-  bb9 {
-    %29 = %28 is error
-    %30 = %29;
-    %31 = println(%30) -> bb10;
+    %28 = fromJsonWithType(maxIntOverflowJson,%27) -> bb10;
   }
   bb10 {
+    %29 = %28 is error
+    %30 = %29;
+    %31 = println(%30) -> bb11;
+  }
+  bb11 {
     %32 = ConstantLoad 9.223372036854776E+18
     tooBig = %32;
     tooBigJson = tooBig;
     %35 = ConstantLoad typedesc
-    %36 = fromJsonWithType(tooBigJson,%35) -> bb11;
-  }
-  bb11 {
-    %37 = %36 is error
-    %38 = %37;
-    %39 = println(%38) -> bb12;
+    %36 = fromJsonWithType(tooBigJson,%35) -> bb12;
   }
   bb12 {
+    %37 = %36 is error
+    %38 = %37;
+    %39 = println(%38) -> bb13;
+  }
+  bb13 {
     %41 = ConstantLoad 0
     %42 = %41;
     %43 = ConstantLoad 0
@@ -84,41 +85,41 @@ main() -> nil|error{
     inf = %47;
     infJson = inf;
     %54 = ConstantLoad typedesc
-    %55 = fromJsonWithType(nanJson,%54) -> bb13;
-  }
-  bb13 {
-    %56 = %55 is error
-    %57 = %56;
-    %58 = println(%57) -> bb14;
+    %55 = fromJsonWithType(nanJson,%54) -> bb14;
   }
   bb14 {
-    %59 = ConstantLoad typedesc
-    %60 = fromJsonWithType(infJson,%59) -> bb15;
+    %56 = %55 is error
+    %57 = %56;
+    %58 = println(%57) -> bb15;
   }
   bb15 {
-    %61 = %60 is error
-    %62 = %61;
-    %63 = println(%62) -> bb16;
+    %59 = ConstantLoad typedesc
+    %60 = fromJsonWithType(infJson,%59) -> bb16;
   }
   bb16 {
-    %64 = ConstantLoad typedesc
-    %65 = fromJsonWithType(nanJson,%64) -> bb17;
+    %61 = %60 is error
+    %62 = %61;
+    %63 = println(%62) -> bb17;
   }
   bb17 {
-    %66 = %65 is error
-    %67 = %66;
-    %68 = println(%67) -> bb18;
+    %64 = ConstantLoad typedesc
+    %65 = fromJsonWithType(nanJson,%64) -> bb18;
   }
   bb18 {
-    %69 = ConstantLoad typedesc
-    %70 = fromJsonWithType(infJson,%69) -> bb19;
+    %66 = %65 is error
+    %67 = %66;
+    %68 = println(%67) -> bb19;
   }
   bb19 {
-    %71 = %70 is error
-    %72 = %71;
-    %73 = println(%72) -> bb20;
+    %69 = ConstantLoad typedesc
+    %70 = fromJsonWithType(infJson,%69) -> bb20;
   }
   bb20 {
+    %71 = %70 is error
+    %72 = %71;
+    %73 = println(%72) -> bb21;
+  }
+  bb21 {
     %74 = ConstantLoad <nil>
     %0 = %74;
     return;

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-open-record-v.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-open-record-v.txt
@@ -7,113 +7,117 @@ main() -> nil|error{
     %4 = ConstantLoad 9
     %5 = newMap {| json... |}{%1=%2, %3=%4}
     catJson = %5;
-    %7 = ConstantLoad typedesc
-    %8 = fromJsonWithType(catJson,%7) -> bb1;
+    %8 = ConstantLoad typedesc
+    %9 = fromJsonWithType(catJson,%8) -> bb1;
   }
   bb1 {
-    $desugar$0 = %8;
-    %10 = $desugar$0 is error
+    %10 = %9 is error
     %10 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %9;
     return;
   }
   bb3 {
-    cat = $desugar$0;
-    %12 = println(cat) -> bb4;
+    %7 = %9;
+    GOTO bb4;
   }
   bb4 {
+    cat = %7;
+    %12 = println(cat) -> bb5;
+  }
+  bb5 {
     %13 = ConstantLoad name
     %14 = ConstantLoad Rex
     %15 = ConstantLoad breed
     %16 = ConstantLoad Labrador
     %17 = newMap {| json... |}{%13=%14, %15=%16}
     dogJson = %17;
-    %19 = ConstantLoad typedesc
-    %20 = fromJsonWithType(dogJson,%19) -> bb5;
-  }
-  bb5 {
-    $desugar$1 = %20;
-    %22 = $desugar$1 is error
-    %22 ? bb6 : bb7;
+    %20 = ConstantLoad typedesc
+    %21 = fromJsonWithType(dogJson,%20) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %22 = %21 is error
+    %22 ? bb7 : bb8;
   }
   bb7 {
-    dog = $desugar$1;
-    %24 = println(dog) -> bb8;
+    %0 = %21;
+    return;
   }
   bb8 {
+    %19 = %21;
+    GOTO bb9;
+  }
+  bb9 {
+    dog = %19;
+    %24 = println(dog) -> bb10;
+  }
+  bb10 {
     %25 = ConstantLoad a
     %26 = ConstantLoad hello
     %27 = ConstantLoad b
     %28 = ConstantLoad world
     %29 = newMap {| json... |}{%25=%26, %27=%28}
     strMapJson = %29;
-    %31 = ConstantLoad typedesc
-    %32 = fromJsonWithType(strMapJson,%31) -> bb9;
-  }
-  bb9 {
-    $desugar$2 = %32;
-    %34 = $desugar$2 is error
-    %34 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %32 = ConstantLoad typedesc
+    %33 = fromJsonWithType(strMapJson,%32) -> bb11;
   }
   bb11 {
-    strMap = $desugar$2;
-    %36 = println(strMap) -> bb12;
+    %34 = %33 is error
+    %34 ? bb12 : bb13;
   }
   bb12 {
+    %0 = %33;
+    return;
+  }
+  bb13 {
+    %31 = %33;
+    GOTO bb14;
+  }
+  bb14 {
+    strMap = %31;
+    %36 = println(strMap) -> bb15;
+  }
+  bb15 {
     %37 = ConstantLoad x
     %38 = ConstantLoad 1
     %39 = ConstantLoad y
     %40 = ConstantLoad 2
     %41 = newMap {| json... |}{%37=%38, %39=%40}
     intMapJson = %41;
-    %43 = ConstantLoad typedesc
-    %44 = fromJsonWithType(intMapJson,%43) -> bb13;
-  }
-  bb13 {
-    $desugar$3 = %44;
-    %46 = $desugar$3 is error
-    %46 ? bb14 : bb15;
-  }
-  bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
-  }
-  bb15 {
-    intMap = $desugar$3;
-    %48 = println(intMap) -> bb16;
+    %44 = ConstantLoad typedesc
+    %45 = fromJsonWithType(intMapJson,%44) -> bb16;
   }
   bb16 {
+    %46 = %45 is error
+    %46 ? bb17 : bb18;
+  }
+  bb17 {
+    %0 = %45;
+    return;
+  }
+  bb18 {
+    %43 = %45;
+    GOTO bb19;
+  }
+  bb19 {
+    intMap = %43;
+    %48 = println(intMap) -> bb20;
+  }
+  bb20 {
     %49 = ConstantLoad name
     %50 = ConstantLoad Whiskers
     %51 = newMap {| json... |}{%49=%50}
     neither = %51;
     %53 = ConstantLoad typedesc
-    %54 = fromJsonWithType(neither,%53) -> bb17;
+    %54 = fromJsonWithType(neither,%53) -> bb21;
   }
-  bb17 {
+  bb21 {
     %55 = %54 is error
     %56 = %55;
-    %57 = println(%56) -> bb18;
+    %57 = println(%56) -> bb22;
   }
-  bb18 {
+  bb22 {
     %58 = ConstantLoad <nil>
     %0 = %58;
     return;

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-p.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-p.txt
@@ -5,22 +5,22 @@ main() -> nil{
     %2 = ConstantLoad Alice
     %3 = newMap {| json... |}{%1=%2}
     missing = %3;
-    %5 = ConstantLoad typedesc
-    %6 = fromJsonWithType(missing,%5) -> bb1;
+    %6 = ConstantLoad typedesc
+    %7 = fromJsonWithType(missing,%6) -> bb1;
   }
   bb1 {
-    $desugar$0 = %6;
-    %8 = $desugar$0 is error
+    %8 = %7 is error
     %8 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %9) = (1, $desugar$0);
-    PopScopeFrame
-    panic %9;
+    panic %7;
   }
   bb3 {
-    _ = $desugar$0;
+    %5 = %7;
+    GOTO bb4;
+  }
+  bb4 {
+    _ = %5;
     return;
   }
 }

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-union-open-v.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-union-open-v.txt
@@ -9,117 +9,122 @@ main() -> nil|error{
     %6 = ConstantLoad 4
     %7 = newMap {| json... |}{%1=%2, %3=%4, %5=%6}
     petJson = %7;
-    %9 = ConstantLoad typedesc
-    %10 = fromJsonWithType(petJson,%9) -> bb1;
+    %10 = ConstantLoad typedesc
+    %11 = fromJsonWithType(petJson,%10) -> bb1;
   }
   bb1 {
-    $desugar$0 = %10;
-    %12 = $desugar$0 is error
+    %12 = %11 is error
     %12 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %11;
     return;
   }
   bb3 {
-    pet = $desugar$0;
-    %14 = println(pet) -> bb4;
+    %9 = %11;
+    GOTO bb4;
   }
   bb4 {
+    pet = %9;
+    %14 = println(pet) -> bb5;
+  }
+  bb5 {
     %15 = ConstantLoad 1
     %16 = ConstantLoad 2
     %17 = ConstantLoad 2
     %18 = newArray [json...][%17]{%15, %16}
     arrJson = %18;
-    %20 = ConstantLoad typedesc
-    %21 = fromJsonWithType(arrJson,%20) -> bb5;
-  }
-  bb5 {
-    $desugar$1 = %21;
-    %23 = $desugar$1 is error
-    %23 ? bb6 : bb7;
+    %21 = ConstantLoad typedesc
+    %22 = fromJsonWithType(arrJson,%21) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %23 = %22 is error
+    %23 ? bb7 : bb8;
   }
   bb7 {
-    arrVal = $desugar$1;
-    %25 = println(arrVal) -> bb8;
+    %0 = %22;
+    return;
   }
   bb8 {
+    %20 = %22;
+    GOTO bb9;
+  }
+  bb9 {
+    arrVal = %20;
+    %25 = println(arrVal) -> bb10;
+  }
+  bb10 {
     %26 = ConstantLoad a
     %27 = ConstantLoad b
     %28 = ConstantLoad 2
     %29 = newArray [json...][%28]{%26, %27}
     strArrJson = %29;
-    %31 = ConstantLoad typedesc
-    %32 = fromJsonWithType(strArrJson,%31) -> bb9;
-  }
-  bb9 {
-    $desugar$2 = %32;
-    %34 = $desugar$2 is error
-    %34 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %32 = ConstantLoad typedesc
+    %33 = fromJsonWithType(strArrJson,%32) -> bb11;
   }
   bb11 {
-    strArrVal = $desugar$2;
-    %36 = println(strArrVal) -> bb12;
+    %34 = %33 is error
+    %34 ? bb12 : bb13;
   }
   bb12 {
-    %37 = ConstantLoad 12
-    floatJson = %37;
-    %39 = ConstantLoad typedesc
-    %40 = fromJsonWithType(floatJson,%39) -> bb13;
+    %0 = %33;
+    return;
   }
   bb13 {
-    $desugar$3 = %40;
-    %42 = $desugar$3 is error
-    %42 ? bb14 : bb15;
+    %31 = %33;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    strArrVal = %31;
+    %36 = println(strArrVal) -> bb15;
   }
   bb15 {
-    numVal = $desugar$3;
-    %44 = numVal is float
-    %45 = %44;
-    %46 = println(%45) -> bb16;
+    %37 = ConstantLoad 12
+    floatJson = %37;
+    %40 = ConstantLoad typedesc
+    %41 = fromJsonWithType(floatJson,%40) -> bb16;
   }
   bb16 {
-    %47 = ConstantLoad 200
-    floatAsByte = %47;
-    %49 = ConstantLoad typedesc
-    %50 = fromJsonWithType(floatAsByte,%49) -> bb17;
+    %42 = %41 is error
+    %42 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %50;
-    %52 = $desugar$4 is error
-    %52 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %41;
     return;
   }
+  bb18 {
+    %39 = %41;
+    GOTO bb19;
+  }
   bb19 {
-    asByte = $desugar$4;
-    %54 = println(asByte) -> bb20;
+    numVal = %39;
+    %44 = numVal is float
+    %45 = %44;
+    %46 = println(%45) -> bb20;
   }
   bb20 {
+    %47 = ConstantLoad 200
+    floatAsByte = %47;
+    %50 = ConstantLoad typedesc
+    %51 = fromJsonWithType(floatAsByte,%50) -> bb21;
+  }
+  bb21 {
+    %52 = %51 is error
+    %52 ? bb22 : bb23;
+  }
+  bb22 {
+    %0 = %51;
+    return;
+  }
+  bb23 {
+    %49 = %51;
+    GOTO bb24;
+  }
+  bb24 {
+    asByte = %49;
+    %54 = println(asByte) -> bb25;
+  }
+  bb25 {
     %55 = ConstantLoad <nil>
     %0 = %55;
     return;

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-union-v.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-union-v.txt
@@ -3,202 +3,210 @@ main() -> nil|error{
   bb0 {
     %1 = ConstantLoad 42
     num = %1;
-    %3 = ConstantLoad typedesc
-    %4 = fromJsonWithType(num,%3) -> bb1;
+    %4 = ConstantLoad typedesc
+    %5 = fromJsonWithType(num,%4) -> bb1;
   }
   bb1 {
-    $desugar$0 = %4;
-    %6 = $desugar$0 is error
+    %6 = %5 is error
     %6 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %5;
     return;
   }
   bb3 {
-    asUnion = $desugar$0;
-    %8 = println(asUnion) -> bb4;
+    %3 = %5;
+    GOTO bb4;
   }
   bb4 {
-    %9 = ConstantLoad hello
-    str = %9;
-    %11 = ConstantLoad typedesc
-    %12 = fromJsonWithType(str,%11) -> bb5;
+    asUnion = %3;
+    %8 = println(asUnion) -> bb5;
   }
   bb5 {
-    $desugar$1 = %12;
-    %14 = $desugar$1 is error
-    %14 ? bb6 : bb7;
+    %9 = ConstantLoad hello
+    str = %9;
+    %12 = ConstantLoad typedesc
+    %13 = fromJsonWithType(str,%12) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %14 = %13 is error
+    %14 ? bb7 : bb8;
   }
   bb7 {
-    asStr = $desugar$1;
-    %16 = println(asStr) -> bb8;
+    %0 = %13;
+    return;
   }
   bb8 {
+    %11 = %13;
+    GOTO bb9;
+  }
+  bb9 {
+    asStr = %11;
+    %16 = println(asStr) -> bb10;
+  }
+  bb10 {
     %17 = ConstantLoad 1
     %18 = ConstantLoad 2
     %19 = ConstantLoad 2
     %20 = newArray [json...][%19]{%17, %18}
     arr = %20;
-    %22 = ConstantLoad typedesc
-    %23 = fromJsonWithType(arr,%22) -> bb9;
-  }
-  bb9 {
-    $desugar$2 = %23;
-    %25 = $desugar$2 is error
-    %25 ? bb10 : bb11;
-  }
-  bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %23 = ConstantLoad typedesc
+    %24 = fromJsonWithType(arr,%23) -> bb11;
   }
   bb11 {
-    asJson = $desugar$2;
-    %27 = println(asJson) -> bb12;
+    %25 = %24 is error
+    %25 ? bb12 : bb13;
   }
   bb12 {
-    %28 = ConstantLoad <nil>
-    nilVal = %28;
-    %30 = ConstantLoad typedesc
-    %31 = fromJsonWithType(nilVal,%30) -> bb13;
-  }
-  bb13 {
-    $desugar$3 = %31;
-    %33 = $desugar$3 is error
-    %33 ? bb14 : bb15;
-  }
-  bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
+    %0 = %24;
     return;
   }
+  bb13 {
+    %22 = %24;
+    GOTO bb14;
+  }
+  bb14 {
+    asJson = %22;
+    %27 = println(asJson) -> bb15;
+  }
   bb15 {
-    asNilable = $desugar$3;
-    %35 = asNilable is nil|int
-    %36 = %35;
-    %37 = println(%36) -> bb16;
+    %28 = ConstantLoad <nil>
+    nilVal = %28;
+    %31 = ConstantLoad typedesc
+    %32 = fromJsonWithType(nilVal,%31) -> bb16;
   }
   bb16 {
+    %33 = %32 is error
+    %33 ? bb17 : bb18;
+  }
+  bb17 {
+    %0 = %32;
+    return;
+  }
+  bb18 {
+    %30 = %32;
+    GOTO bb19;
+  }
+  bb19 {
+    asNilable = %30;
+    %35 = asNilable is nil|int
+    %36 = %35;
+    %37 = println(%36) -> bb20;
+  }
+  bb20 {
     %38 = ConstantLoad name
     %39 = ConstantLoad Bob
     %40 = newMap {| json... |}{%38=%39}
     partial = %40;
-    %42 = ConstantLoad typedesc
-    %43 = fromJsonWithType(partial,%42) -> bb17;
+    %43 = ConstantLoad typedesc
+    %44 = fromJsonWithType(partial,%43) -> bb21;
   }
-  bb17 {
-    $desugar$4 = %43;
-    %45 = $desugar$4 is error
-    %45 ? bb18 : bb19;
+  bb21 {
+    %45 = %44 is error
+    %45 ? bb22 : bb23;
   }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+  bb22 {
+    %0 = %44;
     return;
   }
-  bb19 {
-    withOptional = $desugar$4;
-    %47 = println(withOptional) -> bb20;
+  bb23 {
+    %42 = %44;
+    GOTO bb24;
   }
-  bb20 {
+  bb24 {
+    withOptional = %42;
+    %47 = println(withOptional) -> bb25;
+  }
+  bb25 {
     %48 = ConstantLoad name
     %49 = ConstantLoad Carol
     %50 = newMap {| json... |}{%48=%49}
     missingNilable = %50;
     %52 = ConstantLoad typedesc
-    %53 = fromJsonWithType(missingNilable,%52) -> bb21;
+    %53 = fromJsonWithType(missingNilable,%52) -> bb26;
   }
-  bb21 {
+  bb26 {
     %54 = %53 is error
     %55 = %54;
-    %56 = println(%55) -> bb22;
+    %56 = println(%55) -> bb27;
   }
-  bb22 {
+  bb27 {
     %57 = ConstantLoad name
     %58 = ConstantLoad Carol
     %59 = ConstantLoad score
     %60 = ConstantLoad <nil>
     %61 = newMap {| json... |}{%57=%58, %59=%60}
     explicitNull = %61;
-    %63 = ConstantLoad typedesc
-    %64 = fromJsonWithType(explicitNull,%63) -> bb23;
+    %64 = ConstantLoad typedesc
+    %65 = fromJsonWithType(explicitNull,%64) -> bb28;
   }
-  bb23 {
-    $desugar$5 = %64;
-    %66 = $desugar$5 is error
-    %66 ? bb24 : bb25;
+  bb28 {
+    %66 = %65 is error
+    %66 ? bb29 : bb30;
   }
-  bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+  bb29 {
+    %0 = %65;
     return;
   }
-  bb25 {
-    withScore = $desugar$5;
-    %68 = println(withScore) -> bb26;
+  bb30 {
+    %63 = %65;
+    GOTO bb31;
   }
-  bb26 {
+  bb31 {
+    withScore = %63;
+    %68 = println(withScore) -> bb32;
+  }
+  bb32 {
     %69 = ConstantLoad name
     %70 = ConstantLoad Ann
     %71 = ConstantLoad age
     %72 = ConstantLoad <nil>
     %73 = newMap {| json... |}{%69=%70, %71=%72}
     withNullAge = %73;
-    %75 = ConstantLoad typedesc
-    %76 = fromJsonWithType(withNullAge,%75) -> bb27;
+    %76 = ConstantLoad typedesc
+    %77 = fromJsonWithType(withNullAge,%76) -> bb33;
   }
-  bb27 {
-    $desugar$6 = %76;
-    %78 = $desugar$6 is error
-    %78 ? bb28 : bb29;
+  bb33 {
+    %78 = %77 is error
+    %78 ? bb34 : bb35;
   }
-  bb28 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+  bb34 {
+    %0 = %77;
     return;
   }
-  bb29 {
-    withAge = $desugar$6;
-    %80 = println(withAge) -> bb30;
+  bb35 {
+    %75 = %77;
+    GOTO bb36;
   }
-  bb30 {
+  bb36 {
+    withAge = %75;
+    %80 = println(withAge) -> bb37;
+  }
+  bb37 {
     %81 = ConstantLoad a
     %82 = ConstantLoad 1
     %83 = newMap {| json... |}{%81=%82}
     openMap = %83;
-    %85 = ConstantLoad typedesc
-    %86 = fromJsonWithType(openMap,%85) -> bb31;
+    %86 = ConstantLoad typedesc
+    %87 = fromJsonWithType(openMap,%86) -> bb38;
   }
-  bb31 {
-    $desugar$7 = %86;
-    %88 = $desugar$7 is error
-    %88 ? bb32 : bb33;
+  bb38 {
+    %88 = %87 is error
+    %88 ? bb39 : bb40;
   }
-  bb32 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
+  bb39 {
+    %0 = %87;
     return;
   }
-  bb33 {
-    anyMap = $desugar$7;
-    %90 = println(anyMap) -> bb34;
+  bb40 {
+    %85 = %87;
+    GOTO bb41;
   }
-  bb34 {
+  bb41 {
+    anyMap = %85;
+    %90 = println(anyMap) -> bb42;
+  }
+  bb42 {
     %91 = ConstantLoad <nil>
     %0 = %91;
     return;

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-v.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-v.txt
@@ -6,150 +6,156 @@ main() -> nil|error{
     %3 = ConstantLoad 2
     %4 = newArray [json...][%3]{%1, %2}
     arrForAny = %4;
-    %6 = ConstantLoad typedesc
-    %7 = fromJsonWithType(arrForAny,%6) -> bb1;
+    %7 = ConstantLoad typedesc
+    %8 = fromJsonWithType(arrForAny,%7) -> bb1;
   }
   bb1 {
-    $desugar$0 = %7;
-    %9 = $desugar$0 is error
+    %9 = %8 is error
     %9 ? bb2 : bb3;
   }
   bb2 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$0);
-    PopScopeFrame
+    %0 = %8;
     return;
   }
   bb3 {
-    ad = $desugar$0;
-    %11 = println(ad) -> bb4;
+    %6 = %8;
+    GOTO bb4;
   }
   bb4 {
-    %12 = ConstantLoad 2022
-    num = %12;
-    %14 = ConstantLoad typedesc
-    %15 = fromJsonWithType(num,%14) -> bb5;
+    ad = %6;
+    %11 = println(ad) -> bb5;
   }
   bb5 {
-    $desugar$1 = %15;
-    %17 = $desugar$1 is error
-    %17 ? bb6 : bb7;
+    %12 = ConstantLoad 2022
+    num = %12;
+    %15 = ConstantLoad typedesc
+    %16 = fromJsonWithType(num,%15) -> bb6;
   }
   bb6 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$1);
-    PopScopeFrame
-    return;
+    %17 = %16 is error
+    %17 ? bb7 : bb8;
   }
   bb7 {
-    n = $desugar$1;
-    %19 = n;
-    %20 = println(%19) -> bb8;
+    %0 = %16;
+    return;
   }
   bb8 {
-    %21 = ConstantLoad true
-    %22 = %21;
-    %23 = ConstantLoad typedesc
-    %24 = fromJsonWithType(%22,%23) -> bb9;
+    %14 = %16;
+    GOTO bb9;
   }
   bb9 {
-    $desugar$2 = %24;
-    %26 = $desugar$2 is error
-    %26 ? bb10 : bb11;
+    n = %14;
+    %19 = n;
+    %20 = println(%19) -> bb10;
   }
   bb10 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$2);
-    PopScopeFrame
-    return;
+    %22 = ConstantLoad true
+    %23 = %22;
+    %24 = ConstantLoad typedesc
+    %25 = fromJsonWithType(%23,%24) -> bb11;
   }
   bb11 {
-    b = $desugar$2;
-    %28 = b;
-    %29 = println(%28) -> bb12;
+    %26 = %25 is error
+    %26 ? bb12 : bb13;
   }
   bb12 {
-    %30 = ConstantLoad false
-    %31 = %30;
-    %32 = ConstantLoad typedesc
-    %33 = fromJsonWithType(%31,%32) -> bb13;
+    %0 = %25;
+    return;
   }
   bb13 {
-    $desugar$3 = %33;
-    %35 = $desugar$3 is error
-    %35 ? bb14 : bb15;
+    %21 = %25;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$3);
-    PopScopeFrame
-    return;
+    b = %21;
+    %28 = b;
+    %29 = println(%28) -> bb15;
   }
   bb15 {
-    f = $desugar$3;
-    %37 = f;
-    %38 = println(%37) -> bb16;
+    %31 = ConstantLoad false
+    %32 = %31;
+    %33 = ConstantLoad typedesc
+    %34 = fromJsonWithType(%32,%33) -> bb16;
   }
   bb16 {
-    %39 = ConstantLoad hello
-    strVal = %39;
-    %41 = ConstantLoad typedesc
-    %42 = fromJsonWithType(strVal,%41) -> bb17;
+    %35 = %34 is error
+    %35 ? bb17 : bb18;
   }
   bb17 {
-    $desugar$4 = %42;
-    %44 = $desugar$4 is error
-    %44 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$4);
-    PopScopeFrame
+    %0 = %34;
     return;
   }
+  bb18 {
+    %30 = %34;
+    GOTO bb19;
+  }
   bb19 {
-    s = $desugar$4;
-    %46 = println(s) -> bb20;
+    f = %30;
+    %37 = f;
+    %38 = println(%37) -> bb20;
   }
   bb20 {
+    %39 = ConstantLoad hello
+    strVal = %39;
+    %42 = ConstantLoad typedesc
+    %43 = fromJsonWithType(strVal,%42) -> bb21;
+  }
+  bb21 {
+    %44 = %43 is error
+    %44 ? bb22 : bb23;
+  }
+  bb22 {
+    %0 = %43;
+    return;
+  }
+  bb23 {
+    %41 = %43;
+    GOTO bb24;
+  }
+  bb24 {
+    s = %41;
+    %46 = println(s) -> bb25;
+  }
+  bb25 {
     %47 = ConstantLoad name
     %48 = ConstantLoad Alice
     %49 = newMap {| json... |}{%47=%48}
     noAge = %49;
     %51 = ConstantLoad typedesc
-    %52 = fromJsonWithType(noAge,%51) -> bb21;
+    %52 = fromJsonWithType(noAge,%51) -> bb26;
   }
-  bb21 {
+  bb26 {
     %53 = %52 is error
     %54 = %53;
-    %55 = println(%54) -> bb22;
+    %55 = println(%54) -> bb27;
   }
-  bb22 {
+  bb27 {
     %56 = ConstantLoad name
     %57 = ConstantLoad Alice
     %58 = ConstantLoad age
     %59 = ConstantLoad <nil>
     %60 = newMap {| json... |}{%56=%57, %58=%59}
     nullAge = %60;
-    %62 = ConstantLoad typedesc
-    %63 = fromJsonWithType(nullAge,%62) -> bb23;
+    %63 = ConstantLoad typedesc
+    %64 = fromJsonWithType(nullAge,%63) -> bb28;
   }
-  bb23 {
-    $desugar$5 = %63;
-    %65 = $desugar$5 is error
-    %65 ? bb24 : bb25;
+  bb28 {
+    %65 = %64 is error
+    %65 ? bb29 : bb30;
   }
-  bb24 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$5);
-    PopScopeFrame
+  bb29 {
+    %0 = %64;
     return;
   }
-  bb25 {
-    nilAgePerson = $desugar$5;
-    %67 = println(nilAgePerson) -> bb26;
+  bb30 {
+    %62 = %64;
+    GOTO bb31;
   }
-  bb26 {
+  bb31 {
+    nilAgePerson = %62;
+    %67 = println(nilAgePerson) -> bb32;
+  }
+  bb32 {
     %68 = ConstantLoad 1
     %69 = ConstantLoad 2
     %70 = ConstantLoad 3
@@ -157,50 +163,52 @@ main() -> nil|error{
     %72 = ConstantLoad 4
     %73 = newArray [json...][%72]{%68, %69, %70, %71}
     arr = %73;
-    %75 = ConstantLoad typedesc
-    %76 = fromJsonWithType(arr,%75) -> bb27;
+    %76 = ConstantLoad typedesc
+    %77 = fromJsonWithType(arr,%76) -> bb33;
   }
-  bb27 {
-    $desugar$6 = %76;
-    %78 = $desugar$6 is error
-    %78 ? bb28 : bb29;
+  bb33 {
+    %78 = %77 is error
+    %78 ? bb34 : bb35;
   }
-  bb28 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$6);
-    PopScopeFrame
+  bb34 {
+    %0 = %77;
     return;
   }
-  bb29 {
-    inferred = $desugar$6;
-    %80 = println(inferred) -> bb30;
+  bb35 {
+    %75 = %77;
+    GOTO bb36;
   }
-  bb30 {
+  bb36 {
+    inferred = %75;
+    %80 = println(inferred) -> bb37;
+  }
+  bb37 {
     %81 = ConstantLoad name
     %82 = ConstantLoad Alice
     %83 = ConstantLoad age
     %84 = ConstantLoad 30
     %85 = newMap {| json... |}{%81=%82, %83=%84}
     p = %85;
-    %87 = ConstantLoad typedesc
-    %88 = fromJsonWithType(p,%87) -> bb31;
+    %88 = ConstantLoad typedesc
+    %89 = fromJsonWithType(p,%88) -> bb38;
   }
-  bb31 {
-    $desugar$7 = %88;
-    %90 = $desugar$7 is error
-    %90 ? bb32 : bb33;
+  bb38 {
+    %90 = %89 is error
+    %90 ? bb39 : bb40;
   }
-  bb32 {
-    PushScopeFrame 0
-    (1, %0) = (1, $desugar$7);
-    PopScopeFrame
+  bb39 {
+    %0 = %89;
     return;
   }
-  bb33 {
-    person = $desugar$7;
-    %92 = println(person) -> bb34;
+  bb40 {
+    %87 = %89;
+    GOTO bb41;
   }
-  bb34 {
+  bb41 {
+    person = %87;
+    %92 = println(person) -> bb42;
+  }
+  bb42 {
     %93 = ConstantLoad <nil>
     %0 = %93;
     return;

--- a/corpus/cfg/subset8/08-error/check15-v.txt
+++ b/corpus/cfg/subset8/08-error/check15-v.txt
@@ -1,0 +1,36 @@
+(alwaysErr
+  (bb0 () ()
+    (return
+      (error-constructor-expr (
+        (literal original error))))
+  )
+)
+(main
+  (bb0 () ()
+    (var-def
+      (variable result (type
+        (union-type
+          (error-type)
+          (value-type null))) (expr
+        (trap-expr
+          (invocation nestedScopeCheckpanic ())))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref result))))
+  )
+)
+(nestedScopeCheckpanic
+  (bb0 () (bb1)
+    (literal true)
+  )
+  (bb1 (bb0) (bb2)
+    (literal true)
+  )
+  (bb2 (bb1) (bb3)
+    (expression-stmt
+      (check-panicked-expr
+        (invocation alwaysErr ())))
+  )
+  (bb3 (bb2) (bb4))
+  (bb4 (bb3) ())
+)

--- a/corpus/desugared/library/subset1/http-client-methods-v.txt
+++ b/corpus/desugared/library/subset1/http-client-methods-v.txt
@@ -14,261 +14,205 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (new (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable c (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (literal /put))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (literal body))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (invocation $default$28 (
+            (simple-var-ref $desugar$2)
+            (simple-var-ref $desugar$3))))))
+      (var-def
+        (variable $desugar$5 (expr
+          (invocation $default$29 (
+            (simple-var-ref $desugar$2)
             (simple-var-ref $desugar$3)
             (simple-var-ref $desugar$4))))))
       (var-def
         (variable $desugar$6 (expr
-          (invocation $default$29 (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5))))))
-      (var-def
-        (variable $desugar$7 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$8 (expr
-          (remote-method-call put expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
       (var-def
         (variable r1 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (remote-method-call put expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$2)
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)
+              (simple-var-ref $desugar$5)
+              (simple-var-ref $desugar$6)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r1)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$9 (expr
+        (variable $desugar$7 (expr
           (literal /patch))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$8 (expr
           (mapping-constructor-expr
             (key-value
               (literal key)
               (literal val))))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$9 (expr
           (invocation $default$24 (
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$10))))))
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8))))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$10 (expr
           (invocation $default$25 (
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11))))))
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8)
+            (simple-var-ref $desugar$9))))))
       (var-def
-        (variable $desugar$13 (expr
+        (variable $desugar$11 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$14 (expr
-          (remote-method-call patch expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
       (var-def
         (variable r2 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (remote-method-call patch expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$7)
+              (simple-var-ref $desugar$8)
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)
+              (simple-var-ref $desugar$11)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r2)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$12 (expr
           (literal /delete))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$13 (expr
           (invocation $default$16 (
-            (simple-var-ref $desugar$15))))))
+            (simple-var-ref $desugar$12))))))
       (var-def
-        (variable $desugar$17 (expr
+        (variable $desugar$14 (expr
           (invocation $default$17 (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13))))))
       (var-def
-        (variable $desugar$18 (expr
+        (variable $desugar$15 (expr
           (invocation $default$18 (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17))))))
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13)
+            (simple-var-ref $desugar$14))))))
       (var-def
-        (variable $desugar$19 (expr
+        (variable $desugar$16 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$20 (expr
-          (remote-method-call delete expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17)
-            (simple-var-ref $desugar$18)
-            (simple-var-ref $desugar$19))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
       (var-def
         (variable r3 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$20))))
+          (checked-expr
+            (remote-method-call delete expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$12)
+              (simple-var-ref $desugar$13)
+              (simple-var-ref $desugar$14)
+              (simple-var-ref $desugar$15)
+              (simple-var-ref $desugar$16)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r3)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$21 (expr
+        (variable $desugar$17 (expr
           (literal /head))))
       (var-def
-        (variable $desugar$22 (expr
+        (variable $desugar$18 (expr
           (invocation $default$22 (
-            (simple-var-ref $desugar$21))))))
-      (var-def
-        (variable $desugar$23 (expr
-          (remote-method-call head expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$21)
-            (simple-var-ref $desugar$22))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$23))) ())
+            (simple-var-ref $desugar$17))))))
       (var-def
         (variable r4 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$23))))
+          (checked-expr
+            (remote-method-call head expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$17)
+              (simple-var-ref $desugar$18)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r4)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$24 (expr
+        (variable $desugar$19 (expr
           (literal /options))))
       (var-def
-        (variable $desugar$25 (expr
+        (variable $desugar$20 (expr
           (invocation $default$23 (
-            (simple-var-ref $desugar$24))))))
+            (simple-var-ref $desugar$19))))))
       (var-def
-        (variable $desugar$26 (expr
+        (variable $desugar$21 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$27 (expr
-          (remote-method-call options expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$24)
-            (simple-var-ref $desugar$25)
-            (simple-var-ref $desugar$26))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$27))) ())
       (var-def
         (variable r5 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$27))))
+          (checked-expr
+            (remote-method-call options expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$19)
+              (simple-var-ref $desugar$20)
+              (simple-var-ref $desugar$21)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r5)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$28 (expr
+        (variable $desugar$22 (expr
           (literal PATCH))))
       (var-def
-        (variable $desugar$29 (expr
+        (variable $desugar$23 (expr
           (literal /execute))))
       (var-def
-        (variable $desugar$30 (expr
+        (variable $desugar$24 (expr
           (literal exec body))))
       (var-def
-        (variable $desugar$31 (expr
+        (variable $desugar$25 (expr
           (invocation $default$19 (
-            (simple-var-ref $desugar$28)
-            (simple-var-ref $desugar$29)
-            (simple-var-ref $desugar$30))))))
+            (simple-var-ref $desugar$22)
+            (simple-var-ref $desugar$23)
+            (simple-var-ref $desugar$24))))))
       (var-def
-        (variable $desugar$32 (expr
+        (variable $desugar$26 (expr
           (invocation $default$20 (
-            (simple-var-ref $desugar$28)
-            (simple-var-ref $desugar$29)
-            (simple-var-ref $desugar$30)
-            (simple-var-ref $desugar$31))))))
+            (simple-var-ref $desugar$22)
+            (simple-var-ref $desugar$23)
+            (simple-var-ref $desugar$24)
+            (simple-var-ref $desugar$25))))))
       (var-def
-        (variable $desugar$33 (expr
+        (variable $desugar$27 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$34 (expr
-          (remote-method-call execute expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$28)
-            (simple-var-ref $desugar$29)
-            (simple-var-ref $desugar$30)
-            (simple-var-ref $desugar$31)
-            (simple-var-ref $desugar$32)
-            (simple-var-ref $desugar$33))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$34))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$34))) ())
       (var-def
         (variable r6 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$34))))
+          (checked-expr
+            (remote-method-call execute expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$22)
+              (simple-var-ref $desugar$23)
+              (simple-var-ref $desugar$24)
+              (simple-var-ref $desugar$25)
+              (simple-var-ref $desugar$26)
+              (simple-var-ref $desugar$27)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset1/http-client-post-v.txt
+++ b/corpus/desugared/library/subset1/http-client-post-v.txt
@@ -14,93 +14,69 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (new (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable c (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (literal /post))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (literal hello world))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (invocation $default$26 (
+            (simple-var-ref $desugar$2)
+            (simple-var-ref $desugar$3))))))
+      (var-def
+        (variable $desugar$5 (expr
+          (invocation $default$27 (
+            (simple-var-ref $desugar$2)
             (simple-var-ref $desugar$3)
             (simple-var-ref $desugar$4))))))
       (var-def
         (variable $desugar$6 (expr
-          (invocation $default$27 (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5))))))
-      (var-def
-        (variable $desugar$7 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$8 (expr
-          (remote-method-call post expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
       (var-def
         (variable r (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (remote-method-call post expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$2)
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)
+              (simple-var-ref $desugar$5)
+              (simple-var-ref $desugar$6)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$9 (expr
-          (remote-method-call post expr:
-            (simple-var-ref c) (
-            (literal /post)
-            (literal {"key":"value"})
-            (literal <nil>)
-            (literal application/json)
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
-      (var-def
         (variable r2 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (remote-method-call post expr:
+              (simple-var-ref c) (
+              (literal /post)
+              (literal {"key":"value"})
+              (literal <nil>)
+              (literal application/json)
+              (typedesc-expr)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r2)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$7 (expr
           (literal /post))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$8 (expr
           (mapping-constructor-expr
             (key-value
               (literal name)
@@ -109,38 +85,30 @@
               (literal count)
               (literal 1))))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$9 (expr
           (invocation $default$26 (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11))))))
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8))))))
       (var-def
-        (variable $desugar$13 (expr
+        (variable $desugar$10 (expr
           (invocation $default$27 (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12))))))
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8)
+            (simple-var-ref $desugar$9))))))
       (var-def
-        (variable $desugar$14 (expr
+        (variable $desugar$11 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$15 (expr
-          (remote-method-call post expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13)
-            (simple-var-ref $desugar$14))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$15))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$15))) ())
       (var-def
         (variable r3 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$15))))
+          (checked-expr
+            (remote-method-call post expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$7)
+              (simple-var-ref $desugar$8)
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)
+              (simple-var-ref $desugar$11)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset1/http-client-response-headers-v.txt
+++ b/corpus/desugared/library/subset1/http-client-response-headers-v.txt
@@ -15,69 +15,53 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (new (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable c (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$3))))))
+            (simple-var-ref $desugar$2))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$6 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
       (var-def
         (variable r (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$2)
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)))))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$5 (expr
           (literal x-absent))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$6 (expr
           (invocation $default$4 (
-            (simple-var-ref $desugar$7))))))
+            (simple-var-ref $desugar$5))))))
       (expression-stmt
         (invocation io println (
           (invocation hasHeader expr:
             (simple-var-ref r) (
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
+            (simple-var-ref $desugar$5)
+            (simple-var-ref $desugar$6))))))
       (var-def
-        (variable $desugar$9 (expr
+        (variable $desugar$7 (expr
           (invocation $default$2 ()))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (invocation getHeaderNames expr:
               (simple-var-ref r) (
-              (simple-var-ref $desugar$9))))))))
+              (simple-var-ref $desugar$7))))))))
       (expression-stmt
         (invocation io println (
           (invocation hasHeader expr:

--- a/corpus/desugared/library/subset1/http-client-response-payload-v.txt
+++ b/corpus/desugared/library/subset1/http-client-response-payload-v.txt
@@ -15,60 +15,36 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (new (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable c (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$3))))))
+            (simple-var-ref $desugar$2))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$6 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
       (var-def
         (variable r (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$6))))
-      (var-def
-        (variable $desugar$7 (expr
-          (invocation getBinaryPayload expr:
-            (simple-var-ref r) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$2)
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)))))))
       (var-def
         (variable b (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation getBinaryPayload expr:
+              (simple-var-ref r) ())))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (

--- a/corpus/desugared/library/subset1/http-client-tls-v.txt
+++ b/corpus/desugared/library/subset1/http-client-tls-v.txt
@@ -7,95 +7,119 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal secureSocket)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal enable)
-                    (literal false))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable c1 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal secureSocket)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal enable)
+                      (literal false)))))))))))
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$2 (expr
+        (variable $desugar$1 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$1))))))
+            (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$4 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c1) (
-            (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2)
-            (simple-var-ref $desugar$3))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
       (var-def
         (variable r1 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c1) (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)
+              (simple-var-ref $desugar$2)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r1)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$5 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal secureSocket)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal enable)
-                    (literal false))
-                  (key-value
-                    (literal verifyHostName)
-                    (literal false))
-                  (key-value
-                    (literal shareSession)
-                    (literal false))
-                  (key-value
-                    (literal serverName)
-                    (literal example.com))
-                  (key-value
-                    (literal ciphers)
-                    (list-constructor-expr
-                      (literal TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)))
-                  (key-value
-                    (literal handshakeTimeout)
-                    (literal 10))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable c2 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal secureSocket)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal enable)
+                      (literal false))
+                    (key-value
+                      (literal verifyHostName)
+                      (literal false))
+                    (key-value
+                      (literal shareSession)
+                      (literal false))
+                    (key-value
+                      (literal serverName)
+                      (literal example.com))
+                    (key-value
+                      (literal ciphers)
+                      (list-constructor-expr
+                        (literal TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)))
+                    (key-value
+                      (literal handshakeTimeout)
+                      (literal 10)))))))))))
+      (var-def
+        (variable $desugar$3 (expr
+          (literal /path))))
+      (var-def
+        (variable $desugar$4 (expr
+          (invocation $default$21 (
+            (simple-var-ref $desugar$3))))))
+      (var-def
+        (variable $desugar$5 (expr
+          (typedesc-expr))))
+      (var-def
+        (variable r2 (type
+          (user-defined-type http Response)) (expr
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c2) (
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)
+              (simple-var-ref $desugar$5)))))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r2)
+            (literal statusCode)))))
+      (var-def
+        (variable c3 (type
+          (user-defined-type http Client)) (expr
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal secureSocket)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal enable)
+                      (literal false))
+                    (key-value
+                      (literal protocol)
+                      (mapping-constructor-expr
+                        (key-value
+                          (literal name)
+                          (literal TLS))
+                        (key-value
+                          (literal versions)
+                          (list-constructor-expr
+                            (literal TLSv1.2)
+                            (literal TLSv1.3))))))))))))))
       (var-def
         (variable $desugar$6 (expr
           (literal /path))))
@@ -107,86 +131,14 @@
         (variable $desugar$8 (expr
           (typedesc-expr))))
       (var-def
-        (variable $desugar$9 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c2) (
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
-      (var-def
-        (variable r2 (type
-          (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$9))))
-      (expression-stmt
-        (invocation io println (
-          (index-based-access
-            (simple-var-ref r2)
-            (literal statusCode)))))
-      (var-def
-        (variable $desugar$10 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal secureSocket)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal enable)
-                    (literal false))
-                  (key-value
-                    (literal protocol)
-                    (mapping-constructor-expr
-                      (key-value
-                        (literal name)
-                        (literal TLS))
-                      (key-value
-                        (literal versions)
-                        (list-constructor-expr
-                          (literal TLSv1.2)
-                          (literal TLSv1.3)))))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
-      (var-def
-        (variable c3 (type
-          (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$10))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal /path))))
-      (var-def
-        (variable $desugar$12 (expr
-          (invocation $default$21 (
-            (simple-var-ref $desugar$11))))))
-      (var-def
-        (variable $desugar$13 (expr
-          (typedesc-expr))))
-      (var-def
-        (variable $desugar$14 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c3) (
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
-      (var-def
         (variable r3 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c3) (
+              (simple-var-ref $desugar$6)
+              (simple-var-ref $desugar$7)
+              (simple-var-ref $desugar$8)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset1/http-client-v.txt
+++ b/corpus/desugared/library/subset1/http-client-v.txt
@@ -7,121 +7,119 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable c1 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr)))))))
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$2 (expr
+        (variable $desugar$1 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$1))))))
+            (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$4 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c1) (
-            (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2)
-            (simple-var-ref $desugar$3))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
       (var-def
         (variable r1 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c1) (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)
+              (simple-var-ref $desugar$2)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r1)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$5 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal timeout)
-                (literal 30))
-              (key-value
-                (literal followRedirects)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal enabled)
-                    (literal false))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable c2 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal timeout)
+                  (literal 30))
+                (key-value
+                  (literal followRedirects)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal enabled)
+                      (literal false)))))))))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$3 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$4 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$6))))))
+            (simple-var-ref $desugar$3))))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$5 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$9 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c2) (
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
       (var-def
         (variable r2 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c2) (
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)
+              (simple-var-ref $desugar$5)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r2)
             (literal statusCode)))))
-      (var-def
-        (variable $desugar$10 (expr
-          (invocation getTextPayload expr:
-            (simple-var-ref r2) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$10))))
+          (checked-expr
+            (invocation getTextPayload expr:
+              (simple-var-ref r2) ())))))
+      (var-def
+        (variable $desugar$6 (expr
+          (literal https://example.com))))
+      (var-def
+        (variable $desugar$7 (expr
+          (invocation $default$15 (
+            (simple-var-ref $desugar$6))))))
+      (var-def
+        (variable c3 (type
+          (user-defined-type http Client)) (expr
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$6)
+              (simple-var-ref $desugar$7)))))))
+      (var-def
+        (variable $desugar$8 (expr
+          (literal /path))))
+      (var-def
+        (variable $desugar$9 (expr
+          (invocation $default$21 (
+            (simple-var-ref $desugar$8))))))
+      (var-def
+        (variable $desugar$10 (expr
+          (typedesc-expr))))
+      (var-def
+        (variable r3 (type
+          (user-defined-type http Response)) (expr
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c3) (
+              (simple-var-ref $desugar$8)
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)))))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r3)
+            (literal statusCode)))))
       (var-def
         (variable $desugar$11 (expr
           (literal https://example.com))))
@@ -130,194 +128,92 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$11))))))
       (var-def
-        (variable $desugar$13 (expr
-          (new (
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
-      (var-def
-        (variable c3 (type
-          (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$13))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal /path))))
-      (var-def
-        (variable $desugar$15 (expr
-          (invocation $default$21 (
-            (simple-var-ref $desugar$14))))))
-      (var-def
-        (variable $desugar$16 (expr
-          (typedesc-expr))))
-      (var-def
-        (variable $desugar$17 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c3) (
-            (simple-var-ref $desugar$14)
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
-      (var-def
-        (variable r3 (type
-          (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$17))))
-      (expression-stmt
-        (invocation io println (
-          (index-based-access
-            (simple-var-ref r3)
-            (literal statusCode)))))
-      (var-def
-        (variable $desugar$18 (expr
-          (literal https://example.com))))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation $default$15 (
-            (simple-var-ref $desugar$18))))))
-      (var-def
-        (variable $desugar$20 (expr
-          (new (
-            (simple-var-ref $desugar$18)
-            (simple-var-ref $desugar$19))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
-      (var-def
         (variable c4 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c4) (
-            (literal /path)
-            (mapping-constructor-expr
-              (key-value
-                (literal X-Custom)
-                (literal value)))
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$21))) ())
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$11)
+              (simple-var-ref $desugar$12)))))))
       (var-def
         (variable r4 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$21))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c4) (
+              (literal /path)
+              (mapping-constructor-expr
+                (key-value
+                  (literal X-Custom)
+                  (literal value)))
+              (typedesc-expr)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r4)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$22 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal httpVersion)
-                (literal 1.1))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
-      (var-def
         (variable c5 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$22))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal httpVersion)
+                  (literal 1.1)))))))))
       (var-def
-        (variable $desugar$23 (expr
+        (variable $desugar$13 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$24 (expr
+        (variable $desugar$14 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$23))))))
+            (simple-var-ref $desugar$13))))))
       (var-def
-        (variable $desugar$25 (expr
+        (variable $desugar$15 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$26 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c5) (
-            (simple-var-ref $desugar$23)
-            (simple-var-ref $desugar$24)
-            (simple-var-ref $desugar$25))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$26))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$26))) ())
       (var-def
         (variable r5 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$26))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c5) (
+              (simple-var-ref $desugar$13)
+              (simple-var-ref $desugar$14)
+              (simple-var-ref $desugar$15)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r5)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$27 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal httpVersion)
-                (literal 2.0))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$27))) ())
-      (var-def
         (variable c6 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$27))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal httpVersion)
+                  (literal 2.0)))))))))
       (var-def
-        (variable $desugar$28 (expr
+        (variable $desugar$16 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$29 (expr
+        (variable $desugar$17 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$28))))))
+            (simple-var-ref $desugar$16))))))
       (var-def
-        (variable $desugar$30 (expr
+        (variable $desugar$18 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$31 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c6) (
-            (simple-var-ref $desugar$28)
-            (simple-var-ref $desugar$29)
-            (simple-var-ref $desugar$30))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$31))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$31))) ())
       (var-def
         (variable r6 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$31))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c6) (
+              (simple-var-ref $desugar$16)
+              (simple-var-ref $desugar$17)
+              (simple-var-ref $desugar$18)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset2/civil-functions-v.txt
+++ b/corpus/desugared/library/subset2/civil-functions-v.txt
@@ -19,19 +19,11 @@
               (simple-var-ref utcWithPrecision)))
             (literal 2)))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation time utcFromString (
-            (literal 2024-06-15T10:30:45.00Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable base (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2024-06-15T10:30:45.00Z)))))))
       (var-def
         (variable later (type
           (user-defined-type time Utc)) (expr
@@ -131,34 +123,18 @@
             (simple-var-ref civil)
             (literal day)))))
       (var-def
-        (variable $desugar$1 (expr
-          (new
-            (user-defined-type time TimeZone) (
-            (literal +05:30))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable tz (type
           (user-defined-type time TimeZone)) (expr
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation time utcFromString (
-            (literal 2021-04-12T17:50:50.00Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (new
+              (user-defined-type time TimeZone) (
+              (literal +05:30)))))))
       (var-def
         (variable utcBase (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2021-04-12T17:50:50.00Z)))))))
       (var-def
         (variable civilOffset (type
           (user-defined-type time Civil)) (expr
@@ -166,55 +142,31 @@
             (simple-var-ref tz) (
             (simple-var-ref utcBase))))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation utcFromCivil expr:
-            (simple-var-ref tz) (
-            (simple-var-ref civilOffset))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable roundTripped (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation utcFromCivil expr:
+              (simple-var-ref tz) (
+              (simple-var-ref civilOffset)))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (
             (simple-var-ref roundTripped))))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation time civilToString (
-            (simple-var-ref civilOffset))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable civilStr (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation time civilToString (
+              (simple-var-ref civilOffset)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref civilStr))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation time civilFromString (
-            (literal 2021-04-12T23:20:50.520+05:30[Asia/Colombo]))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable parsed (type
           (user-defined-type time Civil)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation time civilFromString (
+              (literal 2021-04-12T23:20:50.520+05:30[Asia/Colombo])))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset2/civil-iana-zone-v.txt
+++ b/corpus/desugared/library/subset2/civil-iana-zone-v.txt
@@ -7,19 +7,11 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation time civilFromString (
-            (literal 2021-04-12T23:20:50.520+05:30[Asia/Colombo]))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable c (type
           (user-defined-type time Civil)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation time civilFromString (
+              (literal 2021-04-12T23:20:50.520+05:30[Asia/Colombo])))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset2/civil-zone-handling-v.txt
+++ b/corpus/desugared/library/subset2/civil-zone-handling-v.txt
@@ -7,116 +7,92 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation time civilToString (
-            (mapping-constructor-expr
-              (key-value
-                (literal year)
-                (literal 2021))
-              (key-value
-                (literal month)
-                (literal 4))
-              (key-value
-                (literal day)
-                (literal 12))
-              (key-value
-                (literal hour)
-                (literal 23))
-              (key-value
-                (literal minute)
-                (literal 20))
-              (key-value
-                (literal second)
-                (literal 50))
-              (key-value
-                (literal timeAbbrev)
-                (literal Asia/Colombo))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable named (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation time civilToString (
+              (mapping-constructor-expr
+                (key-value
+                  (literal year)
+                  (literal 2021))
+                (key-value
+                  (literal month)
+                  (literal 4))
+                (key-value
+                  (literal day)
+                  (literal 12))
+                (key-value
+                  (literal hour)
+                  (literal 23))
+                (key-value
+                  (literal minute)
+                  (literal 20))
+                (key-value
+                  (literal second)
+                  (literal 50))
+                (key-value
+                  (literal timeAbbrev)
+                  (literal Asia/Colombo)))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref named))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation time civilToString (
-            (mapping-constructor-expr
-              (key-value
-                (literal year)
-                (literal 2021))
-              (key-value
-                (literal month)
-                (literal 4))
-              (key-value
-                (literal day)
-                (literal 12))
-              (key-value
-                (literal hour)
-                (literal 23))
-              (key-value
-                (literal minute)
-                (literal 20))
-              (key-value
-                (literal second)
-                (literal 50))
-              (key-value
-                (literal timeAbbrev)
-                (literal +05:30))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable numeric (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation time civilToString (
+              (mapping-constructor-expr
+                (key-value
+                  (literal year)
+                  (literal 2021))
+                (key-value
+                  (literal month)
+                  (literal 4))
+                (key-value
+                  (literal day)
+                  (literal 12))
+                (key-value
+                  (literal hour)
+                  (literal 23))
+                (key-value
+                  (literal minute)
+                  (literal 20))
+                (key-value
+                  (literal second)
+                  (literal 50))
+                (key-value
+                  (literal timeAbbrev)
+                  (literal +05:30)))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref numeric))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation time civilToString (
-            (mapping-constructor-expr
-              (key-value
-                (literal year)
-                (literal 2021))
-              (key-value
-                (literal month)
-                (literal 4))
-              (key-value
-                (literal day)
-                (literal 12))
-              (key-value
-                (literal hour)
-                (literal 17))
-              (key-value
-                (literal minute)
-                (literal 50))
-              (key-value
-                (literal second)
-                (literal 50))
-              (key-value
-                (literal timeAbbrev)
-                (literal Z))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable utc (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation time civilToString (
+              (mapping-constructor-expr
+                (key-value
+                  (literal year)
+                  (literal 2021))
+                (key-value
+                  (literal month)
+                  (literal 4))
+                (key-value
+                  (literal day)
+                  (literal 12))
+                (key-value
+                  (literal hour)
+                  (literal 17))
+                (key-value
+                  (literal minute)
+                  (literal 50))
+                (key-value
+                  (literal second)
+                  (literal 50))
+                (key-value
+                  (literal timeAbbrev)
+                  (literal Z)))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref utc))))
@@ -148,67 +124,51 @@
             (simple-var-ref noZone)
             (error-type)))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation time civilToString (
-            (mapping-constructor-expr
-              (key-value
-                (literal year)
-                (literal 2021))
-              (key-value
-                (literal month)
-                (literal 4))
-              (key-value
-                (literal day)
-                (literal 12))
-              (key-value
-                (literal hour)
-                (literal 23))
-              (key-value
-                (literal minute)
-                (literal 20))
-              (key-value
-                (literal second)
-                (literal 50))
-              (key-value
-                (literal utcOffset)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal hours)
-                    (literal 5))
-                  (key-value
-                    (literal minutes)
-                    (literal 30))
-                  (key-value
-                    (literal seconds)
-                    (literal 30))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable withSeconds (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation time civilToString (
+              (mapping-constructor-expr
+                (key-value
+                  (literal year)
+                  (literal 2021))
+                (key-value
+                  (literal month)
+                  (literal 4))
+                (key-value
+                  (literal day)
+                  (literal 12))
+                (key-value
+                  (literal hour)
+                  (literal 23))
+                (key-value
+                  (literal minute)
+                  (literal 20))
+                (key-value
+                  (literal second)
+                  (literal 50))
+                (key-value
+                  (literal utcOffset)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal hours)
+                      (literal 5))
+                    (key-value
+                      (literal minutes)
+                      (literal 30))
+                    (key-value
+                      (literal seconds)
+                      (literal 30)))))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref withSeconds))))
       (var-def
-        (variable $desugar$4 (expr
-          (new
-            (user-defined-type time TimeZone) (
-            (literal -05:00))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable west (type
           (user-defined-type time TimeZone)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (new
+              (user-defined-type time TimeZone) (
+              (literal -05:00)))))))
       (var-def
         (variable westOffset (type
           (union-type
@@ -246,20 +206,12 @@
               (simple-var-ref tooBig)
               (error-type)))))
         (var-def
-          (variable $desugar$5 (expr
-            (new
-              (user-defined-type time TimeZone) (
-              (literal UTC))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$5))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$5))) ())
-        (var-def
           (variable utcZone (type
             (user-defined-type time TimeZone)) (expr
-            (simple-var-ref $desugar$5))))
+            (checked-expr
+              (new
+                (user-defined-type time TimeZone) (
+                (literal UTC)))))))
         (var-def
           (variable invalidDate (type
             (union-type
@@ -292,95 +244,79 @@
               (simple-var-ref invalidDate)
               (error-type)))))
         (var-def
-          (variable $desugar$6 (expr
-            (invocation time civilToEmailString (
-              (mapping-constructor-expr
-                (key-value
-                  (literal year)
-                  (literal 2024))
-                (key-value
-                  (literal month)
-                  (literal 6))
-                (key-value
-                  (literal day)
-                  (literal 15))
-                (key-value
-                  (literal hour)
-                  (literal 10))
-                (key-value
-                  (literal minute)
-                  (literal 30))
-                (key-value
-                  (literal second)
-                  (literal 45))
-                (key-value
-                  (literal utcOffset)
-                  (mapping-constructor-expr
-                    (key-value
-                      (literal hours)
-                      (literal 0))
-                    (key-value
-                      (literal minutes)
-                      (literal 0))))
-                (key-value
-                  (literal timeAbbrev)
-                  (literal GMT)))
-              (literal ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$6))) ())
-        (var-def
           (variable emailComment (type
             (value-type string)) (expr
-            (simple-var-ref $desugar$6))))
+            (checked-expr
+              (invocation time civilToEmailString (
+                (mapping-constructor-expr
+                  (key-value
+                    (literal year)
+                    (literal 2024))
+                  (key-value
+                    (literal month)
+                    (literal 6))
+                  (key-value
+                    (literal day)
+                    (literal 15))
+                  (key-value
+                    (literal hour)
+                    (literal 10))
+                  (key-value
+                    (literal minute)
+                    (literal 30))
+                  (key-value
+                    (literal second)
+                    (literal 45))
+                  (key-value
+                    (literal utcOffset)
+                    (mapping-constructor-expr
+                      (key-value
+                        (literal hours)
+                        (literal 0))
+                      (key-value
+                        (literal minutes)
+                        (literal 0))))
+                  (key-value
+                    (literal timeAbbrev)
+                    (literal GMT)))
+                (literal ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT)))))))
         (expression-stmt
           (invocation io println (
             (simple-var-ref emailComment))))
         (var-def
-          (variable $desugar$7 (expr
-            (invocation time civilToEmailString (
-              (mapping-constructor-expr
-                (key-value
-                  (literal year)
-                  (literal 2024))
-                (key-value
-                  (literal month)
-                  (literal 6))
-                (key-value
-                  (literal day)
-                  (literal 15))
-                (key-value
-                  (literal hour)
-                  (literal 10))
-                (key-value
-                  (literal minute)
-                  (literal 30))
-                (key-value
-                  (literal second)
-                  (literal 45))
-                (key-value
-                  (literal utcOffset)
-                  (mapping-constructor-expr
-                    (key-value
-                      (literal hours)
-                      (literal 0))
-                    (key-value
-                      (literal minutes)
-                      (literal 0)))))
-              (literal ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$7))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$7))) ())
-        (var-def
           (variable noAbbrev (type
             (value-type string)) (expr
-            (simple-var-ref $desugar$7))))
+            (checked-expr
+              (invocation time civilToEmailString (
+                (mapping-constructor-expr
+                  (key-value
+                    (literal year)
+                    (literal 2024))
+                  (key-value
+                    (literal month)
+                    (literal 6))
+                  (key-value
+                    (literal day)
+                    (literal 15))
+                  (key-value
+                    (literal hour)
+                    (literal 10))
+                  (key-value
+                    (literal minute)
+                    (literal 30))
+                  (key-value
+                    (literal second)
+                    (literal 45))
+                  (key-value
+                    (literal utcOffset)
+                    (mapping-constructor-expr
+                      (key-value
+                        (literal hours)
+                        (literal 0))
+                      (key-value
+                        (literal minutes)
+                        (literal 0)))))
+                (literal ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT)))))))
         (expression-stmt
           (invocation io println (
             (simple-var-ref noAbbrev))))))))

--- a/corpus/desugared/library/subset2/crypto-aes1-v.txt
+++ b/corpus/desugared/library/subset2/crypto-aes1-v.txt
@@ -97,23 +97,15 @@
             (simple-var-ref $desugar$1)
             (simple-var-ref $desugar$2))))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation crypto encryptAesCbc (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2)
-            (simple-var-ref $desugar$3))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable cbc (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation crypto encryptAesCbc (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)
+              (simple-var-ref $desugar$2)
+              (simple-var-ref $desugar$3)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
@@ -122,213 +114,157 @@
             (invocation lang.array length (
               (simple-var-ref plaintext)))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (simple-var-ref cbc))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$5 (expr
           (simple-var-ref key))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$6 (expr
           (simple-var-ref iv))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$7 (expr
           (invocation $default$23 (
+            (simple-var-ref $desugar$4)
             (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation crypto decryptAesCbc (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+            (simple-var-ref $desugar$6))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$9)
+            (checked-expr
+              (invocation crypto decryptAesCbc (
+                (simple-var-ref $desugar$4)
+                (simple-var-ref $desugar$5)
+                (simple-var-ref $desugar$6)
+                (simple-var-ref $desugar$7))))
             (simple-var-ref plaintext)))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$8 (expr
           (simple-var-ref plaintext))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$9 (expr
           (simple-var-ref key))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$10 (expr
           (invocation $default$19 (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11))))))
-      (var-def
-        (variable $desugar$13 (expr
-          (invocation crypto encryptAesEcb (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
+            (simple-var-ref $desugar$8)
+            (simple-var-ref $desugar$9))))))
       (var-def
         (variable ecb (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$13))))
+          (checked-expr
+            (invocation crypto encryptAesEcb (
+              (simple-var-ref $desugar$8)
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)))))))
+      (var-def
+        (variable $desugar$11 (expr
+          (simple-var-ref ecb))))
+      (var-def
+        (variable $desugar$12 (expr
+          (simple-var-ref key))))
+      (var-def
+        (variable $desugar$13 (expr
+          (invocation $default$24 (
+            (simple-var-ref $desugar$11)
+            (simple-var-ref $desugar$12))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr ==
+            (checked-expr
+              (invocation crypto decryptAesEcb (
+                (simple-var-ref $desugar$11)
+                (simple-var-ref $desugar$12)
+                (simple-var-ref $desugar$13))))
+            (simple-var-ref plaintext)))))
       (var-def
         (variable $desugar$14 (expr
-          (simple-var-ref ecb))))
+          (simple-var-ref plaintext))))
       (var-def
         (variable $desugar$15 (expr
           (simple-var-ref key))))
       (var-def
         (variable $desugar$16 (expr
-          (invocation $default$24 (
-            (simple-var-ref $desugar$14)
-            (simple-var-ref $desugar$15))))))
+          (simple-var-ref iv12))))
       (var-def
         (variable $desugar$17 (expr
-          (invocation crypto decryptAesEcb (
+          (invocation $default$20 (
             (simple-var-ref $desugar$14)
             (simple-var-ref $desugar$15)
             (simple-var-ref $desugar$16))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
-      (expression-stmt
-        (invocation io println (
-          (binary-expr ==
-            (simple-var-ref $desugar$17)
-            (simple-var-ref plaintext)))))
       (var-def
         (variable $desugar$18 (expr
-          (simple-var-ref plaintext))))
+          (invocation $default$21 (
+            (simple-var-ref $desugar$14)
+            (simple-var-ref $desugar$15)
+            (simple-var-ref $desugar$16)
+            (simple-var-ref $desugar$17))))))
+      (var-def
+        (variable gcm (type
+          (array-type
+            (value-type byte) dimensions: 1 ([]))) (expr
+          (checked-expr
+            (invocation crypto encryptAesGcm (
+              (simple-var-ref $desugar$14)
+              (simple-var-ref $desugar$15)
+              (simple-var-ref $desugar$16)
+              (simple-var-ref $desugar$17)
+              (simple-var-ref $desugar$18)))))))
       (var-def
         (variable $desugar$19 (expr
-          (simple-var-ref key))))
+          (simple-var-ref gcm))))
       (var-def
         (variable $desugar$20 (expr
-          (simple-var-ref iv12))))
+          (simple-var-ref key))))
       (var-def
         (variable $desugar$21 (expr
-          (invocation $default$20 (
-            (simple-var-ref $desugar$18)
-            (simple-var-ref $desugar$19)
-            (simple-var-ref $desugar$20))))))
+          (simple-var-ref iv12))))
       (var-def
         (variable $desugar$22 (expr
-          (invocation $default$21 (
-            (simple-var-ref $desugar$18)
+          (invocation $default$25 (
             (simple-var-ref $desugar$19)
             (simple-var-ref $desugar$20)
             (simple-var-ref $desugar$21))))))
       (var-def
         (variable $desugar$23 (expr
-          (invocation crypto encryptAesGcm (
-            (simple-var-ref $desugar$18)
+          (invocation $default$26 (
             (simple-var-ref $desugar$19)
             (simple-var-ref $desugar$20)
             (simple-var-ref $desugar$21)
             (simple-var-ref $desugar$22))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$23))) ())
-      (var-def
-        (variable gcm (type
-          (array-type
-            (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$23))))
-      (var-def
-        (variable $desugar$24 (expr
-          (simple-var-ref gcm))))
-      (var-def
-        (variable $desugar$25 (expr
-          (simple-var-ref key))))
-      (var-def
-        (variable $desugar$26 (expr
-          (simple-var-ref iv12))))
-      (var-def
-        (variable $desugar$27 (expr
-          (invocation $default$25 (
-            (simple-var-ref $desugar$24)
-            (simple-var-ref $desugar$25)
-            (simple-var-ref $desugar$26))))))
-      (var-def
-        (variable $desugar$28 (expr
-          (invocation $default$26 (
-            (simple-var-ref $desugar$24)
-            (simple-var-ref $desugar$25)
-            (simple-var-ref $desugar$26)
-            (simple-var-ref $desugar$27))))))
-      (var-def
-        (variable $desugar$29 (expr
-          (invocation crypto decryptAesGcm (
-            (simple-var-ref $desugar$24)
-            (simple-var-ref $desugar$25)
-            (simple-var-ref $desugar$26)
-            (simple-var-ref $desugar$27)
-            (simple-var-ref $desugar$28))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$29))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$29))) ())
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$29)
+            (checked-expr
+              (invocation crypto decryptAesGcm (
+                (simple-var-ref $desugar$19)
+                (simple-var-ref $desugar$20)
+                (simple-var-ref $desugar$21)
+                (simple-var-ref $desugar$22)
+                (simple-var-ref $desugar$23))))
             (simple-var-ref plaintext)))))
-      (var-def
-        (variable $desugar$30 (expr
-          (invocation crypto encryptAesGcm (
-            (simple-var-ref plaintext)
-            (simple-var-ref key)
-            (simple-var-ref iv12)
-            (literal NONE)
-            (literal 96))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$30))) ())
       (var-def
         (variable gcm96 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$30))))
-      (var-def
-        (variable $desugar$31 (expr
-          (invocation crypto decryptAesGcm (
-            (simple-var-ref gcm96)
-            (simple-var-ref key)
-            (simple-var-ref iv12)
-            (literal NONE)
-            (literal 96))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$31))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$31))) ())
+          (checked-expr
+            (invocation crypto encryptAesGcm (
+              (simple-var-ref plaintext)
+              (simple-var-ref key)
+              (simple-var-ref iv12)
+              (literal NONE)
+              (literal 96)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$31)
+            (checked-expr
+              (invocation crypto decryptAesGcm (
+                (simple-var-ref gcm96)
+                (simple-var-ref key)
+                (simple-var-ref iv12)
+                (literal NONE)
+                (literal 96))))
             (simple-var-ref plaintext)))))
       (var-def
         (variable badKey (type
@@ -341,20 +277,20 @@
             (literal 3)
             (literal 4)))))
       (var-def
-        (variable $desugar$32 (expr
+        (variable $desugar$24 (expr
           (simple-var-ref plaintext))))
       (var-def
-        (variable $desugar$33 (expr
+        (variable $desugar$25 (expr
           (simple-var-ref badKey))))
       (var-def
-        (variable $desugar$34 (expr
+        (variable $desugar$26 (expr
           (simple-var-ref iv))))
       (var-def
-        (variable $desugar$35 (expr
+        (variable $desugar$27 (expr
           (invocation $default$18 (
-            (simple-var-ref $desugar$32)
-            (simple-var-ref $desugar$33)
-            (simple-var-ref $desugar$34))))))
+            (simple-var-ref $desugar$24)
+            (simple-var-ref $desugar$25)
+            (simple-var-ref $desugar$26))))))
       (var-def
         (variable cbcErr (type
           (union-type
@@ -362,26 +298,26 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto encryptAesCbc (
-            (simple-var-ref $desugar$32)
-            (simple-var-ref $desugar$33)
-            (simple-var-ref $desugar$34)
-            (simple-var-ref $desugar$35))))))
+            (simple-var-ref $desugar$24)
+            (simple-var-ref $desugar$25)
+            (simple-var-ref $desugar$26)
+            (simple-var-ref $desugar$27))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref cbcErr)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$36 (expr
+        (variable $desugar$28 (expr
           (simple-var-ref plaintext))))
       (var-def
-        (variable $desugar$37 (expr
+        (variable $desugar$29 (expr
           (simple-var-ref badKey))))
       (var-def
-        (variable $desugar$38 (expr
+        (variable $desugar$30 (expr
           (invocation $default$19 (
-            (simple-var-ref $desugar$36)
-            (simple-var-ref $desugar$37))))))
+            (simple-var-ref $desugar$28)
+            (simple-var-ref $desugar$29))))))
       (var-def
         (variable ecbErr (type
           (union-type
@@ -389,36 +325,36 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto encryptAesEcb (
-            (simple-var-ref $desugar$36)
-            (simple-var-ref $desugar$37)
-            (simple-var-ref $desugar$38))))))
+            (simple-var-ref $desugar$28)
+            (simple-var-ref $desugar$29)
+            (simple-var-ref $desugar$30))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref ecbErr)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$39 (expr
+        (variable $desugar$31 (expr
           (simple-var-ref plaintext))))
       (var-def
-        (variable $desugar$40 (expr
+        (variable $desugar$32 (expr
           (simple-var-ref badKey))))
       (var-def
-        (variable $desugar$41 (expr
+        (variable $desugar$33 (expr
           (simple-var-ref iv12))))
       (var-def
-        (variable $desugar$42 (expr
+        (variable $desugar$34 (expr
           (invocation $default$20 (
-            (simple-var-ref $desugar$39)
-            (simple-var-ref $desugar$40)
-            (simple-var-ref $desugar$41))))))
+            (simple-var-ref $desugar$31)
+            (simple-var-ref $desugar$32)
+            (simple-var-ref $desugar$33))))))
       (var-def
-        (variable $desugar$43 (expr
+        (variable $desugar$35 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$39)
-            (simple-var-ref $desugar$40)
-            (simple-var-ref $desugar$41)
-            (simple-var-ref $desugar$42))))))
+            (simple-var-ref $desugar$31)
+            (simple-var-ref $desugar$32)
+            (simple-var-ref $desugar$33)
+            (simple-var-ref $desugar$34))))))
       (var-def
         (variable gcmErr (type
           (union-type
@@ -426,11 +362,11 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto encryptAesGcm (
-            (simple-var-ref $desugar$39)
-            (simple-var-ref $desugar$40)
-            (simple-var-ref $desugar$41)
-            (simple-var-ref $desugar$42)
-            (simple-var-ref $desugar$43))))))
+            (simple-var-ref $desugar$31)
+            (simple-var-ref $desugar$32)
+            (simple-var-ref $desugar$33)
+            (simple-var-ref $desugar$34)
+            (simple-var-ref $desugar$35))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -458,11 +394,76 @@
             (literal 0)
             (literal 0)))))
       (var-def
-        (variable $desugar$44 (expr
+        (variable $desugar$36 (expr
           (simple-var-ref zeros))))
       (var-def
-        (variable $desugar$45 (expr
+        (variable $desugar$37 (expr
           (simple-var-ref key))))
+      (var-def
+        (variable $desugar$38 (expr
+          (simple-var-ref iv))))
+      (var-def
+        (variable $desugar$39 (expr
+          (invocation $default$23 (
+            (simple-var-ref $desugar$36)
+            (simple-var-ref $desugar$37)
+            (simple-var-ref $desugar$38))))))
+      (var-def
+        (variable padErr (type
+          (union-type
+            (array-type
+              (value-type byte) dimensions: 1 ([]))
+            (user-defined-type crypto Error))) (expr
+          (invocation crypto decryptAesCbc (
+            (simple-var-ref $desugar$36)
+            (simple-var-ref $desugar$37)
+            (simple-var-ref $desugar$38)
+            (simple-var-ref $desugar$39))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref padErr)
+            (user-defined-type crypto Error)))))
+      (var-def
+        (variable $desugar$40 (expr
+          (list-constructor-expr
+            (literal 1)
+            (literal 2)
+            (literal 3)))))
+      (var-def
+        (variable $desugar$41 (expr
+          (simple-var-ref key))))
+      (var-def
+        (variable $desugar$42 (expr
+          (simple-var-ref iv))))
+      (var-def
+        (variable $desugar$43 (expr
+          (invocation $default$23 (
+            (simple-var-ref $desugar$40)
+            (simple-var-ref $desugar$41)
+            (simple-var-ref $desugar$42))))))
+      (var-def
+        (variable sizeErr (type
+          (union-type
+            (array-type
+              (value-type byte) dimensions: 1 ([]))
+            (user-defined-type crypto Error))) (expr
+          (invocation crypto decryptAesCbc (
+            (simple-var-ref $desugar$40)
+            (simple-var-ref $desugar$41)
+            (simple-var-ref $desugar$42)
+            (simple-var-ref $desugar$43))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref sizeErr)
+            (user-defined-type crypto Error)))))
+      (var-def
+        (variable $desugar$44 (expr
+          (simple-var-ref cbc))))
+      (var-def
+        (variable $desugar$45 (expr
+          (simple-var-ref badKey))))
       (var-def
         (variable $desugar$46 (expr
           (simple-var-ref iv))))
@@ -473,7 +474,7 @@
             (simple-var-ref $desugar$45)
             (simple-var-ref $desugar$46))))))
       (var-def
-        (variable padErr (type
+        (variable cbcDecErr (type
           (union-type
             (array-type
               (value-type byte) dimensions: 1 ([]))
@@ -486,84 +487,19 @@
       (expression-stmt
         (invocation io println (
           (type-test-expr is
-            (simple-var-ref padErr)
-            (user-defined-type crypto Error)))))
-      (var-def
-        (variable $desugar$48 (expr
-          (list-constructor-expr
-            (literal 1)
-            (literal 2)
-            (literal 3)))))
-      (var-def
-        (variable $desugar$49 (expr
-          (simple-var-ref key))))
-      (var-def
-        (variable $desugar$50 (expr
-          (simple-var-ref iv))))
-      (var-def
-        (variable $desugar$51 (expr
-          (invocation $default$23 (
-            (simple-var-ref $desugar$48)
-            (simple-var-ref $desugar$49)
-            (simple-var-ref $desugar$50))))))
-      (var-def
-        (variable sizeErr (type
-          (union-type
-            (array-type
-              (value-type byte) dimensions: 1 ([]))
-            (user-defined-type crypto Error))) (expr
-          (invocation crypto decryptAesCbc (
-            (simple-var-ref $desugar$48)
-            (simple-var-ref $desugar$49)
-            (simple-var-ref $desugar$50)
-            (simple-var-ref $desugar$51))))))
-      (expression-stmt
-        (invocation io println (
-          (type-test-expr is
-            (simple-var-ref sizeErr)
-            (user-defined-type crypto Error)))))
-      (var-def
-        (variable $desugar$52 (expr
-          (simple-var-ref cbc))))
-      (var-def
-        (variable $desugar$53 (expr
-          (simple-var-ref badKey))))
-      (var-def
-        (variable $desugar$54 (expr
-          (simple-var-ref iv))))
-      (var-def
-        (variable $desugar$55 (expr
-          (invocation $default$23 (
-            (simple-var-ref $desugar$52)
-            (simple-var-ref $desugar$53)
-            (simple-var-ref $desugar$54))))))
-      (var-def
-        (variable cbcDecErr (type
-          (union-type
-            (array-type
-              (value-type byte) dimensions: 1 ([]))
-            (user-defined-type crypto Error))) (expr
-          (invocation crypto decryptAesCbc (
-            (simple-var-ref $desugar$52)
-            (simple-var-ref $desugar$53)
-            (simple-var-ref $desugar$54)
-            (simple-var-ref $desugar$55))))))
-      (expression-stmt
-        (invocation io println (
-          (type-test-expr is
             (simple-var-ref cbcDecErr)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$56 (expr
+        (variable $desugar$48 (expr
           (simple-var-ref ecb))))
       (var-def
-        (variable $desugar$57 (expr
+        (variable $desugar$49 (expr
           (simple-var-ref badKey))))
       (var-def
-        (variable $desugar$58 (expr
+        (variable $desugar$50 (expr
           (invocation $default$24 (
-            (simple-var-ref $desugar$56)
-            (simple-var-ref $desugar$57))))))
+            (simple-var-ref $desugar$48)
+            (simple-var-ref $desugar$49))))))
       (var-def
         (variable ecbDecErr (type
           (union-type
@@ -571,28 +507,28 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto decryptAesEcb (
-            (simple-var-ref $desugar$56)
-            (simple-var-ref $desugar$57)
-            (simple-var-ref $desugar$58))))))
+            (simple-var-ref $desugar$48)
+            (simple-var-ref $desugar$49)
+            (simple-var-ref $desugar$50))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref ecbDecErr)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$59 (expr
+        (variable $desugar$51 (expr
           (list-constructor-expr
             (literal 1)
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$60 (expr
+        (variable $desugar$52 (expr
           (simple-var-ref key))))
       (var-def
-        (variable $desugar$61 (expr
+        (variable $desugar$53 (expr
           (invocation $default$24 (
-            (simple-var-ref $desugar$59)
-            (simple-var-ref $desugar$60))))))
+            (simple-var-ref $desugar$51)
+            (simple-var-ref $desugar$52))))))
       (var-def
         (variable ecbSizeErr (type
           (union-type
@@ -600,25 +536,25 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto decryptAesEcb (
-            (simple-var-ref $desugar$59)
-            (simple-var-ref $desugar$60)
-            (simple-var-ref $desugar$61))))))
+            (simple-var-ref $desugar$51)
+            (simple-var-ref $desugar$52)
+            (simple-var-ref $desugar$53))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref ecbSizeErr)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$62 (expr
+        (variable $desugar$54 (expr
           (simple-var-ref zeros))))
       (var-def
-        (variable $desugar$63 (expr
+        (variable $desugar$55 (expr
           (simple-var-ref key))))
       (var-def
-        (variable $desugar$64 (expr
+        (variable $desugar$56 (expr
           (invocation $default$24 (
-            (simple-var-ref $desugar$62)
-            (simple-var-ref $desugar$63))))))
+            (simple-var-ref $desugar$54)
+            (simple-var-ref $desugar$55))))))
       (var-def
         (variable ecbPadErr (type
           (union-type
@@ -626,29 +562,29 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto decryptAesEcb (
-            (simple-var-ref $desugar$62)
-            (simple-var-ref $desugar$63)
-            (simple-var-ref $desugar$64))))))
+            (simple-var-ref $desugar$54)
+            (simple-var-ref $desugar$55)
+            (simple-var-ref $desugar$56))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref ecbPadErr)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$65 (expr
+        (variable $desugar$57 (expr
           (list-constructor-expr))))
       (var-def
-        (variable $desugar$66 (expr
+        (variable $desugar$58 (expr
           (simple-var-ref key))))
       (var-def
-        (variable $desugar$67 (expr
+        (variable $desugar$59 (expr
           (simple-var-ref iv))))
       (var-def
-        (variable $desugar$68 (expr
+        (variable $desugar$60 (expr
           (invocation $default$23 (
-            (simple-var-ref $desugar$65)
-            (simple-var-ref $desugar$66)
-            (simple-var-ref $desugar$67))))))
+            (simple-var-ref $desugar$57)
+            (simple-var-ref $desugar$58)
+            (simple-var-ref $desugar$59))))))
       (var-def
         (variable emptyErr (type
           (union-type
@@ -656,10 +592,10 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto decryptAesCbc (
-            (simple-var-ref $desugar$65)
-            (simple-var-ref $desugar$66)
-            (simple-var-ref $desugar$67)
-            (simple-var-ref $desugar$68))))))
+            (simple-var-ref $desugar$57)
+            (simple-var-ref $desugar$58)
+            (simple-var-ref $desugar$59)
+            (simple-var-ref $desugar$60))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -734,27 +670,27 @@
             (simple-var-ref gcmDecCombo)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$69 (expr
+        (variable $desugar$61 (expr
           (simple-var-ref gcm))))
       (var-def
-        (variable $desugar$70 (expr
+        (variable $desugar$62 (expr
           (simple-var-ref badKey))))
       (var-def
-        (variable $desugar$71 (expr
+        (variable $desugar$63 (expr
           (simple-var-ref iv12))))
       (var-def
-        (variable $desugar$72 (expr
+        (variable $desugar$64 (expr
           (invocation $default$25 (
-            (simple-var-ref $desugar$69)
-            (simple-var-ref $desugar$70)
-            (simple-var-ref $desugar$71))))))
+            (simple-var-ref $desugar$61)
+            (simple-var-ref $desugar$62)
+            (simple-var-ref $desugar$63))))))
       (var-def
-        (variable $desugar$73 (expr
+        (variable $desugar$65 (expr
           (invocation $default$26 (
-            (simple-var-ref $desugar$69)
-            (simple-var-ref $desugar$70)
-            (simple-var-ref $desugar$71)
-            (simple-var-ref $desugar$72))))))
+            (simple-var-ref $desugar$61)
+            (simple-var-ref $desugar$62)
+            (simple-var-ref $desugar$63)
+            (simple-var-ref $desugar$64))))))
       (var-def
         (variable gcmDecKeyErr (type
           (union-type
@@ -762,11 +698,11 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto decryptAesGcm (
-            (simple-var-ref $desugar$69)
-            (simple-var-ref $desugar$70)
-            (simple-var-ref $desugar$71)
-            (simple-var-ref $desugar$72)
-            (simple-var-ref $desugar$73))))))
+            (simple-var-ref $desugar$61)
+            (simple-var-ref $desugar$62)
+            (simple-var-ref $desugar$63)
+            (simple-var-ref $desugar$64)
+            (simple-var-ref $desugar$65))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -794,27 +730,27 @@
             (literal 1)
             (literal 0)))))
       (var-def
-        (variable $desugar$74 (expr
+        (variable $desugar$66 (expr
           (simple-var-ref gcm))))
       (var-def
-        (variable $desugar$75 (expr
+        (variable $desugar$67 (expr
           (simple-var-ref key2))))
       (var-def
-        (variable $desugar$76 (expr
+        (variable $desugar$68 (expr
           (simple-var-ref iv12))))
       (var-def
-        (variable $desugar$77 (expr
+        (variable $desugar$69 (expr
           (invocation $default$25 (
-            (simple-var-ref $desugar$74)
-            (simple-var-ref $desugar$75)
-            (simple-var-ref $desugar$76))))))
+            (simple-var-ref $desugar$66)
+            (simple-var-ref $desugar$67)
+            (simple-var-ref $desugar$68))))))
       (var-def
-        (variable $desugar$78 (expr
+        (variable $desugar$70 (expr
           (invocation $default$26 (
-            (simple-var-ref $desugar$74)
-            (simple-var-ref $desugar$75)
-            (simple-var-ref $desugar$76)
-            (simple-var-ref $desugar$77))))))
+            (simple-var-ref $desugar$66)
+            (simple-var-ref $desugar$67)
+            (simple-var-ref $desugar$68)
+            (simple-var-ref $desugar$69))))))
       (var-def
         (variable gcmAuthErr (type
           (union-type
@@ -822,11 +758,11 @@
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto decryptAesGcm (
-            (simple-var-ref $desugar$74)
-            (simple-var-ref $desugar$75)
-            (simple-var-ref $desugar$76)
-            (simple-var-ref $desugar$77)
-            (simple-var-ref $desugar$78))))))
+            (simple-var-ref $desugar$66)
+            (simple-var-ref $desugar$67)
+            (simple-var-ref $desugar$68)
+            (simple-var-ref $desugar$69)
+            (simple-var-ref $desugar$70))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is

--- a/corpus/desugared/library/subset2/crypto-content-v.txt
+++ b/corpus/desugared/library/subset2/crypto-content-v.txt
@@ -119,231 +119,135 @@ Eubczj1asLiR3WmG1u2v/ntgx3FESVPFlpEMX66jA4DTWUF8aSNSNZIhKoIorIVZ
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadBytes (
-            (literal /tmp/bal_crypto_content.pem))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable certBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation crypto decodeRsaPublicKeyFromContent (
-            (simple-var-ref certBytes))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+          (checked-expr
+            (invocation io fileReadBytes (
+              (literal /tmp/bal_crypto_content.pem)))))))
       (var-def
         (variable pub (type
           (user-defined-type crypto PublicKey)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation crypto decodeRsaPublicKeyFromContent (
+              (simple-var-ref certBytes)))))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$3 (expr
           (simple-var-ref data))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$4 (expr
           (simple-var-ref pub))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$5 (expr
           (invocation $default$17 (
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.array length (
               (group-expr
-                (simple-var-ref $desugar$9))))
+                (checked-expr
+                  (invocation crypto encryptRsaEcb (
+                    (simple-var-ref $desugar$3)
+                    (simple-var-ref $desugar$4)
+                    (simple-var-ref $desugar$5)))))))
             (literal 0)))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$6 (expr
           (literal /tmp/bal_crypto_content.pem))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$7 (expr
           (simple-var-ref keyPem))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$8 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11))))))
-      (var-def
-        (variable $desugar$13 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7))))))
       (expression-stmt
-        (simple-var-ref $desugar$13))
-      (var-def
-        (variable $desugar$14 (expr
-          (invocation io fileReadBytes (
-            (literal /tmp/bal_crypto_content.pem))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8)))))
       (var-def
         (variable keyBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (literal /tmp/bal_crypto_content.pem)))))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$9 (expr
           (simple-var-ref keyBytes))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$10 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$15))))))
-      (var-def
-        (variable $desugar$17 (expr
-          (invocation crypto decodeRsaPrivateKeyFromContent (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
+            (simple-var-ref $desugar$9))))))
       (var-def
         (variable pk (type
           (user-defined-type crypto PrivateKey)) (expr
-          (simple-var-ref $desugar$17))))
-      (var-def
-        (variable $desugar$18 (expr
-          (invocation crypto signRsaSha256 (
-            (simple-var-ref data)
-            (simple-var-ref pk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
+          (checked-expr
+            (invocation crypto decodeRsaPrivateKeyFromContent (
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.array length (
               (group-expr
-                (simple-var-ref $desugar$18))))
+                (checked-expr
+                  (invocation crypto signRsaSha256 (
+                    (simple-var-ref data)
+                    (simple-var-ref pk)))))))
             (literal 0)))))
       (var-def
-        (variable $desugar$19 (expr
+        (variable $desugar$11 (expr
           (literal /tmp/bal_crypto_content.pem))))
       (var-def
-        (variable $desugar$20 (expr
+        (variable $desugar$12 (expr
           (simple-var-ref encKeyPem))))
       (var-def
-        (variable $desugar$21 (expr
+        (variable $desugar$13 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$19)
-            (simple-var-ref $desugar$20))))))
-      (var-def
-        (variable $desugar$22 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$19)
-            (simple-var-ref $desugar$20)
-            (simple-var-ref $desugar$21))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
+            (simple-var-ref $desugar$11)
+            (simple-var-ref $desugar$12))))))
       (expression-stmt
-        (simple-var-ref $desugar$22))
-      (var-def
-        (variable $desugar$23 (expr
-          (invocation io fileReadBytes (
-            (literal /tmp/bal_crypto_content.pem))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$23))) ())
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$11)
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13)))))
       (var-def
         (variable encBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$23))))
-      (var-def
-        (variable $desugar$24 (expr
-          (invocation crypto decodeRsaPrivateKeyFromContent (
-            (simple-var-ref encBytes)
-            (literal secret))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$24))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$24))) ())
+          (checked-expr
+            (invocation io fileReadBytes (
+              (literal /tmp/bal_crypto_content.pem)))))))
       (var-def
         (variable encPk (type
           (user-defined-type crypto PrivateKey)) (expr
-          (simple-var-ref $desugar$24))))
-      (var-def
-        (variable $desugar$25 (expr
-          (invocation crypto signRsaSha256 (
-            (simple-var-ref data)
-            (simple-var-ref encPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$25))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$25))) ())
+          (checked-expr
+            (invocation crypto decodeRsaPrivateKeyFromContent (
+              (simple-var-ref encBytes)
+              (literal secret)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.array length (
               (group-expr
-                (simple-var-ref $desugar$25))))
+                (checked-expr
+                  (invocation crypto signRsaSha256 (
+                    (simple-var-ref data)
+                    (simple-var-ref encPk)))))))
             (literal 0)))))
       (var-def
         (variable junk (type
@@ -366,49 +270,33 @@ Eubczj1asLiR3WmG1u2v/ntgx3FESVPFlpEMX66jA4DTWUF8aSNSNZIhKoIorIVZ
             (simple-var-ref bad)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$26 (expr
-          (invocation crypto buildRsaPublicKey (
-            (literal B53CF3F3B675BF146DDCEDBA46A69ED21618D27CC15479FE2606D11649CD5945491F84D6FF7C722CA1030FECF46FEE4184FD9C66290F4AA290F1A04BD9FB2227747B00985A08CF5778A87168F6CFD96C626394F1C8D2B3DB9A475EDFF8127AF420B34A7CCEA4B81ED156759479C8862463495D23B6C3EDB4DA632324C5E061834EA74DB67752AAB02B0BFE737F330D6F9ED4CA8D76537E5CB5911DEF71573D395A85B2A5958509D7E4E18795A28EDC7007EA36FE8088A5AC93C54F89CA0CCF9DE41E88AD94644CE841A32DA56E8969F8575F0DD0735818CEF373BE3757145DE5DED5203D823BB98DD9F8831C68FAE7E6F040B921E75F3C57469B8E2C1BCE1365)
-            (literal 10001))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$26))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$26))) ())
-      (var-def
         (variable built (type
           (user-defined-type crypto PublicKey)) (expr
-          (simple-var-ref $desugar$26))))
+          (checked-expr
+            (invocation crypto buildRsaPublicKey (
+              (literal B53CF3F3B675BF146DDCEDBA46A69ED21618D27CC15479FE2606D11649CD5945491F84D6FF7C722CA1030FECF46FEE4184FD9C66290F4AA290F1A04BD9FB2227747B00985A08CF5778A87168F6CFD96C626394F1C8D2B3DB9A475EDFF8127AF420B34A7CCEA4B81ED156759479C8862463495D23B6C3EDB4DA632324C5E061834EA74DB67752AAB02B0BFE737F330D6F9ED4CA8D76537E5CB5911DEF71573D395A85B2A5958509D7E4E18795A28EDC7007EA36FE8088A5AC93C54F89CA0CCF9DE41E88AD94644CE841A32DA56E8969F8575F0DD0735818CEF373BE3757145DE5DED5203D823BB98DD9F8831C68FAE7E6F040B921E75F3C57469B8E2C1BCE1365)
+              (literal 10001)))))))
       (var-def
-        (variable $desugar$27 (expr
+        (variable $desugar$14 (expr
           (simple-var-ref data))))
       (var-def
-        (variable $desugar$28 (expr
+        (variable $desugar$15 (expr
           (simple-var-ref built))))
       (var-def
-        (variable $desugar$29 (expr
+        (variable $desugar$16 (expr
           (invocation $default$17 (
-            (simple-var-ref $desugar$27)
-            (simple-var-ref $desugar$28))))))
-      (var-def
-        (variable $desugar$30 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref $desugar$27)
-            (simple-var-ref $desugar$28)
-            (simple-var-ref $desugar$29))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$30))) ())
+            (simple-var-ref $desugar$14)
+            (simple-var-ref $desugar$15))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.array length (
               (group-expr
-                (simple-var-ref $desugar$30))))
+                (checked-expr
+                  (invocation crypto encryptRsaEcb (
+                    (simple-var-ref $desugar$14)
+                    (simple-var-ref $desugar$15)
+                    (simple-var-ref $desugar$16)))))))
             (literal 0)))))
       (var-def
         (variable badBuilt (type

--- a/corpus/desugared/library/subset2/crypto-hmac1-v.txt
+++ b/corpus/desugared/library/subset2/crypto-hmac1-v.txt
@@ -29,21 +29,13 @@
             (literal 101)
             (literal 116)))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation crypto hmacSha256 (
-            (simple-var-ref input)
-            (simple-var-ref key))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable mac (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation crypto hmacSha256 (
+              (simple-var-ref input)
+              (simple-var-ref key)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (

--- a/corpus/desugared/library/subset2/crypto-hmac2-v.txt
+++ b/corpus/desugared/library/subset2/crypto-hmac2-v.txt
@@ -28,67 +28,35 @@
             (literal 114)
             (literal 101)
             (literal 116)))))
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation crypto hmacMd5 (
-            (simple-var-ref input)
-            (simple-var-ref key))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (group-expr
-              (simple-var-ref $desugar$0)))))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation crypto hmacSha1 (
-            (simple-var-ref input)
-            (simple-var-ref key))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+              (checked-expr
+                (invocation crypto hmacMd5 (
+                  (simple-var-ref input)
+                  (simple-var-ref key))))))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (group-expr
-              (simple-var-ref $desugar$1)))))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation crypto hmacSha384 (
-            (simple-var-ref input)
-            (simple-var-ref key))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+              (checked-expr
+                (invocation crypto hmacSha1 (
+                  (simple-var-ref input)
+                  (simple-var-ref key))))))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (group-expr
-              (simple-var-ref $desugar$2)))))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation crypto hmacSha512 (
-            (simple-var-ref input)
-            (simple-var-ref key))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+              (checked-expr
+                (invocation crypto hmacSha384 (
+                  (simple-var-ref input)
+                  (simple-var-ref key))))))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (group-expr
-              (simple-var-ref $desugar$3))))))))))
+              (checked-expr
+                (invocation crypto hmacSha512 (
+                  (simple-var-ref input)
+                  (simple-var-ref key)))))))))))))

--- a/corpus/desugared/library/subset2/crypto-kdf1-v.txt
+++ b/corpus/desugared/library/subset2/crypto-kdf1-v.txt
@@ -52,64 +52,40 @@
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
             (simple-var-ref $desugar$2))))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation crypto hkdfSha256 (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2)
-            (simple-var-ref $desugar$3))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (group-expr
-              (simple-var-ref $desugar$4)))))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation crypto hkdfSha256 (
-            (simple-var-ref input)
-            (literal 64)
-            (simple-var-ref salt)
-            (simple-var-ref info))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+              (checked-expr
+                (invocation crypto hkdfSha256 (
+                  (simple-var-ref $desugar$0)
+                  (simple-var-ref $desugar$1)
+                  (simple-var-ref $desugar$2)
+                  (simple-var-ref $desugar$3))))))))))
       (var-def
         (variable d1 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation crypto hkdfSha256 (
+              (simple-var-ref input)
+              (literal 64)
+              (simple-var-ref salt)
+              (simple-var-ref info)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (simple-var-ref d1))))))
       (var-def
-        (variable $desugar$6 (expr
-          (invocation crypto hkdfSha256 (
-            (simple-var-ref input)
-            (literal 64)
-            (simple-var-ref salt)
-            (simple-var-ref info))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (var-def
         (variable d2 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation crypto hkdfSha256 (
+              (simple-var-ref input)
+              (literal 64)
+              (simple-var-ref salt)
+              (simple-var-ref info)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
@@ -121,23 +97,15 @@
             (simple-var-ref d1)
             (simple-var-ref d2))))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation crypto hkdfSha256 (
-            (simple-var-ref input)
-            (literal 64)
-            (simple-var-ref info)
-            (simple-var-ref salt))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable other (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation crypto hkdfSha256 (
+              (simple-var-ref input)
+              (literal 64)
+              (simple-var-ref info)
+              (simple-var-ref salt)))))))
       (expression-stmt
         (invocation io println (
           (invocation crypto equalConstantTime (

--- a/corpus/desugared/library/subset2/crypto-keys-enc-v.txt
+++ b/corpus/desugared/library/subset2/crypto-keys-enc-v.txt
@@ -130,194 +130,114 @@ O7ekKjOszIhNsvlgkHI=
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation crypto decodeRsaPrivateKeyFromKeyFile (
-            (literal /tmp/bal_crypto_enc.pem)
-            (literal secret))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable pkPbes2 (type
           (user-defined-type crypto PrivateKey)) (expr
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation crypto signRsaSha256 (
-            (simple-var-ref data)
-            (simple-var-ref pkPbes2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+          (checked-expr
+            (invocation crypto decodeRsaPrivateKeyFromKeyFile (
+              (literal /tmp/bal_crypto_enc.pem)
+              (literal secret)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.array length (
               (group-expr
-                (simple-var-ref $desugar$5))))
+                (checked-expr
+                  (invocation crypto signRsaSha256 (
+                    (simple-var-ref data)
+                    (simple-var-ref pkPbes2)))))))
+            (literal 0)))))
+      (var-def
+        (variable $desugar$3 (expr
+          (literal /tmp/bal_crypto_enc.pem))))
+      (var-def
+        (variable $desugar$4 (expr
+          (simple-var-ref pbe3des))))
+      (var-def
+        (variable $desugar$5 (expr
+          (invocation $default$1 (
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
+      (expression-stmt
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4)
+            (simple-var-ref $desugar$5)))))
+      (var-def
+        (variable pk3des (type
+          (user-defined-type crypto PrivateKey)) (expr
+          (checked-expr
+            (invocation crypto decodeRsaPrivateKeyFromKeyFile (
+              (literal /tmp/bal_crypto_enc.pem)
+              (literal secret)))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr >
+            (invocation lang.array length (
+              (group-expr
+                (checked-expr
+                  (invocation crypto signRsaSha256 (
+                    (simple-var-ref data)
+                    (simple-var-ref pk3des)))))))
             (literal 0)))))
       (var-def
         (variable $desugar$6 (expr
           (literal /tmp/bal_crypto_enc.pem))))
       (var-def
         (variable $desugar$7 (expr
-          (simple-var-ref pbe3des))))
+          (simple-var-ref pbeRc2))))
       (var-def
         (variable $desugar$8 (expr
           (invocation $default$1 (
             (simple-var-ref $desugar$6)
             (simple-var-ref $desugar$7))))))
-      (var-def
-        (variable $desugar$9 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$6)
             (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$9))
-      (var-def
-        (variable $desugar$10 (expr
-          (invocation crypto decodeRsaPrivateKeyFromKeyFile (
-            (literal /tmp/bal_crypto_enc.pem)
-            (literal secret))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
-      (var-def
-        (variable pk3des (type
-          (user-defined-type crypto PrivateKey)) (expr
-          (simple-var-ref $desugar$10))))
-      (var-def
-        (variable $desugar$11 (expr
-          (invocation crypto signRsaSha256 (
-            (simple-var-ref data)
-            (simple-var-ref pk3des))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
-      (expression-stmt
-        (invocation io println (
-          (binary-expr >
-            (invocation lang.array length (
-              (group-expr
-                (simple-var-ref $desugar$11))))
-            (literal 0)))))
-      (var-def
-        (variable $desugar$12 (expr
-          (literal /tmp/bal_crypto_enc.pem))))
-      (var-def
-        (variable $desugar$13 (expr
-          (simple-var-ref pbeRc2))))
-      (var-def
-        (variable $desugar$14 (expr
-          (invocation $default$1 (
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (var-def
-        (variable $desugar$15 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13)
-            (simple-var-ref $desugar$14))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$15))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$15))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$15))
-      (var-def
-        (variable $desugar$16 (expr
-          (invocation crypto decodeRsaPrivateKeyFromKeyFile (
-            (literal /tmp/bal_crypto_enc.pem)
-            (literal secret))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$16))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$16))) ())
+            (simple-var-ref $desugar$8)))))
       (var-def
         (variable pkRc2 (type
           (user-defined-type crypto PrivateKey)) (expr
-          (simple-var-ref $desugar$16))))
-      (var-def
-        (variable $desugar$17 (expr
-          (invocation crypto signRsaSha256 (
-            (simple-var-ref data)
-            (simple-var-ref pkRc2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
+          (checked-expr
+            (invocation crypto decodeRsaPrivateKeyFromKeyFile (
+              (literal /tmp/bal_crypto_enc.pem)
+              (literal secret)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.array length (
               (group-expr
-                (simple-var-ref $desugar$17))))
+                (checked-expr
+                  (invocation crypto signRsaSha256 (
+                    (simple-var-ref data)
+                    (simple-var-ref pkRc2)))))))
             (literal 0)))))
       (var-def
-        (variable $desugar$18 (expr
+        (variable $desugar$9 (expr
           (literal /tmp/bal_crypto_enc.pem))))
       (var-def
-        (variable $desugar$19 (expr
+        (variable $desugar$10 (expr
           (simple-var-ref pbes2))))
       (var-def
-        (variable $desugar$20 (expr
+        (variable $desugar$11 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$18)
-            (simple-var-ref $desugar$19))))))
-      (var-def
-        (variable $desugar$21 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$18)
-            (simple-var-ref $desugar$19)
-            (simple-var-ref $desugar$20))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$21))) ())
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10))))))
       (expression-stmt
-        (simple-var-ref $desugar$21))
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10)
+            (simple-var-ref $desugar$11)))))
       (var-def
         (variable bad (type
           (union-type

--- a/corpus/desugared/library/subset2/crypto-keys-v.txt
+++ b/corpus/desugared/library/subset2/crypto-keys-v.txt
@@ -99,131 +99,83 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
+            (simple-var-ref $desugar$2)))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (literal /tmp/bal_rsa_cert.pem))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (simple-var-ref rsaCert))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$5 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5))))))
-      (var-def
-        (variable $desugar$7 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
       (expression-stmt
-        (simple-var-ref $desugar$7))
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4)
+            (simple-var-ref $desugar$5)))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$6 (expr
           (literal /tmp/bal_ec_key.pem))))
       (var-def
-        (variable $desugar$9 (expr
+        (variable $desugar$7 (expr
           (simple-var-ref ecKey))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$8 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$8)
-            (simple-var-ref $desugar$9))))))
-      (var-def
-        (variable $desugar$11 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$8)
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$10))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7))))))
       (expression-stmt
-        (simple-var-ref $desugar$11))
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8)))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$9 (expr
           (literal /tmp/bal_ec_cert.pem))))
       (var-def
-        (variable $desugar$13 (expr
+        (variable $desugar$10 (expr
           (simple-var-ref ecCert))))
       (var-def
-        (variable $desugar$14 (expr
+        (variable $desugar$11 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (var-def
-        (variable $desugar$15 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13)
-            (simple-var-ref $desugar$14))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$15))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$15))) ())
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10))))))
       (expression-stmt
-        (simple-var-ref $desugar$15))
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10)
+            (simple-var-ref $desugar$11)))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$12 (expr
           (literal /tmp/bal_rsa_key.pem))))
       (var-def
-        (variable $desugar$17 (expr
+        (variable $desugar$13 (expr
           (invocation $default$0 (
-            (simple-var-ref $desugar$16))))))
-      (var-def
-        (variable $desugar$18 (expr
-          (invocation crypto decodeRsaPrivateKeyFromKeyFile (
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
+            (simple-var-ref $desugar$12))))))
       (var-def
         (variable rsaPk (type
           (user-defined-type crypto PrivateKey)) (expr
-          (simple-var-ref $desugar$18))))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation crypto decodeRsaPublicKeyFromCertFile (
-            (literal /tmp/bal_rsa_cert.pem))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$19))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$19))) ())
+          (checked-expr
+            (invocation crypto decodeRsaPrivateKeyFromKeyFile (
+              (simple-var-ref $desugar$12)
+              (simple-var-ref $desugar$13)))))))
       (var-def
         (variable rsaPub (type
           (user-defined-type crypto PublicKey)) (expr
-          (simple-var-ref $desugar$19))))
+          (checked-expr
+            (invocation crypto decodeRsaPublicKeyFromCertFile (
+              (literal /tmp/bal_rsa_cert.pem)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
@@ -248,600 +200,336 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
             (literal 7)
             (literal 8)))))
       (var-def
-        (variable $desugar$20 (expr
-          (invocation crypto signRsaSha256 (
-            (simple-var-ref data)
-            (simple-var-ref rsaPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
-      (var-def
         (variable s256 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (invocation crypto verifyRsaSha256Signature (
-            (simple-var-ref data)
-            (simple-var-ref s256)
-            (simple-var-ref rsaPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$21))) ())
+          (checked-expr
+            (invocation crypto signRsaSha256 (
+              (simple-var-ref data)
+              (simple-var-ref rsaPk)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$21))))
-      (var-def
-        (variable $desugar$22 (expr
-          (invocation crypto signRsaSha384 (
-            (simple-var-ref data)
-            (simple-var-ref rsaPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
+          (checked-expr
+            (invocation crypto verifyRsaSha256Signature (
+              (simple-var-ref data)
+              (simple-var-ref s256)
+              (simple-var-ref rsaPub)))))))
       (var-def
         (variable s384 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$22))))
-      (var-def
-        (variable $desugar$23 (expr
-          (invocation crypto verifyRsaSha384Signature (
-            (simple-var-ref data)
-            (simple-var-ref s384)
-            (simple-var-ref rsaPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$23))) ())
+          (checked-expr
+            (invocation crypto signRsaSha384 (
+              (simple-var-ref data)
+              (simple-var-ref rsaPk)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$23))))
-      (var-def
-        (variable $desugar$24 (expr
-          (invocation crypto signRsaSha512 (
-            (simple-var-ref data)
-            (simple-var-ref rsaPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$24))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$24))) ())
+          (checked-expr
+            (invocation crypto verifyRsaSha384Signature (
+              (simple-var-ref data)
+              (simple-var-ref s384)
+              (simple-var-ref rsaPub)))))))
       (var-def
         (variable s512 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$24))))
-      (var-def
-        (variable $desugar$25 (expr
-          (invocation crypto verifyRsaSha512Signature (
-            (simple-var-ref data)
-            (simple-var-ref s512)
-            (simple-var-ref rsaPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$25))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$25))) ())
+          (checked-expr
+            (invocation crypto signRsaSha512 (
+              (simple-var-ref data)
+              (simple-var-ref rsaPk)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$25))))
-      (var-def
-        (variable $desugar$26 (expr
-          (invocation crypto signRsaSha1 (
-            (simple-var-ref data)
-            (simple-var-ref rsaPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$26))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$26))) ())
+          (checked-expr
+            (invocation crypto verifyRsaSha512Signature (
+              (simple-var-ref data)
+              (simple-var-ref s512)
+              (simple-var-ref rsaPub)))))))
       (var-def
         (variable s1 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$26))))
-      (var-def
-        (variable $desugar$27 (expr
-          (invocation crypto verifyRsaSha1Signature (
-            (simple-var-ref data)
-            (simple-var-ref s1)
-            (simple-var-ref rsaPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$27))) ())
+          (checked-expr
+            (invocation crypto signRsaSha1 (
+              (simple-var-ref data)
+              (simple-var-ref rsaPk)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$27))))
-      (var-def
-        (variable $desugar$28 (expr
-          (invocation crypto signRsaMd5 (
-            (simple-var-ref data)
-            (simple-var-ref rsaPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$28))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$28))) ())
+          (checked-expr
+            (invocation crypto verifyRsaSha1Signature (
+              (simple-var-ref data)
+              (simple-var-ref s1)
+              (simple-var-ref rsaPub)))))))
       (var-def
         (variable sMd5 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$28))))
-      (var-def
-        (variable $desugar$29 (expr
-          (invocation crypto verifyRsaMd5Signature (
-            (simple-var-ref data)
-            (simple-var-ref sMd5)
-            (simple-var-ref rsaPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$29))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$29))) ())
+          (checked-expr
+            (invocation crypto signRsaMd5 (
+              (simple-var-ref data)
+              (simple-var-ref rsaPk)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$29))))
-      (var-def
-        (variable $desugar$30 (expr
-          (invocation crypto signRsaSsaPss256 (
-            (simple-var-ref data)
-            (simple-var-ref rsaPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$30))) ())
+          (checked-expr
+            (invocation crypto verifyRsaMd5Signature (
+              (simple-var-ref data)
+              (simple-var-ref sMd5)
+              (simple-var-ref rsaPub)))))))
       (var-def
         (variable sPss (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$30))))
-      (var-def
-        (variable $desugar$31 (expr
-          (invocation crypto verifyRsaSsaPss256Signature (
-            (simple-var-ref data)
-            (simple-var-ref sPss)
-            (simple-var-ref rsaPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$31))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$31))) ())
+          (checked-expr
+            (invocation crypto signRsaSsaPss256 (
+              (simple-var-ref data)
+              (simple-var-ref rsaPk)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$31))))
-      (var-def
-        (variable $desugar$32 (expr
-          (invocation crypto verifyRsaSha256Signature (
-            (list-constructor-expr
-              (literal 9)
-              (literal 9)
-              (literal 9))
-            (simple-var-ref s256)
-            (simple-var-ref rsaPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$32))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$32))) ())
+          (checked-expr
+            (invocation crypto verifyRsaSsaPss256Signature (
+              (simple-var-ref data)
+              (simple-var-ref sPss)
+              (simple-var-ref rsaPub)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$32))))
+          (checked-expr
+            (invocation crypto verifyRsaSha256Signature (
+              (list-constructor-expr
+                (literal 9)
+                (literal 9)
+                (literal 9))
+              (simple-var-ref s256)
+              (simple-var-ref rsaPub)))))))
       (var-def
-        (variable $desugar$33 (expr
+        (variable $desugar$14 (expr
           (simple-var-ref data))))
       (var-def
-        (variable $desugar$34 (expr
+        (variable $desugar$15 (expr
           (simple-var-ref rsaPub))))
       (var-def
-        (variable $desugar$35 (expr
+        (variable $desugar$16 (expr
           (invocation $default$17 (
-            (simple-var-ref $desugar$33)
-            (simple-var-ref $desugar$34))))))
-      (var-def
-        (variable $desugar$36 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref $desugar$33)
-            (simple-var-ref $desugar$34)
-            (simple-var-ref $desugar$35))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$36))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$36))) ())
+            (simple-var-ref $desugar$14)
+            (simple-var-ref $desugar$15))))))
       (var-def
         (variable ct (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$36))))
+          (checked-expr
+            (invocation crypto encryptRsaEcb (
+              (simple-var-ref $desugar$14)
+              (simple-var-ref $desugar$15)
+              (simple-var-ref $desugar$16)))))))
       (var-def
-        (variable $desugar$37 (expr
+        (variable $desugar$17 (expr
           (simple-var-ref ct))))
       (var-def
-        (variable $desugar$38 (expr
+        (variable $desugar$18 (expr
           (simple-var-ref rsaPk))))
       (var-def
-        (variable $desugar$39 (expr
+        (variable $desugar$19 (expr
           (invocation $default$22 (
-            (simple-var-ref $desugar$37)
-            (simple-var-ref $desugar$38))))))
-      (var-def
-        (variable $desugar$40 (expr
-          (invocation crypto decryptRsaEcb (
-            (simple-var-ref $desugar$37)
-            (simple-var-ref $desugar$38)
-            (simple-var-ref $desugar$39))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$40))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$40))) ())
+            (simple-var-ref $desugar$17)
+            (simple-var-ref $desugar$18))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$40)
+            (checked-expr
+              (invocation crypto decryptRsaEcb (
+                (simple-var-ref $desugar$17)
+                (simple-var-ref $desugar$18)
+                (simple-var-ref $desugar$19))))
             (simple-var-ref data)))))
-      (var-def
-        (variable $desugar$41 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref data)
-            (simple-var-ref rsaPub)
-            (literal OAEPwithMD5andMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$41))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$41))) ())
       (var-def
         (variable oaepMd5 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$41))))
-      (var-def
-        (variable $desugar$42 (expr
-          (invocation crypto decryptRsaEcb (
-            (simple-var-ref oaepMd5)
-            (simple-var-ref rsaPk)
-            (literal OAEPwithMD5andMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$42))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$42))) ())
+          (checked-expr
+            (invocation crypto encryptRsaEcb (
+              (simple-var-ref data)
+              (simple-var-ref rsaPub)
+              (literal OAEPwithMD5andMGF1)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$42)
+            (checked-expr
+              (invocation crypto decryptRsaEcb (
+                (simple-var-ref oaepMd5)
+                (simple-var-ref rsaPk)
+                (literal OAEPwithMD5andMGF1))))
             (simple-var-ref data)))))
-      (var-def
-        (variable $desugar$43 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref data)
-            (simple-var-ref rsaPub)
-            (literal OAEPWithSHA1AndMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$43))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$43))) ())
       (var-def
         (variable oaep1 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$43))))
-      (var-def
-        (variable $desugar$44 (expr
-          (invocation crypto decryptRsaEcb (
-            (simple-var-ref oaep1)
-            (simple-var-ref rsaPk)
-            (literal OAEPWithSHA1AndMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$44))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$44))) ())
+          (checked-expr
+            (invocation crypto encryptRsaEcb (
+              (simple-var-ref data)
+              (simple-var-ref rsaPub)
+              (literal OAEPWithSHA1AndMGF1)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$44)
+            (checked-expr
+              (invocation crypto decryptRsaEcb (
+                (simple-var-ref oaep1)
+                (simple-var-ref rsaPk)
+                (literal OAEPWithSHA1AndMGF1))))
             (simple-var-ref data)))))
-      (var-def
-        (variable $desugar$45 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref data)
-            (simple-var-ref rsaPub)
-            (literal OAEPWithSHA256AndMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$45))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$45))) ())
       (var-def
         (variable oaep256 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$45))))
-      (var-def
-        (variable $desugar$46 (expr
-          (invocation crypto decryptRsaEcb (
-            (simple-var-ref oaep256)
-            (simple-var-ref rsaPk)
-            (literal OAEPWithSHA256AndMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$46))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$46))) ())
+          (checked-expr
+            (invocation crypto encryptRsaEcb (
+              (simple-var-ref data)
+              (simple-var-ref rsaPub)
+              (literal OAEPWithSHA256AndMGF1)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$46)
+            (checked-expr
+              (invocation crypto decryptRsaEcb (
+                (simple-var-ref oaep256)
+                (simple-var-ref rsaPk)
+                (literal OAEPWithSHA256AndMGF1))))
             (simple-var-ref data)))))
-      (var-def
-        (variable $desugar$47 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref data)
-            (simple-var-ref rsaPub)
-            (literal OAEPwithSHA384andMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$47))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$47))) ())
       (var-def
         (variable oaep384 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$47))))
-      (var-def
-        (variable $desugar$48 (expr
-          (invocation crypto decryptRsaEcb (
-            (simple-var-ref oaep384)
-            (simple-var-ref rsaPk)
-            (literal OAEPwithSHA384andMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$48))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$48))) ())
+          (checked-expr
+            (invocation crypto encryptRsaEcb (
+              (simple-var-ref data)
+              (simple-var-ref rsaPub)
+              (literal OAEPwithSHA384andMGF1)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$48)
+            (checked-expr
+              (invocation crypto decryptRsaEcb (
+                (simple-var-ref oaep384)
+                (simple-var-ref rsaPk)
+                (literal OAEPwithSHA384andMGF1))))
             (simple-var-ref data)))))
-      (var-def
-        (variable $desugar$49 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref data)
-            (simple-var-ref rsaPub)
-            (literal OAEPwithSHA512andMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$49))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$49))) ())
       (var-def
         (variable oaep512 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$49))))
-      (var-def
-        (variable $desugar$50 (expr
-          (invocation crypto decryptRsaEcb (
-            (simple-var-ref oaep512)
-            (simple-var-ref rsaPk)
-            (literal OAEPwithSHA512andMGF1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$50))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$50))) ())
+          (checked-expr
+            (invocation crypto encryptRsaEcb (
+              (simple-var-ref data)
+              (simple-var-ref rsaPub)
+              (literal OAEPwithSHA512andMGF1)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$50)
+            (checked-expr
+              (invocation crypto decryptRsaEcb (
+                (simple-var-ref oaep512)
+                (simple-var-ref rsaPk)
+                (literal OAEPwithSHA512andMGF1))))
             (simple-var-ref data)))))
       (var-def
-        (variable $desugar$51 (expr
+        (variable $desugar$20 (expr
           (literal /tmp/bal_ec_key.pem))))
       (var-def
-        (variable $desugar$52 (expr
+        (variable $desugar$21 (expr
           (invocation $default$2 (
-            (simple-var-ref $desugar$51))))))
-      (var-def
-        (variable $desugar$53 (expr
-          (invocation crypto decodeEcPrivateKeyFromKeyFile (
-            (simple-var-ref $desugar$51)
-            (simple-var-ref $desugar$52))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$53))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$53))) ())
+            (simple-var-ref $desugar$20))))))
       (var-def
         (variable ecPk (type
           (user-defined-type crypto PrivateKey)) (expr
-          (simple-var-ref $desugar$53))))
-      (var-def
-        (variable $desugar$54 (expr
-          (invocation crypto decodeEcPublicKeyFromCertFile (
-            (literal /tmp/bal_ec_cert.pem))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$54))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$54))) ())
+          (checked-expr
+            (invocation crypto decodeEcPrivateKeyFromKeyFile (
+              (simple-var-ref $desugar$20)
+              (simple-var-ref $desugar$21)))))))
       (var-def
         (variable ecPub (type
           (user-defined-type crypto PublicKey)) (expr
-          (simple-var-ref $desugar$54))))
-      (var-def
-        (variable $desugar$55 (expr
-          (invocation crypto signSha256withEcdsa (
-            (simple-var-ref data)
-            (simple-var-ref ecPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$55))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$55))) ())
+          (checked-expr
+            (invocation crypto decodeEcPublicKeyFromCertFile (
+              (literal /tmp/bal_ec_cert.pem)))))))
       (var-def
         (variable e256 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$55))))
-      (var-def
-        (variable $desugar$56 (expr
-          (invocation crypto verifySha256withEcdsaSignature (
-            (simple-var-ref data)
-            (simple-var-ref e256)
-            (simple-var-ref ecPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$56))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$56))) ())
+          (checked-expr
+            (invocation crypto signSha256withEcdsa (
+              (simple-var-ref data)
+              (simple-var-ref ecPk)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$56))))
-      (var-def
-        (variable $desugar$57 (expr
-          (invocation crypto signSha384withEcdsa (
-            (simple-var-ref data)
-            (simple-var-ref ecPk))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$57))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$57))) ())
+          (checked-expr
+            (invocation crypto verifySha256withEcdsaSignature (
+              (simple-var-ref data)
+              (simple-var-ref e256)
+              (simple-var-ref ecPub)))))))
       (var-def
         (variable e384 (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$57))))
-      (var-def
-        (variable $desugar$58 (expr
-          (invocation crypto verifySha384withEcdsaSignature (
-            (simple-var-ref data)
-            (simple-var-ref e384)
-            (simple-var-ref ecPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$58))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$58))) ())
+          (checked-expr
+            (invocation crypto signSha384withEcdsa (
+              (simple-var-ref data)
+              (simple-var-ref ecPk)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$58))))
+          (checked-expr
+            (invocation crypto verifySha384withEcdsaSignature (
+              (simple-var-ref data)
+              (simple-var-ref e384)
+              (simple-var-ref ecPub)))))))
       (var-def
-        (variable $desugar$59 (expr
+        (variable $desugar$22 (expr
           (simple-var-ref data))))
       (var-def
-        (variable $desugar$60 (expr
+        (variable $desugar$23 (expr
           (simple-var-ref rsaPk))))
       (var-def
-        (variable $desugar$61 (expr
+        (variable $desugar$24 (expr
           (invocation $default$17 (
-            (simple-var-ref $desugar$59)
-            (simple-var-ref $desugar$60))))))
-      (var-def
-        (variable $desugar$62 (expr
-          (invocation crypto encryptRsaEcb (
-            (simple-var-ref $desugar$59)
-            (simple-var-ref $desugar$60)
-            (simple-var-ref $desugar$61))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$62))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$62))) ())
+            (simple-var-ref $desugar$22)
+            (simple-var-ref $desugar$23))))))
       (var-def
         (variable ctPriv (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$62))))
+          (checked-expr
+            (invocation crypto encryptRsaEcb (
+              (simple-var-ref $desugar$22)
+              (simple-var-ref $desugar$23)
+              (simple-var-ref $desugar$24)))))))
       (var-def
-        (variable $desugar$63 (expr
+        (variable $desugar$25 (expr
           (simple-var-ref ctPriv))))
       (var-def
-        (variable $desugar$64 (expr
+        (variable $desugar$26 (expr
           (simple-var-ref rsaPk))))
       (var-def
-        (variable $desugar$65 (expr
+        (variable $desugar$27 (expr
           (invocation $default$22 (
-            (simple-var-ref $desugar$63)
-            (simple-var-ref $desugar$64))))))
-      (var-def
-        (variable $desugar$66 (expr
-          (invocation crypto decryptRsaEcb (
-            (simple-var-ref $desugar$63)
-            (simple-var-ref $desugar$64)
-            (simple-var-ref $desugar$65))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$66))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$66))) ())
+            (simple-var-ref $desugar$25)
+            (simple-var-ref $desugar$26))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$66)
+            (checked-expr
+              (invocation crypto decryptRsaEcb (
+                (simple-var-ref $desugar$25)
+                (simple-var-ref $desugar$26)
+                (simple-var-ref $desugar$27))))
             (simple-var-ref data)))))
       (var-def
-        (variable $desugar$67 (expr
+        (variable $desugar$28 (expr
           (simple-var-ref data))))
       (var-def
-        (variable $desugar$68 (expr
+        (variable $desugar$29 (expr
           (simple-var-ref rsaPk))))
       (var-def
-        (variable $desugar$69 (expr
+        (variable $desugar$30 (expr
           (invocation $default$22 (
-            (simple-var-ref $desugar$67)
-            (simple-var-ref $desugar$68))))))
+            (simple-var-ref $desugar$28)
+            (simple-var-ref $desugar$29))))))
       (var-def
         (variable decErr (type
           (union-type
@@ -849,25 +537,25 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto decryptRsaEcb (
-            (simple-var-ref $desugar$67)
-            (simple-var-ref $desugar$68)
-            (simple-var-ref $desugar$69))))))
+            (simple-var-ref $desugar$28)
+            (simple-var-ref $desugar$29)
+            (simple-var-ref $desugar$30))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref decErr)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$70 (expr
+        (variable $desugar$31 (expr
           (simple-var-ref ct))))
       (var-def
-        (variable $desugar$71 (expr
+        (variable $desugar$32 (expr
           (simple-var-ref rsaPub))))
       (var-def
-        (variable $desugar$72 (expr
+        (variable $desugar$33 (expr
           (invocation $default$22 (
-            (simple-var-ref $desugar$70)
-            (simple-var-ref $desugar$71))))))
+            (simple-var-ref $desugar$31)
+            (simple-var-ref $desugar$32))))))
       (var-def
         (variable decPubErr (type
           (union-type
@@ -875,32 +563,24 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
               (value-type byte) dimensions: 1 ([]))
             (user-defined-type crypto Error))) (expr
           (invocation crypto decryptRsaEcb (
-            (simple-var-ref $desugar$70)
-            (simple-var-ref $desugar$71)
-            (simple-var-ref $desugar$72))))))
+            (simple-var-ref $desugar$31)
+            (simple-var-ref $desugar$32)
+            (simple-var-ref $desugar$33))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref decPubErr)
             (user-defined-type crypto Error)))))
-      (var-def
-        (variable $desugar$73 (expr
-          (invocation crypto verifyRsaSsaPss256Signature (
-            (list-constructor-expr
-              (literal 9)
-              (literal 9)
-              (literal 9))
-            (simple-var-ref sPss)
-            (simple-var-ref rsaPub))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$73))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$73))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$73))))
+          (checked-expr
+            (invocation crypto verifyRsaSsaPss256Signature (
+              (list-constructor-expr
+                (literal 9)
+                (literal 9)
+                (literal 9))
+              (simple-var-ref sPss)
+              (simple-var-ref rsaPub)))))))
       (var-def
         (variable rsaSignEc (type
           (union-type
@@ -986,40 +666,40 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
             (simple-var-ref ecVerifyRsa)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$74 (expr
+        (variable $desugar$34 (expr
           (literal /tmp/bal_no_such.pem))))
       (var-def
-        (variable $desugar$75 (expr
+        (variable $desugar$35 (expr
           (invocation $default$0 (
-            (simple-var-ref $desugar$74))))))
+            (simple-var-ref $desugar$34))))))
       (var-def
         (variable rsaKeyMissing (type
           (union-type
             (user-defined-type crypto PrivateKey)
             (user-defined-type crypto Error))) (expr
           (invocation crypto decodeRsaPrivateKeyFromKeyFile (
-            (simple-var-ref $desugar$74)
-            (simple-var-ref $desugar$75))))))
+            (simple-var-ref $desugar$34)
+            (simple-var-ref $desugar$35))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref rsaKeyMissing)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$76 (expr
+        (variable $desugar$36 (expr
           (literal /tmp/bal_no_such.pem))))
       (var-def
-        (variable $desugar$77 (expr
+        (variable $desugar$37 (expr
           (invocation $default$2 (
-            (simple-var-ref $desugar$76))))))
+            (simple-var-ref $desugar$36))))))
       (var-def
         (variable ecKeyMissing (type
           (union-type
             (user-defined-type crypto PrivateKey)
             (user-defined-type crypto Error))) (expr
           (invocation crypto decodeEcPrivateKeyFromKeyFile (
-            (simple-var-ref $desugar$76)
-            (simple-var-ref $desugar$77))))))
+            (simple-var-ref $desugar$36)
+            (simple-var-ref $desugar$37))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -1050,40 +730,40 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
             (simple-var-ref ecCertMissing)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$78 (expr
+        (variable $desugar$38 (expr
           (literal /tmp/bal_ec_key.pem))))
       (var-def
-        (variable $desugar$79 (expr
+        (variable $desugar$39 (expr
           (invocation $default$0 (
-            (simple-var-ref $desugar$78))))))
+            (simple-var-ref $desugar$38))))))
       (var-def
         (variable ecAsRsaKey (type
           (union-type
             (user-defined-type crypto PrivateKey)
             (user-defined-type crypto Error))) (expr
           (invocation crypto decodeRsaPrivateKeyFromKeyFile (
-            (simple-var-ref $desugar$78)
-            (simple-var-ref $desugar$79))))))
+            (simple-var-ref $desugar$38)
+            (simple-var-ref $desugar$39))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref ecAsRsaKey)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$80 (expr
+        (variable $desugar$40 (expr
           (literal /tmp/bal_rsa_key.pem))))
       (var-def
-        (variable $desugar$81 (expr
+        (variable $desugar$41 (expr
           (invocation $default$2 (
-            (simple-var-ref $desugar$80))))))
+            (simple-var-ref $desugar$40))))))
       (var-def
         (variable rsaAsEcKey (type
           (union-type
             (user-defined-type crypto PrivateKey)
             (user-defined-type crypto Error))) (expr
           (invocation crypto decodeEcPrivateKeyFromKeyFile (
-            (simple-var-ref $desugar$80)
-            (simple-var-ref $desugar$81))))))
+            (simple-var-ref $desugar$40)
+            (simple-var-ref $desugar$41))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -1122,75 +802,59 @@ j8SfkAvXrHcCIDBDbfZxrJtPWany9a7fCZBKyWG8nNy2HkzSxYeJ2GHh
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$82 (expr
+        (variable $desugar$42 (expr
           (simple-var-ref junk))))
       (var-def
-        (variable $desugar$83 (expr
+        (variable $desugar$43 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$82))))))
+            (simple-var-ref $desugar$42))))))
       (var-def
         (variable junkKey (type
           (union-type
             (user-defined-type crypto PrivateKey)
             (user-defined-type crypto Error))) (expr
           (invocation crypto decodeRsaPrivateKeyFromContent (
-            (simple-var-ref $desugar$82)
-            (simple-var-ref $desugar$83))))))
+            (simple-var-ref $desugar$42)
+            (simple-var-ref $desugar$43))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref junkKey)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$84 (expr
-          (invocation io fileReadBytes (
-            (literal /tmp/bal_ec_key.pem))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$84))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$84))) ())
-      (var-def
         (variable ecKeyBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$84))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (literal /tmp/bal_ec_key.pem)))))))
       (var-def
-        (variable $desugar$85 (expr
+        (variable $desugar$44 (expr
           (simple-var-ref ecKeyBytes))))
       (var-def
-        (variable $desugar$86 (expr
+        (variable $desugar$45 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$85))))))
+            (simple-var-ref $desugar$44))))))
       (var-def
         (variable ecAsRsaContent (type
           (union-type
             (user-defined-type crypto PrivateKey)
             (user-defined-type crypto Error))) (expr
           (invocation crypto decodeRsaPrivateKeyFromContent (
-            (simple-var-ref $desugar$85)
-            (simple-var-ref $desugar$86))))))
+            (simple-var-ref $desugar$44)
+            (simple-var-ref $desugar$45))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref ecAsRsaContent)
             (user-defined-type crypto Error)))))
       (var-def
-        (variable $desugar$87 (expr
-          (invocation io fileReadBytes (
-            (literal /tmp/bal_ec_cert.pem))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$87))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$87))) ())
-      (var-def
         (variable ecCertBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$87))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (literal /tmp/bal_ec_cert.pem)))))))
       (var-def
         (variable ecAsRsaCertContent (type
           (union-type

--- a/corpus/desugared/library/subset2/crypto-password1-v.txt
+++ b/corpus/desugared/library/subset2/crypto-password1-v.txt
@@ -19,242 +19,138 @@
           (invocation $default$9 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation crypto hashBcrypt (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable bcryptHash (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation crypto hashBcrypt (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.string length (
               (simple-var-ref bcryptHash)))
             (literal 0)))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation crypto verifyBcrypt (
-            (simple-var-ref password)
-            (simple-var-ref bcryptHash))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation crypto verifyBcrypt (
-            (literal wrong)
-            (simple-var-ref bcryptHash))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (invocation crypto verifyBcrypt (
+              (simple-var-ref password)
+              (simple-var-ref bcryptHash)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation crypto verifyBcrypt (
+              (literal wrong)
+              (simple-var-ref bcryptHash)))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$2 (expr
           (simple-var-ref password))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$3 (expr
           (invocation $default$10 (
-            (simple-var-ref $desugar$5))))))
+            (simple-var-ref $desugar$2))))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$4 (expr
           (invocation $default$11 (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6))))))
+            (simple-var-ref $desugar$2)
+            (simple-var-ref $desugar$3))))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$5 (expr
           (invocation $default$12 (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation crypto hashArgon2 (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+            (simple-var-ref $desugar$2)
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
       (var-def
         (variable argon2Hash (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation crypto hashArgon2 (
+              (simple-var-ref $desugar$2)
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)
+              (simple-var-ref $desugar$5)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.string length (
               (simple-var-ref argon2Hash)))
             (literal 0)))))
-      (var-def
-        (variable $desugar$10 (expr
-          (invocation crypto verifyArgon2 (
-            (simple-var-ref password)
-            (simple-var-ref argon2Hash))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$10))))
-      (var-def
-        (variable $desugar$11 (expr
-          (invocation crypto verifyArgon2 (
-            (literal wrong)
-            (simple-var-ref argon2Hash))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
+          (checked-expr
+            (invocation crypto verifyArgon2 (
+              (simple-var-ref password)
+              (simple-var-ref argon2Hash)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$11))))
+          (checked-expr
+            (invocation crypto verifyArgon2 (
+              (literal wrong)
+              (simple-var-ref argon2Hash)))))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$6 (expr
           (simple-var-ref password))))
       (var-def
-        (variable $desugar$13 (expr
+        (variable $desugar$7 (expr
           (invocation $default$13 (
-            (simple-var-ref $desugar$12))))))
+            (simple-var-ref $desugar$6))))))
       (var-def
-        (variable $desugar$14 (expr
+        (variable $desugar$8 (expr
           (invocation $default$14 (
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (var-def
-        (variable $desugar$15 (expr
-          (invocation crypto hashPbkdf2 (
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13)
-            (simple-var-ref $desugar$14))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$15))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$15))) ())
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7))))))
       (var-def
         (variable pbkdf2Hash (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$15))))
+          (checked-expr
+            (invocation crypto hashPbkdf2 (
+              (simple-var-ref $desugar$6)
+              (simple-var-ref $desugar$7)
+              (simple-var-ref $desugar$8)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
             (invocation lang.string length (
               (simple-var-ref pbkdf2Hash)))
             (literal 0)))))
-      (var-def
-        (variable $desugar$16 (expr
-          (invocation crypto verifyPbkdf2 (
-            (simple-var-ref password)
-            (simple-var-ref pbkdf2Hash))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$16))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$16))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$16))))
-      (var-def
-        (variable $desugar$17 (expr
-          (invocation crypto verifyPbkdf2 (
-            (literal wrong)
-            (simple-var-ref pbkdf2Hash))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
+          (checked-expr
+            (invocation crypto verifyPbkdf2 (
+              (simple-var-ref password)
+              (simple-var-ref pbkdf2Hash)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$17))))
-      (var-def
-        (variable $desugar$18 (expr
-          (invocation crypto hashPbkdf2 (
-            (simple-var-ref password)
-            (literal 10000)
-            (literal SHA512))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
+          (checked-expr
+            (invocation crypto verifyPbkdf2 (
+              (literal wrong)
+              (simple-var-ref pbkdf2Hash)))))))
       (var-def
         (variable pbkdf2Sha512 (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$18))))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation crypto verifyPbkdf2 (
-            (simple-var-ref password)
-            (simple-var-ref pbkdf2Sha512))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$19))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$19))) ())
+          (checked-expr
+            (invocation crypto hashPbkdf2 (
+              (simple-var-ref password)
+              (literal 10000)
+              (literal SHA512)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$19))))
-      (var-def
-        (variable $desugar$20 (expr
-          (invocation crypto hashPbkdf2 (
-            (simple-var-ref password)
-            (literal 10000)
-            (literal SHA1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
+          (checked-expr
+            (invocation crypto verifyPbkdf2 (
+              (simple-var-ref password)
+              (simple-var-ref pbkdf2Sha512)))))))
       (var-def
         (variable pbkdf2Sha1 (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (invocation crypto verifyPbkdf2 (
-            (simple-var-ref password)
-            (simple-var-ref pbkdf2Sha1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$21))) ())
+          (checked-expr
+            (invocation crypto hashPbkdf2 (
+              (simple-var-ref password)
+              (literal 10000)
+              (literal SHA1)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$21)))))))
+          (checked-expr
+            (invocation crypto verifyPbkdf2 (
+              (simple-var-ref password)
+              (simple-var-ref pbkdf2Sha1))))))))))

--- a/corpus/desugared/library/subset2/email-date-v.txt
+++ b/corpus/desugared/library/subset2/email-date-v.txt
@@ -7,32 +7,24 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation time utcFromString (
-            (literal 2024-06-15T10:30:45.00Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable utc (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2024-06-15T10:30:45.00Z)))))))
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (simple-var-ref utc))))
       (var-def
-        (variable $desugar$2 (expr
+        (variable $desugar$1 (expr
           (invocation $default$2 (
-            (simple-var-ref $desugar$1))))))
+            (simple-var-ref $desugar$0))))))
       (var-def
         (variable emailStr (type
           (value-type string)) (expr
           (invocation time utcToEmailString (
-            (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
+            (simple-var-ref $desugar$0)
+            (simple-var-ref $desugar$1))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref emailStr))))
@@ -82,34 +74,18 @@
             (simple-var-ref bad)
             (error-type)))))
       (var-def
-        (variable $desugar$3 (expr
-          (new
-            (user-defined-type time TimeZone) (
-            (literal +00:00))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable tz (type
           (user-defined-type time TimeZone)) (expr
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation time utcFromString (
-            (literal 2024-06-15T10:30:45.00Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (new
+              (user-defined-type time TimeZone) (
+              (literal +00:00)))))))
       (var-def
         (variable utcBase (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2024-06-15T10:30:45.00Z)))))))
       (var-def
         (variable civil (type
           (user-defined-type time Civil)) (expr

--- a/corpus/desugared/library/subset2/http-client-compression-v.txt
+++ b/corpus/desugared/library/subset2/http-client-compression-v.txt
@@ -7,70 +7,80 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable c1 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr)))))))
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$2 (expr
+        (variable $desugar$1 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$1))))))
+            (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$4 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c1) (
-            (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2)
-            (simple-var-ref $desugar$3))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
       (var-def
         (variable r1 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c1) (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)
+              (simple-var-ref $desugar$2)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r1)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$5 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal compression)
-                (literal AUTO))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable c2 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal compression)
+                  (literal AUTO)))))))))
+      (var-def
+        (variable $desugar$3 (expr
+          (literal /path))))
+      (var-def
+        (variable $desugar$4 (expr
+          (invocation $default$21 (
+            (simple-var-ref $desugar$3))))))
+      (var-def
+        (variable $desugar$5 (expr
+          (typedesc-expr))))
+      (var-def
+        (variable r2 (type
+          (user-defined-type http Response)) (expr
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c2) (
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)
+              (simple-var-ref $desugar$5)))))))
+      (expression-stmt
+        (invocation io println (
+          (index-based-access
+            (simple-var-ref r2)
+            (literal statusCode)))))
+      (var-def
+        (variable c3 (type
+          (user-defined-type http Client)) (expr
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal compression)
+                  (literal ALWAYS)))))))))
       (var-def
         (variable $desugar$6 (expr
           (literal /path))))
@@ -82,178 +92,88 @@
         (variable $desugar$8 (expr
           (typedesc-expr))))
       (var-def
-        (variable $desugar$9 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c2) (
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
-      (var-def
-        (variable r2 (type
-          (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$9))))
-      (expression-stmt
-        (invocation io println (
-          (index-based-access
-            (simple-var-ref r2)
-            (literal statusCode)))))
-      (var-def
-        (variable $desugar$10 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal compression)
-                (literal ALWAYS))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
-      (var-def
-        (variable c3 (type
-          (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$10))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal /path))))
-      (var-def
-        (variable $desugar$12 (expr
-          (invocation $default$21 (
-            (simple-var-ref $desugar$11))))))
-      (var-def
-        (variable $desugar$13 (expr
-          (typedesc-expr))))
-      (var-def
-        (variable $desugar$14 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c3) (
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
-      (var-def
         (variable r3 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c3) (
+              (simple-var-ref $desugar$6)
+              (simple-var-ref $desugar$7)
+              (simple-var-ref $desugar$8)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r3)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$15 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal compression)
-                (literal NEVER))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$15))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$15))) ())
-      (var-def
         (variable c4 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$15))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal compression)
+                  (literal NEVER)))))))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$9 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$17 (expr
+        (variable $desugar$10 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$16))))))
+            (simple-var-ref $desugar$9))))))
       (var-def
-        (variable $desugar$18 (expr
+        (variable $desugar$11 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$19 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c4) (
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17)
-            (simple-var-ref $desugar$18))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$19))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$19))) ())
       (var-def
         (variable r4 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$19))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c4) (
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)
+              (simple-var-ref $desugar$11)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r4)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$20 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal timeout)
-                (literal 15))
-              (key-value
-                (literal httpVersion)
-                (literal 1.1))
-              (key-value
-                (literal compression)
-                (literal NEVER))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
-      (var-def
         (variable c5 (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$20))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal timeout)
+                  (literal 15))
+                (key-value
+                  (literal httpVersion)
+                  (literal 1.1))
+                (key-value
+                  (literal compression)
+                  (literal NEVER)))))))))
       (var-def
-        (variable $desugar$21 (expr
+        (variable $desugar$12 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$22 (expr
+        (variable $desugar$13 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$21))))))
+            (simple-var-ref $desugar$12))))))
       (var-def
-        (variable $desugar$23 (expr
+        (variable $desugar$14 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$24 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c5) (
-            (simple-var-ref $desugar$21)
-            (simple-var-ref $desugar$22)
-            (simple-var-ref $desugar$23))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$24))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$24))) ())
       (var-def
         (variable r5 (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$24))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c5) (
+              (simple-var-ref $desugar$12)
+              (simple-var-ref $desugar$13)
+              (simple-var-ref $desugar$14)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset2/http-client-proxy-v.txt
+++ b/corpus/desugared/library/subset2/http-client-proxy-v.txt
@@ -14,74 +14,50 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (new (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+        (variable _ (type
+          (user-defined-type http Client)) (expr
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
         (variable _ (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal proxy)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal host)
-                    (literal proxy.example.com))
-                  (key-value
-                    (literal port)
-                    (literal 3128))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal proxy)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal host)
+                      (literal proxy.example.com))
+                    (key-value
+                      (literal port)
+                      (literal 3128)))))))))))
       (var-def
         (variable _ (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal proxy)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal host)
-                    (literal proxy.example.com))
-                  (key-value
-                    (literal port)
-                    (literal 3128))
-                  (key-value
-                    (literal userName)
-                    (literal user))
-                  (key-value
-                    (literal password)
-                    (literal secret))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
-        (variable _ (type
-          (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal proxy)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal host)
+                      (literal proxy.example.com))
+                    (key-value
+                      (literal port)
+                      (literal 3128))
+                    (key-value
+                      (literal userName)
+                      (literal user))
+                    (key-value
+                      (literal password)
+                      (literal secret)))))))))))
       (expression-stmt
         (invocation io println (
           (literal ok)))))))

--- a/corpus/desugared/library/subset2/http-client-response-limits-v.txt
+++ b/corpus/desugared/library/subset2/http-client-response-limits-v.txt
@@ -14,93 +14,61 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (new (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+        (variable _ (type
+          (user-defined-type http Client)) (expr
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
         (variable _ (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal responseLimits)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal maxStatusLineLength)
-                    (literal 4096))
-                  (key-value
-                    (literal maxHeaderSize)
-                    (literal 8192))
-                  (key-value
-                    (literal maxEntityBodySize)
-                    (unary-expr -
-                      (literal 1)))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal responseLimits)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal maxStatusLineLength)
+                      (literal 4096))
+                    (key-value
+                      (literal maxHeaderSize)
+                      (literal 8192))
+                    (key-value
+                      (literal maxEntityBodySize)
+                      (unary-expr -
+                        (literal 1))))))))))))
       (var-def
         (variable _ (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal responseLimits)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal maxHeaderSize)
-                    (literal 16384))
-                  (key-value
-                    (literal maxEntityBodySize)
-                    (literal 1000000))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal responseLimits)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal maxHeaderSize)
+                      (literal 16384))
+                    (key-value
+                      (literal maxEntityBodySize)
+                      (literal 1000000)))))))))))
       (var-def
         (variable _ (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (new (
-            (literal https://example.com)
-            (mapping-constructor-expr
-              (key-value
-                (literal responseLimits)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal maxEntityBodySize)
-                    (literal 0))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
-        (variable _ (type
-          (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (new (
+              (literal https://example.com)
+              (mapping-constructor-expr
+                (key-value
+                  (literal responseLimits)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal maxEntityBodySize)
+                      (literal 0)))))))))))
       (var-def
         (variable negStatusLine (type
           (union-type

--- a/corpus/desugared/library/subset2/http-parse-header-v.txt
+++ b/corpus/desugared/library/subset2/http-parse-header-v.txt
@@ -8,35 +8,19 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation http parseHeader (
-            (literal text/plain;q=0.9, application/json))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable values (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation http parseHeader (
+              (literal text/plain;q=0.9, application/json)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (simple-var-ref values))))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation http parseHeader (
-            (literal multipart/form-data; boundary="----boundary"))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable quoted (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation http parseHeader (
+              (literal multipart/form-data; boundary="----boundary")))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
@@ -58,18 +42,10 @@
               (literal params))
             (literal boundary)))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation http parseHeader (
-            (literal multipart/form-data; boundary))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable noVal (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation http parseHeader (
+              (literal multipart/form-data; boundary)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
@@ -84,18 +60,10 @@
               (literal params))
             (literal boundary)))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation http parseHeader (
-            (literal text/html))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable single (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation http parseHeader (
+              (literal text/html)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (

--- a/corpus/desugared/library/subset2/http-request-response-v.txt
+++ b/corpus/desugared/library/subset2/http-request-response-v.txt
@@ -33,19 +33,11 @@
           (simple-var-ref req) (
           (simple-var-ref $desugar$0)
           (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation getTextPayload expr:
-            (simple-var-ref req) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation getTextPayload expr:
+              (simple-var-ref req) ())))))
       (expression-stmt
         (invocation io println (
           (invocation getContentType expr:
@@ -60,36 +52,20 @@
           (simple-var-ref req) (
           (literal X-One)
           (literal v2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation getHeader expr:
-            (simple-var-ref req) (
-            (literal X-One))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation getHeaders expr:
-            (simple-var-ref req) (
-            (literal X-One))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (invocation getHeader expr:
+              (simple-var-ref req) (
+              (literal X-One)))))))
       (var-def
         (variable xs (type
           (array-type
             (value-type string) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation getHeaders expr:
+              (simple-var-ref req) (
+              (literal X-One)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
@@ -104,19 +80,11 @@
           (invocation hasHeader expr:
             (simple-var-ref req) (
             (literal X-Absent))))))
-      (var-def
-        (variable $desugar$5 (expr
+      (expression-stmt
+        (checked-expr
           (invocation setContentType expr:
             (simple-var-ref req) (
-            (literal application/json))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$5))
+            (literal application/json)))))
       (expression-stmt
         (invocation io println (
           (invocation getContentType expr:
@@ -149,67 +117,51 @@
               (literal tag)))
             (value-type null)))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$2 (expr
           (mapping-constructor-expr
             (key-value
               (literal k)
               (literal v))))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$3 (expr
           (invocation $default$11 (
-            (simple-var-ref $desugar$6))))))
+            (simple-var-ref $desugar$2))))))
       (expression-stmt
         (invocation setJsonPayload expr:
           (simple-var-ref req) (
-          (simple-var-ref $desugar$6)
-          (simple-var-ref $desugar$7))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation getJsonPayload expr:
-            (simple-var-ref req) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+          (simple-var-ref $desugar$2)
+          (simple-var-ref $desugar$3))))
       (var-def
         (variable jp (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (invocation getJsonPayload expr:
+              (simple-var-ref req) ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref jp))))
       (var-def
-        (variable $desugar$9 (expr
+        (variable $desugar$4 (expr
           (list-constructor-expr
             (literal 1)
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$5 (expr
           (invocation $default$10 (
-            (simple-var-ref $desugar$9))))))
+            (simple-var-ref $desugar$4))))))
       (expression-stmt
         (invocation setBinaryPayload expr:
           (simple-var-ref req) (
-          (simple-var-ref $desugar$9)
-          (simple-var-ref $desugar$10))))
-      (var-def
-        (variable $desugar$11 (expr
-          (invocation getBinaryPayload expr:
-            (simple-var-ref req) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
+          (simple-var-ref $desugar$4)
+          (simple-var-ref $desugar$5))))
       (var-def
         (variable bp (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$11))))
+          (checked-expr
+            (invocation getBinaryPayload expr:
+              (simple-var-ref req) ())))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
@@ -229,92 +181,76 @@
           (literal X-Resp)
           (literal r1))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$6 (expr
           (literal X-Resp))))
       (var-def
-        (variable $desugar$13 (expr
+        (variable $desugar$7 (expr
           (literal r2))))
       (var-def
-        (variable $desugar$14 (expr
+        (variable $desugar$8 (expr
           (invocation $default$0 (
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7))))))
       (expression-stmt
         (invocation addHeader expr:
           (simple-var-ref res) (
-          (simple-var-ref $desugar$12)
-          (simple-var-ref $desugar$13)
-          (simple-var-ref $desugar$14))))
+          (simple-var-ref $desugar$6)
+          (simple-var-ref $desugar$7)
+          (simple-var-ref $desugar$8))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref res)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$9 (expr
           (literal X-Resp))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$10 (expr
           (invocation $default$4 (
-            (simple-var-ref $desugar$15))))))
+            (simple-var-ref $desugar$9))))))
       (expression-stmt
         (invocation io println (
           (invocation hasHeader expr:
             (simple-var-ref res) (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10))))))
       (var-def
-        (variable $desugar$17 (expr
+        (variable $desugar$11 (expr
           (literal X-Resp))))
       (var-def
-        (variable $desugar$18 (expr
+        (variable $desugar$12 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$17))))))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation getHeader expr:
-            (simple-var-ref res) (
-            (simple-var-ref $desugar$17)
-            (simple-var-ref $desugar$18))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$19))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$19))) ())
+            (simple-var-ref $desugar$11))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$19))))
+          (checked-expr
+            (invocation getHeader expr:
+              (simple-var-ref res) (
+              (simple-var-ref $desugar$11)
+              (simple-var-ref $desugar$12)))))))
       (var-def
-        (variable $desugar$20 (expr
+        (variable $desugar$13 (expr
           (literal X-Resp))))
       (var-def
-        (variable $desugar$21 (expr
+        (variable $desugar$14 (expr
           (invocation $default$3 (
-            (simple-var-ref $desugar$20))))))
-      (var-def
-        (variable $desugar$22 (expr
-          (invocation getHeaders expr:
-            (simple-var-ref res) (
-            (simple-var-ref $desugar$20)
-            (simple-var-ref $desugar$21))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
+            (simple-var-ref $desugar$13))))))
       (var-def
         (variable rs (type
           (array-type
             (value-type string) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$22))))
+          (checked-expr
+            (invocation getHeaders expr:
+              (simple-var-ref res) (
+              (simple-var-ref $desugar$13)
+              (simple-var-ref $desugar$14)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (simple-var-ref rs))))))
       (var-def
-        (variable $desugar$23 (expr
+        (variable $desugar$15 (expr
           (invocation $default$2 ()))))
       (expression-stmt
         (invocation io println (
@@ -322,158 +258,126 @@
             (invocation lang.array length (
               (invocation getHeaderNames expr:
                 (simple-var-ref res) (
-                (simple-var-ref $desugar$23)))))
+                (simple-var-ref $desugar$15)))))
             (literal 1)))))
-      (var-def
-        (variable $desugar$24 (expr
+      (expression-stmt
+        (checked-expr
           (invocation setContentType expr:
             (simple-var-ref res) (
-            (literal text/plain))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$24))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$24))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$24))
+            (literal text/plain)))))
       (expression-stmt
         (invocation io println (
           (invocation getContentType expr:
             (simple-var-ref res) ()))))
       (var-def
-        (variable $desugar$25 (expr
+        (variable $desugar$16 (expr
           (literal resp body))))
       (var-def
-        (variable $desugar$26 (expr
+        (variable $desugar$17 (expr
           (invocation $default$9 (
-            (simple-var-ref $desugar$25))))))
+            (simple-var-ref $desugar$16))))))
       (expression-stmt
         (invocation setTextPayload expr:
           (simple-var-ref res) (
-          (simple-var-ref $desugar$25)
-          (simple-var-ref $desugar$26))))
-      (var-def
-        (variable $desugar$27 (expr
-          (invocation getTextPayload expr:
-            (simple-var-ref res) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$27))) ())
+          (simple-var-ref $desugar$16)
+          (simple-var-ref $desugar$17))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$27))))
+          (checked-expr
+            (invocation getTextPayload expr:
+              (simple-var-ref res) ())))))
       (var-def
-        (variable $desugar$28 (expr
+        (variable $desugar$18 (expr
           (list-constructor-expr
             (literal 1)
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$29 (expr
+        (variable $desugar$19 (expr
           (invocation $default$8 (
-            (simple-var-ref $desugar$28))))))
+            (simple-var-ref $desugar$18))))))
       (expression-stmt
         (invocation setJsonPayload expr:
           (simple-var-ref res) (
-          (simple-var-ref $desugar$28)
-          (simple-var-ref $desugar$29))))
-      (var-def
-        (variable $desugar$30 (expr
-          (invocation getJsonPayload expr:
-            (simple-var-ref res) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$30))) ())
+          (simple-var-ref $desugar$18)
+          (simple-var-ref $desugar$19))))
       (var-def
         (variable rj (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$30))))
+          (checked-expr
+            (invocation getJsonPayload expr:
+              (simple-var-ref res) ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref rj))))
       (var-def
-        (variable $desugar$31 (expr
+        (variable $desugar$20 (expr
           (list-constructor-expr
             (literal 10)
             (literal 20)
             (literal 30)))))
       (var-def
-        (variable $desugar$32 (expr
+        (variable $desugar$21 (expr
           (invocation $default$7 (
-            (simple-var-ref $desugar$31))))))
+            (simple-var-ref $desugar$20))))))
       (expression-stmt
         (invocation setBinaryPayload expr:
           (simple-var-ref res) (
-          (simple-var-ref $desugar$31)
-          (simple-var-ref $desugar$32))))
-      (var-def
-        (variable $desugar$33 (expr
-          (invocation getBinaryPayload expr:
-            (simple-var-ref res) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$33))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$33))) ())
+          (simple-var-ref $desugar$20)
+          (simple-var-ref $desugar$21))))
       (var-def
         (variable rb (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$33))))
+          (checked-expr
+            (invocation getBinaryPayload expr:
+              (simple-var-ref res) ())))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (simple-var-ref rb))))))
       (var-def
-        (variable $desugar$34 (expr
+        (variable $desugar$22 (expr
           (literal X-Resp))))
       (var-def
-        (variable $desugar$35 (expr
+        (variable $desugar$23 (expr
           (invocation $default$6 (
-            (simple-var-ref $desugar$34))))))
+            (simple-var-ref $desugar$22))))))
       (expression-stmt
         (invocation removeHeader expr:
           (simple-var-ref res) (
-          (simple-var-ref $desugar$34)
-          (simple-var-ref $desugar$35))))
+          (simple-var-ref $desugar$22)
+          (simple-var-ref $desugar$23))))
       (var-def
-        (variable $desugar$36 (expr
+        (variable $desugar$24 (expr
           (literal X-Resp))))
       (var-def
-        (variable $desugar$37 (expr
+        (variable $desugar$25 (expr
           (invocation $default$4 (
-            (simple-var-ref $desugar$36))))))
+            (simple-var-ref $desugar$24))))))
       (expression-stmt
         (invocation io println (
           (invocation hasHeader expr:
             (simple-var-ref res) (
-            (simple-var-ref $desugar$36)
-            (simple-var-ref $desugar$37))))))
+            (simple-var-ref $desugar$24)
+            (simple-var-ref $desugar$25))))))
       (var-def
-        (variable $desugar$38 (expr
+        (variable $desugar$26 (expr
           (invocation $default$5 ()))))
       (expression-stmt
         (invocation removeAllHeaders expr:
           (simple-var-ref res) (
-          (simple-var-ref $desugar$38))))
+          (simple-var-ref $desugar$26))))
       (var-def
-        (variable $desugar$39 (expr
+        (variable $desugar$27 (expr
           (literal Content-Type))))
       (var-def
-        (variable $desugar$40 (expr
+        (variable $desugar$28 (expr
           (invocation $default$4 (
-            (simple-var-ref $desugar$39))))))
+            (simple-var-ref $desugar$27))))))
       (expression-stmt
         (invocation io println (
           (invocation hasHeader expr:
             (simple-var-ref res) (
-            (simple-var-ref $desugar$39)
-            (simple-var-ref $desugar$40)))))))))
+            (simple-var-ref $desugar$27)
+            (simple-var-ref $desugar$28)))))))))

--- a/corpus/desugared/library/subset2/io-file-bytes1-v.txt
+++ b/corpus/desugared/library/subset2/io-file-bytes1-v.txt
@@ -31,35 +31,19 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadBytes (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable readBack (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (

--- a/corpus/desugared/library/subset2/io-file-bytes2-v.txt
+++ b/corpus/desugared/library/subset2/io-file-bytes2-v.txt
@@ -24,51 +24,27 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+            (simple-var-ref $desugar$2)))))
       (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref path)
             (list-constructor-expr
               (literal 4)
               (literal 5))
-            (literal APPEND))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$4))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation io fileReadBytes (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+            (literal APPEND)))))
       (var-def
         (variable readBack (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (

--- a/corpus/desugared/library/subset2/io-file-errors-v.txt
+++ b/corpus/desugared/library/subset2/io-file-errors-v.txt
@@ -54,20 +54,12 @@
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
+            (simple-var-ref $desugar$2)))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -79,30 +71,22 @@
           (value-type string)) (expr
           (literal /tmp/bal_io_trailing_json.json))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (simple-var-ref trailingJson))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (literal {"k": 1} extra))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$5 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5))))))
-      (var-def
-        (variable $desugar$7 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
       (expression-stmt
-        (simple-var-ref $desugar$7))
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4)
+            (simple-var-ref $desugar$5)))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is

--- a/corpus/desugared/library/subset2/io-file-json-types-v.txt
+++ b/corpus/desugared/library/subset2/io-file-json-types-v.txt
@@ -9,33 +9,17 @@
         (variable floatPath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_json_float.json))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteJson (
             (simple-var-ref floatPath)
-            (literal 3.14))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation io fileReadJson (
-            (simple-var-ref floatPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+            (literal 3.14)))))
       (var-def
         (variable floatBack (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation io fileReadJson (
+              (simple-var-ref floatPath)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref floatBack))))
@@ -43,33 +27,17 @@
         (variable decimalPath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_json_decimal.json))))
-      (var-def
-        (variable $desugar$2 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteJson (
             (simple-var-ref decimalPath)
-            (literal 2.5))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$2))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation io fileReadJson (
-            (simple-var-ref decimalPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+            (literal 2.5)))))
       (var-def
         (variable decimalBack (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation io fileReadJson (
+              (simple-var-ref decimalPath)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref decimalBack))))
@@ -77,33 +45,17 @@
         (variable intPath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_json_int.json))))
-      (var-def
-        (variable $desugar$4 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteJson (
             (simple-var-ref intPath)
-            (literal 42))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$4))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation io fileReadJson (
-            (simple-var-ref intPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+            (literal 42)))))
       (var-def
         (variable intBack (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation io fileReadJson (
+              (simple-var-ref intPath)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref intBack))))
@@ -120,33 +72,17 @@
             (literal true)
             (literal <nil>)
             (literal x)))))
-      (var-def
-        (variable $desugar$6 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteJson (
             (simple-var-ref arrPath)
-            (simple-var-ref arr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$6))
-      (var-def
-        (variable $desugar$7 (expr
-          (invocation io fileReadJson (
-            (simple-var-ref arrPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
+            (simple-var-ref arr)))))
       (var-def
         (variable arrBack (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation io fileReadJson (
+              (simple-var-ref arrPath)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref arrBack)))))))

--- a/corpus/desugared/library/subset2/io-file-json1-v.txt
+++ b/corpus/desugared/library/subset2/io-file-json1-v.txt
@@ -19,33 +19,17 @@
             (key-value
               (literal age)
               (literal 30))))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteJson (
             (simple-var-ref path)
-            (simple-var-ref data))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation io fileReadJson (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+            (simple-var-ref data)))))
       (var-def
         (variable result (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation io fileReadJson (
+              (simple-var-ref path)))))))
       (var-def
         (variable m (type
           (constrained-type

--- a/corpus/desugared/library/subset2/io-file-json2-v.txt
+++ b/corpus/desugared/library/subset2/io-file-json2-v.txt
@@ -18,33 +18,17 @@
             (literal true)
             (literal hello)
             (literal <nil>)))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteJson (
             (simple-var-ref path)
-            (simple-var-ref data))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation io fileReadJson (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+            (simple-var-ref data)))))
       (var-def
         (variable result (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation io fileReadJson (
+              (simple-var-ref path)))))))
       (var-def
         (variable arr (type
           (array-type

--- a/corpus/desugared/library/subset2/io-file-lines1-v.txt
+++ b/corpus/desugared/library/subset2/io-file-lines1-v.txt
@@ -24,61 +24,45 @@
           (invocation $default$2 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteLines (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadLines (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable lines (type
           (array-type
             (value-type string) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadLines (
+              (simple-var-ref path)))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$3 (expr
           (simple-var-ref lines))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$4 (expr
           (numeric-literal 0))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$5 (expr
           (invocation lang.array length (
-            (simple-var-ref $desugar$5))))))
+            (simple-var-ref $desugar$3))))))
       (while
         (binary-expr <
-          (simple-var-ref $desugar$6)
-          (simple-var-ref $desugar$7))
+          (simple-var-ref $desugar$4)
+          (simple-var-ref $desugar$5))
         (block-stmt
           (var-def
             (variable line (type
               (value-type string)) (expr
               (index-based-access
-                (simple-var-ref $desugar$5)
-                (simple-var-ref $desugar$6)))))
+                (simple-var-ref $desugar$3)
+                (simple-var-ref $desugar$4)))))
           (expression-stmt
             (invocation io println (
               (simple-var-ref line))))
           (assignment
-            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$4)
             (binary-expr +
-              (simple-var-ref $desugar$6)
+              (simple-var-ref $desugar$4)
               (numeric-literal 1))))))))

--- a/corpus/desugared/library/subset2/io-file-lines2-v.txt
+++ b/corpus/desugared/library/subset2/io-file-lines2-v.txt
@@ -23,50 +23,26 @@
           (invocation $default$2 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteLines (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+            (simple-var-ref $desugar$2)))))
       (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
+        (checked-expr
           (invocation io fileWriteLines (
             (simple-var-ref path)
             (list-constructor-expr
               (literal Line3))
-            (literal APPEND))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$4))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation io fileReadLines (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+            (literal APPEND)))))
       (var-def
         (variable lines (type
           (array-type
             (value-type string) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation io fileReadLines (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (

--- a/corpus/desugared/library/subset2/io-file-mkdir-v.txt
+++ b/corpus/desugared/library/subset2/io-file-mkdir-v.txt
@@ -20,250 +20,146 @@
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadString (
-            (simple-var-ref stringPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadString (
+              (simple-var-ref stringPath)))))))
       (var-def
         (variable linesPath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_mkdir_xyz/lines/a/b/lines.txt))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$3 (expr
           (simple-var-ref linesPath))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$4 (expr
           (list-constructor-expr
             (literal one)
             (literal two)))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$5 (expr
           (invocation $default$2 (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6))))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation io fileWriteLines (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
       (expression-stmt
-        (simple-var-ref $desugar$8))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation io fileReadLines (
-            (simple-var-ref linesPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+        (checked-expr
+          (invocation io fileWriteLines (
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4)
+            (simple-var-ref $desugar$5)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation io fileReadLines (
+              (simple-var-ref linesPath)))))))
       (var-def
         (variable bytesPath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_mkdir_xyz/bytes/a/b/bytes.dat))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$6 (expr
           (simple-var-ref bytesPath))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$7 (expr
           (list-constructor-expr
             (literal 1)
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$8 (expr
           (invocation $default$4 (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11))))))
-      (var-def
-        (variable $desugar$13 (expr
-          (invocation io fileWriteBytes (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7))))))
       (expression-stmt
-        (simple-var-ref $desugar$13))
-      (var-def
-        (variable $desugar$14 (expr
-          (invocation io fileReadBytes (
-            (simple-var-ref bytesPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
+        (checked-expr
+          (invocation io fileWriteBytes (
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (simple-var-ref bytesPath)))))))
       (var-def
         (variable jsonPath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_mkdir_xyz/json/a/b/data.json))))
-      (var-def
-        (variable $desugar$15 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteJson (
             (simple-var-ref jsonPath)
             (mapping-constructor-expr
               (key-value
                 (literal k)
-                (literal v))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$15))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$15))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$15))
-      (var-def
-        (variable $desugar$16 (expr
-          (invocation io fileReadJson (
-            (simple-var-ref jsonPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$16))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$16))) ())
+                (literal v)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$16))))
+          (checked-expr
+            (invocation io fileReadJson (
+              (simple-var-ref jsonPath)))))))
       (var-def
         (variable xmlPath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_mkdir_xyz/xml/a/b/data.xml))))
       (var-def
-        (variable $desugar$17 (expr
+        (variable $desugar$9 (expr
           (simple-var-ref xmlPath))))
       (var-def
-        (variable $desugar$18 (expr
+        (variable $desugar$10 (expr
           (xml-element-literal a))))
       (var-def
-        (variable $desugar$19 (expr
+        (variable $desugar$11 (expr
           (invocation $default$6 (
-            (simple-var-ref $desugar$17)
-            (simple-var-ref $desugar$18))))))
-      (var-def
-        (variable $desugar$20 (expr
-          (invocation io fileWriteXml (
-            (simple-var-ref $desugar$17)
-            (simple-var-ref $desugar$18)
-            (simple-var-ref $desugar$19))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10))))))
       (expression-stmt
-        (simple-var-ref $desugar$20))
-      (var-def
-        (variable $desugar$21 (expr
-          (invocation io fileReadXml (
-            (simple-var-ref xmlPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$21))) ())
+        (checked-expr
+          (invocation io fileWriteXml (
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10)
+            (simple-var-ref $desugar$11)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$21))))
+          (checked-expr
+            (invocation io fileReadXml (
+              (simple-var-ref xmlPath)))))))
       (var-def
         (variable appendPath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_mkdir_xyz/append/c/d/append.txt))))
       (var-def
-        (variable $desugar$22 (expr
+        (variable $desugar$12 (expr
           (simple-var-ref appendPath))))
       (var-def
-        (variable $desugar$23 (expr
+        (variable $desugar$13 (expr
           (literal First))))
       (var-def
-        (variable $desugar$24 (expr
+        (variable $desugar$14 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$22)
-            (simple-var-ref $desugar$23))))))
-      (var-def
-        (variable $desugar$25 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$22)
-            (simple-var-ref $desugar$23)
-            (simple-var-ref $desugar$24))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$25))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$25))) ())
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13))))))
       (expression-stmt
-        (simple-var-ref $desugar$25))
-      (var-def
-        (variable $desugar$26 (expr
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13)
+            (simple-var-ref $desugar$14)))))
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref appendPath)
             (literal Second)
-            (literal APPEND))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$26))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$26))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$26))
-      (var-def
-        (variable $desugar$27 (expr
-          (invocation io fileReadString (
-            (simple-var-ref appendPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$27))) ())
+            (literal APPEND)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$27)))))))
+          (checked-expr
+            (invocation io fileReadString (
+              (simple-var-ref appendPath))))))))))

--- a/corpus/desugared/library/subset2/io-file-string1-v.txt
+++ b/corpus/desugared/library/subset2/io-file-string1-v.txt
@@ -21,34 +21,18 @@ World))))
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadString (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable content (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadString (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref content)))))))

--- a/corpus/desugared/library/subset2/io-file-string2-v.txt
+++ b/corpus/desugared/library/subset2/io-file-string2-v.txt
@@ -20,48 +20,24 @@
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+            (simple-var-ref $desugar$2)))))
       (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref path)
             (literal Second)
-            (literal APPEND))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$4))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation io fileReadString (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+            (literal APPEND)))))
       (var-def
         (variable content (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation io fileReadString (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref content)))))))

--- a/corpus/desugared/library/subset2/io-file-xml-extra-v.txt
+++ b/corpus/desugared/library/subset2/io-file-xml-extra-v.txt
@@ -26,34 +26,18 @@
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadXml (
-            (simple-var-ref nsPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable nsResult (type
           (value-type xml)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadXml (
+              (simple-var-ref nsPath)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref nsResult))))
@@ -66,44 +50,28 @@
           (value-type string)) (expr
           (literal <!DOCTYPE note><!-- a comment --><?target data?><a/><b/>))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$3 (expr
           (simple-var-ref multiPath))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$4 (expr
           (simple-var-ref multiContent))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$5 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6))))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
       (expression-stmt
-        (simple-var-ref $desugar$8))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation io fileReadXml (
-            (simple-var-ref multiPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4)
+            (simple-var-ref $desugar$5)))))
       (var-def
         (variable multiResult (type
           (value-type xml)) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation io fileReadXml (
+              (simple-var-ref multiPath)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref multiResult))))
@@ -112,45 +80,29 @@
           (value-type string)) (expr
           (literal /tmp/bal_io_xml_empty.xml))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$6 (expr
           (simple-var-ref emptyPath))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$7 (expr
           (literal    
   ))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$8 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11))))))
-      (var-def
-        (variable $desugar$13 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7))))))
       (expression-stmt
-        (simple-var-ref $desugar$13))
-      (var-def
-        (variable $desugar$14 (expr
-          (invocation io fileReadXml (
-            (simple-var-ref emptyPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8)))))
       (var-def
         (variable emptyResult (type
           (value-type xml)) (expr
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (invocation io fileReadXml (
+              (simple-var-ref emptyPath)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ===
@@ -161,30 +113,22 @@
           (value-type string)) (expr
           (literal /tmp/bal_io_xml_bad.xml))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$9 (expr
           (simple-var-ref badPath))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$10 (expr
           (literal <root><unclosed></root>))))
       (var-def
-        (variable $desugar$17 (expr
+        (variable $desugar$11 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
-      (var-def
-        (variable $desugar$18 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10))))))
       (expression-stmt
-        (simple-var-ref $desugar$18))
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10)
+            (simple-var-ref $desugar$11)))))
       (var-def
         (variable badResult (type
           (union-type
@@ -202,30 +146,22 @@
           (value-type string)) (expr
           (literal /tmp/bal_io_xml_stray.xml))))
       (var-def
-        (variable $desugar$19 (expr
+        (variable $desugar$12 (expr
           (simple-var-ref strayPath))))
       (var-def
-        (variable $desugar$20 (expr
+        (variable $desugar$13 (expr
           (literal </root>))))
       (var-def
-        (variable $desugar$21 (expr
+        (variable $desugar$14 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$19)
-            (simple-var-ref $desugar$20))))))
-      (var-def
-        (variable $desugar$22 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$19)
-            (simple-var-ref $desugar$20)
-            (simple-var-ref $desugar$21))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13))))))
       (expression-stmt
-        (simple-var-ref $desugar$22))
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13)
+            (simple-var-ref $desugar$14)))))
       (var-def
         (variable strayResult (type
           (union-type

--- a/corpus/desugared/library/subset2/io-file-xml1-v.txt
+++ b/corpus/desugared/library/subset2/io-file-xml1-v.txt
@@ -29,34 +29,18 @@
           (invocation $default$6 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteXml (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadXml (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable result (type
           (value-type xml)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadXml (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref result)))))))

--- a/corpus/desugared/library/subset2/io-file-xml2-v.txt
+++ b/corpus/desugared/library/subset2/io-file-xml2-v.txt
@@ -27,34 +27,18 @@
           (invocation $default$6 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteXml (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadXml (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable result (type
           (value-type xml)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadXml (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref result))))
@@ -63,44 +47,28 @@
           (value-type xml)) (expr
           (xml-element-literal updated))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$3 (expr
           (simple-var-ref path))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$4 (expr
           (simple-var-ref data2))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$5 (expr
           (invocation $default$6 (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6))))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation io fileWriteXml (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
       (expression-stmt
-        (simple-var-ref $desugar$8))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation io fileReadXml (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+        (checked-expr
+          (invocation io fileWriteXml (
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4)
+            (simple-var-ref $desugar$5)))))
       (var-def
         (variable result2 (type
           (value-type xml)) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation io fileReadXml (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref result2)))))))

--- a/corpus/desugared/library/subset2/os-env2-v.txt
+++ b/corpus/desugared/library/subset2/os-env2-v.txt
@@ -13,19 +13,11 @@
             (invocation lang.string length (
               (invocation os getUsername ())))
             (literal 0)))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation os setEnv (
             (literal BAL_TEST_LISTENV)
-            (literal present))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))
+            (literal present)))))
       (var-def
         (variable envs (type
           (constrained-type
@@ -43,15 +35,7 @@
       (expression-stmt
         (invocation io println (
           (simple-var-ref v))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation os unsetEnv (
-            (literal BAL_TEST_LISTENV))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
       (expression-stmt
-        (simple-var-ref $desugar$1)))))
+        (checked-expr
+          (invocation os unsetEnv (
+            (literal BAL_TEST_LISTENV))))))))

--- a/corpus/desugared/library/subset2/os-exec-v.txt
+++ b/corpus/desugared/library/subset2/os-exec-v.txt
@@ -8,63 +8,39 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation os exec (
-            (mapping-constructor-expr
-              (key-value
-                (literal value)
-                (literal echo))
-              (key-value
-                (literal arguments)
-                (list-constructor-expr
-                  (literal hello))))
-            (mapping-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable p (type
           (user-defined-type os Process)) (expr
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation waitForExit expr:
-            (simple-var-ref p) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+          (checked-expr
+            (invocation os exec (
+              (mapping-constructor-expr
+                (key-value
+                  (literal value)
+                  (literal echo))
+                (key-value
+                  (literal arguments)
+                  (list-constructor-expr
+                    (literal hello))))
+              (mapping-constructor-expr)))))))
       (var-def
         (variable code (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation waitForExit expr:
+              (simple-var-ref p) ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref code))))
       (var-def
-        (variable $desugar$2 (expr
+        (variable $desugar$0 (expr
           (invocation $default$0 ()))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation output expr:
-            (simple-var-ref p) (
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
       (var-def
         (variable out (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation output expr:
+              (simple-var-ref p) (
+              (simple-var-ref $desugar$0)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr >
@@ -72,57 +48,33 @@
               (simple-var-ref out)))
             (literal 0)))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation os exec (
-            (mapping-constructor-expr
-              (key-value
-                (literal value)
-                (literal echo))
-              (key-value
-                (literal arguments)
-                (list-constructor-expr
-                  (literal world))))
-            (mapping-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable p2 (type
           (user-defined-type os Process)) (expr
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation waitForExit expr:
-            (simple-var-ref p2) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+          (checked-expr
+            (invocation os exec (
+              (mapping-constructor-expr
+                (key-value
+                  (literal value)
+                  (literal echo))
+                (key-value
+                  (literal arguments)
+                  (list-constructor-expr
+                    (literal world))))
+              (mapping-constructor-expr)))))))
       (var-def
         (variable _ (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (invocation output expr:
-            (simple-var-ref p2) (
-            (numeric-literal 2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
+          (checked-expr
+            (invocation waitForExit expr:
+              (simple-var-ref p2) ())))))
       (var-def
         (variable err (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation output expr:
+              (simple-var-ref p2) (
+              (numeric-literal 2)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
@@ -132,113 +84,65 @@
           (value-type string)) (expr
           (literal /tmp/bal_exec_space_test/foo bar))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation os exec (
-            (mapping-constructor-expr
-              (key-value
-                (literal value)
-                (literal mkdir))
-              (key-value
-                (literal arguments)
-                (list-constructor-expr
-                  (literal -p)
-                  (simple-var-ref dirWithSpace))))
-            (mapping-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable mk (type
           (user-defined-type os Process)) (expr
-          (simple-var-ref $desugar$7))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation waitForExit expr:
-            (simple-var-ref mk) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+          (checked-expr
+            (invocation os exec (
+              (mapping-constructor-expr
+                (key-value
+                  (literal value)
+                  (literal mkdir))
+                (key-value
+                  (literal arguments)
+                  (list-constructor-expr
+                    (literal -p)
+                    (simple-var-ref dirWithSpace))))
+              (mapping-constructor-expr)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$8))))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation os exec (
-            (mapping-constructor-expr
-              (key-value
-                (literal value)
-                (literal ls))
-              (key-value
-                (literal arguments)
-                (list-constructor-expr
-                  (simple-var-ref dirWithSpace))))
-            (mapping-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+          (checked-expr
+            (invocation waitForExit expr:
+              (simple-var-ref mk) ())))))
       (var-def
         (variable lsProc (type
           (user-defined-type os Process)) (expr
-          (simple-var-ref $desugar$9))))
-      (var-def
-        (variable $desugar$10 (expr
-          (invocation waitForExit expr:
-            (simple-var-ref lsProc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
+          (checked-expr
+            (invocation os exec (
+              (mapping-constructor-expr
+                (key-value
+                  (literal value)
+                  (literal ls))
+                (key-value
+                  (literal arguments)
+                  (list-constructor-expr
+                    (simple-var-ref dirWithSpace))))
+              (mapping-constructor-expr)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$10))))
-      (var-def
-        (variable $desugar$11 (expr
-          (invocation os exec (
-            (mapping-constructor-expr
-              (key-value
-                (literal value)
-                (literal rm))
-              (key-value
-                (literal arguments)
-                (list-constructor-expr
-                  (literal -rf)
-                  (literal /tmp/bal_exec_space_test))))
-            (mapping-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
+          (checked-expr
+            (invocation waitForExit expr:
+              (simple-var-ref lsProc) ())))))
       (var-def
         (variable rm (type
           (user-defined-type os Process)) (expr
-          (simple-var-ref $desugar$11))))
-      (var-def
-        (variable $desugar$12 (expr
-          (invocation waitForExit expr:
-            (simple-var-ref rm) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$12))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$12))) ())
+          (checked-expr
+            (invocation os exec (
+              (mapping-constructor-expr
+                (key-value
+                  (literal value)
+                  (literal rm))
+                (key-value
+                  (literal arguments)
+                  (list-constructor-expr
+                    (literal -rf)
+                    (literal /tmp/bal_exec_space_test))))
+              (mapping-constructor-expr)))))))
       (var-def
         (variable _ (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$12))))
+          (checked-expr
+            (invocation waitForExit expr:
+              (simple-var-ref rm) ())))))
       (var-def
         (variable bad (type
           (union-type
@@ -256,27 +160,19 @@
             (simple-var-ref bad)
             (user-defined-type os Error)))))
       (var-def
-        (variable $desugar$13 (expr
-          (invocation os exec (
-            (mapping-constructor-expr
-              (key-value
-                (literal value)
-                (literal echo))
-              (key-value
-                (literal arguments)
-                (list-constructor-expr
-                  (literal bye))))
-            (mapping-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
-      (var-def
         (variable p3 (type
           (user-defined-type os Process)) (expr
-          (simple-var-ref $desugar$13))))
+          (checked-expr
+            (invocation os exec (
+              (mapping-constructor-expr
+                (key-value
+                  (literal value)
+                  (literal echo))
+                (key-value
+                  (literal arguments)
+                  (list-constructor-expr
+                    (literal bye))))
+              (mapping-constructor-expr)))))))
       (expression-stmt
         (invocation exit expr:
           (simple-var-ref p3) ()))

--- a/corpus/desugared/library/subset2/os-setenv1-v.txt
+++ b/corpus/desugared/library/subset2/os-setenv1-v.txt
@@ -6,19 +6,11 @@
       (error-type)
       (value-type null)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation os setEnv (
             (literal BAL_TEST_VAR)
-            (literal hello))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))
+            (literal hello)))))
       (var-def
         (variable v (type
           (value-type string)) (expr
@@ -27,15 +19,7 @@
       (expression-stmt
         (invocation io println (
           (simple-var-ref v))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation os unsetEnv (
-            (literal BAL_TEST_VAR))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
       (expression-stmt
-        (simple-var-ref $desugar$1)))))
+        (checked-expr
+          (invocation os unsetEnv (
+            (literal BAL_TEST_VAR))))))))

--- a/corpus/desugared/library/subset2/random-range1-v.txt
+++ b/corpus/desugared/library/subset2/random-range1-v.txt
@@ -7,20 +7,12 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation random createIntInRange (
-            (literal 10)
-            (literal 20))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable n (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation random createIntInRange (
+              (literal 10)
+              (literal 20)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr &&

--- a/corpus/desugared/library/subset2/time-error-cases-v.txt
+++ b/corpus/desugared/library/subset2/time-error-cases-v.txt
@@ -67,85 +67,69 @@
             (simple-var-ref badCivil)
             (error-type)))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation time utcFromCivil (
-            (mapping-constructor-expr
-              (key-value
-                (literal year)
-                (literal 2021))
-              (key-value
-                (literal month)
-                (literal 4))
-              (key-value
-                (literal day)
-                (literal 12))
-              (key-value
-                (literal hour)
-                (literal 23))
-              (key-value
-                (literal minute)
-                (literal 20))
-              (key-value
-                (literal second)
-                (literal 50))
-              (key-value
-                (literal utcOffset)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal hours)
-                    (literal 5))
-                  (key-value
-                    (literal minutes)
-                    (literal 30))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable fromOffset (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation time utcFromCivil (
+              (mapping-constructor-expr
+                (key-value
+                  (literal year)
+                  (literal 2021))
+                (key-value
+                  (literal month)
+                  (literal 4))
+                (key-value
+                  (literal day)
+                  (literal 12))
+                (key-value
+                  (literal hour)
+                  (literal 23))
+                (key-value
+                  (literal minute)
+                  (literal 20))
+                (key-value
+                  (literal second)
+                  (literal 50))
+                (key-value
+                  (literal utcOffset)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal hours)
+                      (literal 5))
+                    (key-value
+                      (literal minutes)
+                      (literal 30)))))))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (
             (simple-var-ref fromOffset))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation time utcFromCivil (
-            (mapping-constructor-expr
-              (key-value
-                (literal year)
-                (literal 2021))
-              (key-value
-                (literal month)
-                (literal 4))
-              (key-value
-                (literal day)
-                (literal 12))
-              (key-value
-                (literal hour)
-                (literal 17))
-              (key-value
-                (literal minute)
-                (literal 50))
-              (key-value
-                (literal second)
-                (literal 50))
-              (key-value
-                (literal timeAbbrev)
-                (literal Z))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable fromZ (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation time utcFromCivil (
+              (mapping-constructor-expr
+                (key-value
+                  (literal year)
+                  (literal 2021))
+                (key-value
+                  (literal month)
+                  (literal 4))
+                (key-value
+                  (literal day)
+                  (literal 12))
+                (key-value
+                  (literal hour)
+                  (literal 17))
+                (key-value
+                  (literal minute)
+                  (literal 50))
+                (key-value
+                  (literal second)
+                  (literal 50))
+                (key-value
+                  (literal timeAbbrev)
+                  (literal Z)))))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (

--- a/corpus/desugared/library/subset2/time-offset-parsing-v.txt
+++ b/corpus/desugared/library/subset2/time-offset-parsing-v.txt
@@ -7,20 +7,12 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new
-            (user-defined-type time TimeZone) (
-            (literal +0530))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable east (type
           (user-defined-type time TimeZone)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new
+              (user-defined-type time TimeZone) (
+              (literal +0530)))))))
       (var-def
         (variable eastOffset (type
           (union-type
@@ -45,20 +37,12 @@
                 (literal minutes)))))) ())
       (block-stmt
         (var-def
-          (variable $desugar$1 (expr
-            (new
-              (user-defined-type time TimeZone) (
-              (literal -0800))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$1))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$1))) ())
-        (var-def
           (variable west (type
             (user-defined-type time TimeZone)) (expr
-            (simple-var-ref $desugar$1))))
+            (checked-expr
+              (new
+                (user-defined-type time TimeZone) (
+                (literal -0800)))))))
         (var-def
           (variable westOffset (type
             (union-type
@@ -248,37 +232,29 @@
                 (simple-var-ref badDate)
                 (error-type)))))
           (var-def
-            (variable $desugar$2 (expr
-              (invocation time civilToString (
-                (mapping-constructor-expr
-                  (key-value
-                    (literal year)
-                    (literal 2021))
-                  (key-value
-                    (literal month)
-                    (literal 4))
-                  (key-value
-                    (literal day)
-                    (literal 12))
-                  (key-value
-                    (literal hour)
-                    (literal 23))
-                  (key-value
-                    (literal minute)
-                    (literal 20))
-                  (key-value
-                    (literal timeAbbrev)
-                    (literal +05:30))))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$2))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$2))) ())
-          (var-def
             (variable noSec (type
               (value-type string)) (expr
-              (simple-var-ref $desugar$2))))
+              (checked-expr
+                (invocation time civilToString (
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal year)
+                      (literal 2021))
+                    (key-value
+                      (literal month)
+                      (literal 4))
+                    (key-value
+                      (literal day)
+                      (literal 12))
+                    (key-value
+                      (literal hour)
+                      (literal 23))
+                    (key-value
+                      (literal minute)
+                      (literal 20))
+                    (key-value
+                      (literal timeAbbrev)
+                      (literal +05:30)))))))))
           (expression-stmt
             (invocation io println (
               (simple-var-ref noSec)))))))))

--- a/corpus/desugared/library/subset2/time-subsecond-v.txt
+++ b/corpus/desugared/library/subset2/time-subsecond-v.txt
@@ -7,157 +7,109 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation time utcFromString (
-            (literal 2024-06-15T10:30:45.123Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable ms (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2024-06-15T10:30:45.123Z)))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (
             (simple-var-ref ms))))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation time utcFromString (
-            (literal 2024-06-15T10:30:45.123456Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable us (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2024-06-15T10:30:45.123456Z)))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (
             (simple-var-ref us))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation time utcFromString (
-            (literal 2024-06-15T10:30:45.123456789Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable ns (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2024-06-15T10:30:45.123456789Z)))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (
             (simple-var-ref ns))))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation time utcFromString (
-            (literal 2024-06-15T10:30:45.5Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable half (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2024-06-15T10:30:45.5Z)))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (
             (simple-var-ref half))))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation time civilToString (
-            (mapping-constructor-expr
-              (key-value
-                (literal year)
-                (literal 2024))
-              (key-value
-                (literal month)
-                (literal 6))
-              (key-value
-                (literal day)
-                (literal 15))
-              (key-value
-                (literal hour)
-                (literal 10))
-              (key-value
-                (literal minute)
-                (literal 30))
-              (key-value
-                (literal second)
-                (literal 45.5))
-              (key-value
-                (literal timeAbbrev)
-                (literal -08:00))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable neg (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation time civilToString (
+              (mapping-constructor-expr
+                (key-value
+                  (literal year)
+                  (literal 2024))
+                (key-value
+                  (literal month)
+                  (literal 6))
+                (key-value
+                  (literal day)
+                  (literal 15))
+                (key-value
+                  (literal hour)
+                  (literal 10))
+                (key-value
+                  (literal minute)
+                  (literal 30))
+                (key-value
+                  (literal second)
+                  (literal 45.5))
+                (key-value
+                  (literal timeAbbrev)
+                  (literal -08:00)))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref neg))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation time utcFromCivil (
-            (mapping-constructor-expr
-              (key-value
-                (literal year)
-                (literal 2024))
-              (key-value
-                (literal month)
-                (literal 6))
-              (key-value
-                (literal day)
-                (literal 15))
-              (key-value
-                (literal hour)
-                (literal 2))
-              (key-value
-                (literal minute)
-                (literal 30))
-              (key-value
-                (literal second)
-                (literal 45))
-              (key-value
-                (literal utcOffset)
-                (mapping-constructor-expr
-                  (key-value
-                    (literal hours)
-                    (unary-expr -
-                      (literal 8)))
-                  (key-value
-                    (literal minutes)
-                    (literal 0))))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable fromNeg (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation time utcFromCivil (
+              (mapping-constructor-expr
+                (key-value
+                  (literal year)
+                  (literal 2024))
+                (key-value
+                  (literal month)
+                  (literal 6))
+                (key-value
+                  (literal day)
+                  (literal 15))
+                (key-value
+                  (literal hour)
+                  (literal 2))
+                (key-value
+                  (literal minute)
+                  (literal 30))
+                (key-value
+                  (literal second)
+                  (literal 45))
+                (key-value
+                  (literal utcOffset)
+                  (mapping-constructor-expr
+                    (key-value
+                      (literal hours)
+                      (unary-expr -
+                        (literal 8)))
+                    (key-value
+                      (literal minutes)
+                      (literal 0)))))))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (

--- a/corpus/desugared/library/subset2/timezone-fixed-offset-v.txt
+++ b/corpus/desugared/library/subset2/timezone-fixed-offset-v.txt
@@ -7,20 +7,12 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new
-            (user-defined-type time TimeZone) (
-            (literal +05:30))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable tz (type
           (user-defined-type time TimeZone)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new
+              (user-defined-type time TimeZone) (
+              (literal +05:30)))))))
       (var-def
         (variable offset (type
           (union-type
@@ -47,19 +39,11 @@
                 (literal minutes)))))) ())
       (block-stmt
         (var-def
-          (variable $desugar$1 (expr
-            (invocation time utcFromString (
-              (literal 2007-12-03T10:15:30.00Z))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$1))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$1))) ())
-        (var-def
           (variable utc (type
             (user-defined-type time Utc)) (expr
-            (simple-var-ref $desugar$1))))
+            (checked-expr
+              (invocation time utcFromString (
+                (literal 2007-12-03T10:15:30.00Z)))))))
         (var-def
           (variable civil (type
             (user-defined-type time Civil)) (expr
@@ -92,43 +76,27 @@
               (simple-var-ref civil)
               (literal minute)))))
         (var-def
-          (variable $desugar$2 (expr
-            (invocation utcFromCivil expr:
-              (simple-var-ref tz) (
-              (simple-var-ref civil))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$2))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$2))) ())
-        (var-def
           (variable utc2 (type
             (user-defined-type time Utc)) (expr
-            (simple-var-ref $desugar$2))))
+            (checked-expr
+              (invocation utcFromCivil expr:
+                (simple-var-ref tz) (
+                (simple-var-ref civil)))))))
         (expression-stmt
           (invocation io println (
             (invocation time utcToString (
               (simple-var-ref utc2))))))
         (var-def
-          (variable $desugar$3 (expr
-            (invocation civilAddDuration expr:
-              (simple-var-ref tz) (
-              (simple-var-ref civil)
-              (mapping-constructor-expr
-                (key-value
-                  (literal hours)
-                  (literal 2))))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$3))) ())
-        (var-def
           (variable civil2 (type
             (user-defined-type time Civil)) (expr
-            (simple-var-ref $desugar$3))))
+            (checked-expr
+              (invocation civilAddDuration expr:
+                (simple-var-ref tz) (
+                (simple-var-ref civil)
+                (mapping-constructor-expr
+                  (key-value
+                    (literal hours)
+                    (literal 2)))))))))
         (expression-stmt
           (invocation io println (
             (index-based-access

--- a/corpus/desugared/library/subset2/timezone-invalid-v.txt
+++ b/corpus/desugared/library/subset2/timezone-invalid-v.txt
@@ -20,20 +20,12 @@
             (simple-var-ref tz)
             (error-type)))))
       (var-def
-        (variable $desugar$0 (expr
-          (new
-            (user-defined-type time TimeZone) (
-            (literal UTC))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable utcZone (type
           (user-defined-type time TimeZone)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new
+              (user-defined-type time TimeZone) (
+              (literal UTC)))))))
       (var-def
         (variable civil (type
           (user-defined-type time Civil)) (expr

--- a/corpus/desugared/library/subset2/timezone-named-v.txt
+++ b/corpus/desugared/library/subset2/timezone-named-v.txt
@@ -7,20 +7,12 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new
-            (user-defined-type time TimeZone) (
-            (literal Asia/Colombo))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable tz (type
           (user-defined-type time TimeZone)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new
+              (user-defined-type time TimeZone) (
+              (literal Asia/Colombo)))))))
       (var-def
         (variable offset (type
           (union-type
@@ -34,19 +26,11 @@
             (simple-var-ref offset)
             (value-type null)))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation time utcFromString (
-            (literal 2007-12-03T10:15:30.00Z))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable utc (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation time utcFromString (
+              (literal 2007-12-03T10:15:30.00Z)))))))
       (var-def
         (variable civil (type
           (user-defined-type time Civil)) (expr
@@ -84,43 +68,27 @@
             (simple-var-ref civil)
             (literal timeAbbrev)))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation utcFromCivil expr:
-            (simple-var-ref tz) (
-            (simple-var-ref civil))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable utc2 (type
           (user-defined-type time Utc)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation utcFromCivil expr:
+              (simple-var-ref tz) (
+              (simple-var-ref civil)))))))
       (expression-stmt
         (invocation io println (
           (invocation time utcToString (
             (simple-var-ref utc2))))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation civilAddDuration expr:
-            (simple-var-ref tz) (
-            (simple-var-ref civil)
-            (mapping-constructor-expr
-              (key-value
-                (literal months)
-                (literal 1))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable civil2 (type
           (user-defined-type time Civil)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation civilAddDuration expr:
+              (simple-var-ref tz) (
+              (simple-var-ref civil)
+              (mapping-constructor-expr
+                (key-value
+                  (literal months)
+                  (literal 1)))))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset2/timezone-utc-v.txt
+++ b/corpus/desugared/library/subset2/timezone-utc-v.txt
@@ -7,20 +7,12 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new
-            (user-defined-type time TimeZone) (
-            (literal UTC))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable utcZone (type
           (user-defined-type time TimeZone)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new
+              (user-defined-type time TimeZone) (
+              (literal UTC)))))))
       (var-def
         (variable offset (type
           (union-type
@@ -47,19 +39,11 @@
                 (literal minutes)))))) ())
       (block-stmt
         (var-def
-          (variable $desugar$1 (expr
-            (invocation time utcFromString (
-              (literal 2007-12-03T10:15:30.00Z))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$1))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$1))) ())
-        (var-def
           (variable utc (type
             (user-defined-type time Utc)) (expr
-            (simple-var-ref $desugar$1))))
+            (checked-expr
+              (invocation time utcFromString (
+                (literal 2007-12-03T10:15:30.00Z)))))))
         (var-def
           (variable civil (type
             (user-defined-type time Civil)) (expr
@@ -92,43 +76,27 @@
               (simple-var-ref civil)
               (literal minute)))))
         (var-def
-          (variable $desugar$2 (expr
-            (invocation utcFromCivil expr:
-              (simple-var-ref utcZone) (
-              (simple-var-ref civil))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$2))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$2))) ())
-        (var-def
           (variable utc2 (type
             (user-defined-type time Utc)) (expr
-            (simple-var-ref $desugar$2))))
+            (checked-expr
+              (invocation utcFromCivil expr:
+                (simple-var-ref utcZone) (
+                (simple-var-ref civil)))))))
         (expression-stmt
           (invocation io println (
             (invocation time utcToString (
               (simple-var-ref utc2))))))
         (var-def
-          (variable $desugar$3 (expr
-            (invocation civilAddDuration expr:
-              (simple-var-ref utcZone) (
-              (simple-var-ref civil)
-              (mapping-constructor-expr
-                (key-value
-                  (literal days)
-                  (literal 1))))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$3))) ())
-        (var-def
           (variable civil2 (type
             (user-defined-type time Civil)) (expr
-            (simple-var-ref $desugar$3))))
+            (checked-expr
+              (invocation civilAddDuration expr:
+                (simple-var-ref utcZone) (
+                (simple-var-ref civil)
+                (mapping-constructor-expr
+                  (key-value
+                    (literal days)
+                    (literal 1)))))))))
         (expression-stmt
           (invocation io println (
             (index-based-access

--- a/corpus/desugared/library/subset2/url-charset-ascii-v.txt
+++ b/corpus/desugared/library/subset2/url-charset-ascii-v.txt
@@ -6,48 +6,24 @@
       (error-type)
       (value-type null)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation url encode (
-            (literal hello world)
-            (literal US-ASCII))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation url decode (
-            (literal hello%20world)
-            (literal US-ASCII))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal hello world)
+              (literal US-ASCII)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation url encode (
-            (literal a=b)
-            (literal ASCII))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal hello%20world)
+              (literal US-ASCII)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation url encode (
+              (literal a=b)
+              (literal ASCII)))))))
       (var-def
         (variable enc (type
           (union-type
@@ -74,97 +50,49 @@
           (type-test-expr is
             (simple-var-ref dec)
             (error-type)))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation url encode (
-            (literal a b)
-            (literal UTF8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation url encode (
-            (literal café)
-            (literal LATIN-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal a b)
+              (literal UTF8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation url encode (
+              (literal café)
+              (literal LATIN-1)))))))
       (var-def
         (variable original (type
           (value-type string)) (expr
           (literal Hi))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation url encode (
-            (simple-var-ref original)
-            (literal UTF-16))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable utf16 (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (invocation url decode (
-            (simple-var-ref utf16)
-            (literal UTF-16))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
+          (checked-expr
+            (invocation url encode (
+              (simple-var-ref original)
+              (literal UTF-16)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$6)
+            (checked-expr
+              (invocation url decode (
+                (simple-var-ref utf16)
+                (literal UTF-16))))
             (simple-var-ref original)))))
-      (var-def
-        (variable $desugar$7 (expr
-          (invocation url encode (
-            (simple-var-ref original)
-            (literal UTF-16LE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
       (var-def
         (variable utf16le (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$7))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation url decode (
-            (simple-var-ref utf16le)
-            (literal UTF-16LE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+          (checked-expr
+            (invocation url encode (
+              (simple-var-ref original)
+              (literal UTF-16LE)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==
-            (simple-var-ref $desugar$8)
+            (checked-expr
+              (invocation url decode (
+                (simple-var-ref utf16le)
+                (literal UTF-16LE))))
             (simple-var-ref original))))))))

--- a/corpus/desugared/library/subset2/url-charset-iso8859-v.txt
+++ b/corpus/desugared/library/subset2/url-charset-iso8859-v.txt
@@ -6,138 +6,66 @@
       (error-type)
       (value-type null)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation url encode (
-            (literal hello)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation url encode (
-            (literal hello world)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal hello)
+              (literal ISO-8859-1)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation url encode (
-            (literal café)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal hello world)
+              (literal ISO-8859-1)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation url encode (
-            (literal résumé)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal café)
+              (literal ISO-8859-1)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation url decode (
-            (literal caf%E9)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal résumé)
+              (literal ISO-8859-1)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation url decode (
-            (literal r%E9sum%E9)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal caf%E9)
+              (literal ISO-8859-1)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (invocation url decode (
-            (literal hello%20world)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal r%E9sum%E9)
+              (literal ISO-8859-1)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation url decode (
+              (literal hello%20world)
+              (literal ISO-8859-1)))))))
       (var-def
         (variable original (type
           (value-type string)) (expr
           (literal naïve))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation url encode (
-            (simple-var-ref original)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable encoded (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$7))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation url decode (
-            (simple-var-ref encoded)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+          (checked-expr
+            (invocation url encode (
+              (simple-var-ref original)
+              (literal ISO-8859-1)))))))
       (var-def
         (variable decoded (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (invocation url decode (
+              (simple-var-ref encoded)
+              (literal ISO-8859-1)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==

--- a/corpus/desugared/library/subset2/url-charset-utf16be-v.txt
+++ b/corpus/desugared/library/subset2/url-charset-utf16be-v.txt
@@ -6,96 +6,48 @@
       (error-type)
       (value-type null)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation url encode (
-            (literal AB)
-            (literal UTF-16BE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation url encode (
-            (literal hi)
-            (literal UTF-16BE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal AB)
+              (literal UTF-16BE)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation url decode (
-            (literal %00A%00B)
-            (literal UTF-16BE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal hi)
+              (literal UTF-16BE)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation url decode (
-            (literal %00h%00i)
-            (literal UTF-16BE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal %00A%00B)
+              (literal UTF-16BE)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation url decode (
+              (literal %00h%00i)
+              (literal UTF-16BE)))))))
       (var-def
         (variable original (type
           (value-type string)) (expr
           (literal Go))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation url encode (
-            (simple-var-ref original)
-            (literal UTF-16BE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable encoded (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation url decode (
-            (simple-var-ref encoded)
-            (literal UTF-16BE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+          (checked-expr
+            (invocation url encode (
+              (simple-var-ref original)
+              (literal UTF-16BE)))))))
       (var-def
         (variable decoded (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation url decode (
+              (simple-var-ref encoded)
+              (literal UTF-16BE)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==

--- a/corpus/desugared/library/subset2/url-decode-errors-v.txt
+++ b/corpus/desugared/library/subset2/url-decode-errors-v.txt
@@ -32,48 +32,24 @@
           (type-test-expr is
             (simple-var-ref badUtf8)
             (error-type)))))
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation url decode (
-            (literal a%)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation url decode (
-            (literal %2a%2b)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal a%)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation url decode (
-            (literal café)
-            (literal ISO-8859-1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal %2a%2b)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation url decode (
+              (literal café)
+              (literal ISO-8859-1)))))))
       (var-def
         (variable flushErr (type
           (union-type

--- a/corpus/desugared/library/subset2/url-decode-v.txt
+++ b/corpus/desugared/library/subset2/url-decode-v.txt
@@ -7,76 +7,36 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation url decode (
-            (literal param1%3Dhttp%3A%2F%2Fxyz.com%2F%3Fa%3D12%26b%3D55)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable decoded (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation url decode (
+              (literal param1%3Dhttp%3A%2F%2Fxyz.com%2F%3Fa%3D12%26b%3D55)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref decoded))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation url decode (
-            (literal hello%20world)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation url decode (
-            (literal hello+world)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal hello%20world)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation url decode (
-            (literal a%2Ab)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal hello+world)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation url decode (
-            (literal a%7Eb)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (invocation url decode (
+              (literal a%2Ab)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$4)))))))
+          (checked-expr
+            (invocation url decode (
+              (literal a%7Eb)
+              (literal UTF-8))))))))))

--- a/corpus/desugared/library/subset2/url-encode-v.txt
+++ b/corpus/desugared/library/subset2/url-encode-v.txt
@@ -7,76 +7,36 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation url encode (
-            (literal param1=http://xyz.com/?a=12&b=55)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable encoded (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation url encode (
+              (literal param1=http://xyz.com/?a=12&b=55)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref encoded))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation url encode (
-            (literal hello world)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation url encode (
-            (literal a*b)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal hello world)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation url encode (
-            (literal a~b)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal a*b)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation url encode (
-            (literal a.b-c_d)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (invocation url encode (
+              (literal a~b)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$4)))))))
+          (checked-expr
+            (invocation url encode (
+              (literal a.b-c_d)
+              (literal UTF-8))))))))))

--- a/corpus/desugared/library/subset2/url-roundtrip-v.txt
+++ b/corpus/desugared/library/subset2/url-roundtrip-v.txt
@@ -11,35 +11,19 @@
           (value-type string)) (expr
           (literal param1=http://xyz.com/?a=12&b=55&param2=99))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation url encode (
-            (simple-var-ref original)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable encoded (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation url decode (
-            (simple-var-ref encoded)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+          (checked-expr
+            (invocation url encode (
+              (simple-var-ref original)
+              (literal UTF-8)))))))
       (var-def
         (variable decoded (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation url decode (
+              (simple-var-ref encoded)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
           (binary-expr ==

--- a/corpus/desugared/library/subset3/http-client-databind-methods-v.txt
+++ b/corpus/desugared/library/subset3/http-client-databind-methods-v.txt
@@ -15,264 +15,208 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (new (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable c (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (literal req))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (invocation $default$26 (
+            (simple-var-ref $desugar$2)
+            (simple-var-ref $desugar$3))))))
+      (var-def
+        (variable $desugar$5 (expr
+          (invocation $default$27 (
+            (simple-var-ref $desugar$2)
             (simple-var-ref $desugar$3)
             (simple-var-ref $desugar$4))))))
       (var-def
         (variable $desugar$6 (expr
-          (invocation $default$27 (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5))))))
-      (var-def
-        (variable $desugar$7 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$8 (expr
-          (remote-method-call post expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
       (var-def
         (variable postBody (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (remote-method-call post expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$2)
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)
+              (simple-var-ref $desugar$5)
+              (simple-var-ref $desugar$6)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref postBody))))
       (var-def
-        (variable $desugar$9 (expr
+        (variable $desugar$7 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$8 (expr
           (literal req))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$9 (expr
           (invocation $default$28 (
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$10))))))
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8))))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$10 (expr
           (invocation $default$29 (
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11))))))
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8)
+            (simple-var-ref $desugar$9))))))
       (var-def
-        (variable $desugar$13 (expr
+        (variable $desugar$11 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$14 (expr
-          (remote-method-call put expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
       (var-def
         (variable putBody (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (remote-method-call put expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$7)
+              (simple-var-ref $desugar$8)
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)
+              (simple-var-ref $desugar$11)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref putBody))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$12 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$13 (expr
           (literal req))))
       (var-def
-        (variable $desugar$17 (expr
+        (variable $desugar$14 (expr
           (invocation $default$24 (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13))))))
       (var-def
-        (variable $desugar$18 (expr
+        (variable $desugar$15 (expr
           (invocation $default$25 (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17))))))
+            (simple-var-ref $desugar$12)
+            (simple-var-ref $desugar$13)
+            (simple-var-ref $desugar$14))))))
       (var-def
-        (variable $desugar$19 (expr
+        (variable $desugar$16 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$20 (expr
-          (remote-method-call patch expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17)
-            (simple-var-ref $desugar$18)
-            (simple-var-ref $desugar$19))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
       (var-def
         (variable patchBody (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$20))))
+          (checked-expr
+            (remote-method-call patch expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$12)
+              (simple-var-ref $desugar$13)
+              (simple-var-ref $desugar$14)
+              (simple-var-ref $desugar$15)
+              (simple-var-ref $desugar$16)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref patchBody))))
       (var-def
-        (variable $desugar$21 (expr
+        (variable $desugar$17 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$22 (expr
+        (variable $desugar$18 (expr
           (invocation $default$16 (
-            (simple-var-ref $desugar$21))))))
+            (simple-var-ref $desugar$17))))))
       (var-def
-        (variable $desugar$23 (expr
+        (variable $desugar$19 (expr
           (invocation $default$17 (
-            (simple-var-ref $desugar$21)
-            (simple-var-ref $desugar$22))))))
+            (simple-var-ref $desugar$17)
+            (simple-var-ref $desugar$18))))))
       (var-def
-        (variable $desugar$24 (expr
+        (variable $desugar$20 (expr
           (invocation $default$18 (
-            (simple-var-ref $desugar$21)
-            (simple-var-ref $desugar$22)
-            (simple-var-ref $desugar$23))))))
+            (simple-var-ref $desugar$17)
+            (simple-var-ref $desugar$18)
+            (simple-var-ref $desugar$19))))))
       (var-def
-        (variable $desugar$25 (expr
+        (variable $desugar$21 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$26 (expr
-          (remote-method-call delete expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$21)
-            (simple-var-ref $desugar$22)
-            (simple-var-ref $desugar$23)
-            (simple-var-ref $desugar$24)
-            (simple-var-ref $desugar$25))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$26))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$26))) ())
       (var-def
         (variable deleteBody (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$26))))
+          (checked-expr
+            (remote-method-call delete expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$17)
+              (simple-var-ref $desugar$18)
+              (simple-var-ref $desugar$19)
+              (simple-var-ref $desugar$20)
+              (simple-var-ref $desugar$21)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref deleteBody))))
       (var-def
-        (variable $desugar$27 (expr
+        (variable $desugar$22 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$28 (expr
+        (variable $desugar$23 (expr
           (invocation $default$23 (
-            (simple-var-ref $desugar$27))))))
+            (simple-var-ref $desugar$22))))))
       (var-def
-        (variable $desugar$29 (expr
+        (variable $desugar$24 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$30 (expr
-          (remote-method-call options expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$27)
-            (simple-var-ref $desugar$28)
-            (simple-var-ref $desugar$29))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$30))) ())
       (var-def
         (variable optionsBody (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$30))))
+          (checked-expr
+            (remote-method-call options expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$22)
+              (simple-var-ref $desugar$23)
+              (simple-var-ref $desugar$24)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref optionsBody))))
       (var-def
-        (variable $desugar$31 (expr
+        (variable $desugar$25 (expr
           (literal PATCH))))
       (var-def
-        (variable $desugar$32 (expr
+        (variable $desugar$26 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$33 (expr
+        (variable $desugar$27 (expr
           (literal req))))
       (var-def
-        (variable $desugar$34 (expr
+        (variable $desugar$28 (expr
           (invocation $default$19 (
-            (simple-var-ref $desugar$31)
-            (simple-var-ref $desugar$32)
-            (simple-var-ref $desugar$33))))))
+            (simple-var-ref $desugar$25)
+            (simple-var-ref $desugar$26)
+            (simple-var-ref $desugar$27))))))
       (var-def
-        (variable $desugar$35 (expr
+        (variable $desugar$29 (expr
           (invocation $default$20 (
-            (simple-var-ref $desugar$31)
-            (simple-var-ref $desugar$32)
-            (simple-var-ref $desugar$33)
-            (simple-var-ref $desugar$34))))))
+            (simple-var-ref $desugar$25)
+            (simple-var-ref $desugar$26)
+            (simple-var-ref $desugar$27)
+            (simple-var-ref $desugar$28))))))
       (var-def
-        (variable $desugar$36 (expr
+        (variable $desugar$30 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$37 (expr
-          (remote-method-call execute expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$31)
-            (simple-var-ref $desugar$32)
-            (simple-var-ref $desugar$33)
-            (simple-var-ref $desugar$34)
-            (simple-var-ref $desugar$35)
-            (simple-var-ref $desugar$36))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$37))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$37))) ())
       (var-def
         (variable execBody (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$37))))
+          (checked-expr
+            (remote-method-call execute expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$25)
+              (simple-var-ref $desugar$26)
+              (simple-var-ref $desugar$27)
+              (simple-var-ref $desugar$28)
+              (simple-var-ref $desugar$29)
+              (simple-var-ref $desugar$30)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref execBody))))
@@ -281,88 +225,64 @@
           (user-defined-type http Request)) (expr
           (new ()))))
       (var-def
-        (variable $desugar$38 (expr
+        (variable $desugar$31 (expr
           (literal fwd))))
       (var-def
-        (variable $desugar$39 (expr
+        (variable $desugar$32 (expr
           (invocation $default$12 (
-            (simple-var-ref $desugar$38))))))
+            (simple-var-ref $desugar$31))))))
       (expression-stmt
         (invocation setTextPayload expr:
           (simple-var-ref req) (
-          (simple-var-ref $desugar$38)
-          (simple-var-ref $desugar$39))))
-      (var-def
-        (variable $desugar$40 (expr
-          (remote-method-call forward expr:
-            (simple-var-ref c) (
-            (literal /path)
-            (simple-var-ref req)
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$40))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$40))) ())
+          (simple-var-ref $desugar$31)
+          (simple-var-ref $desugar$32))))
       (var-def
         (variable forwardBody (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$40))))
+          (checked-expr
+            (remote-method-call forward expr:
+              (simple-var-ref c) (
+              (literal /path)
+              (simple-var-ref req)
+              (typedesc-expr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref forwardBody))))
       (var-def
-        (variable $desugar$41 (expr
+        (variable $desugar$33 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$42 (expr
+        (variable $desugar$34 (expr
           (invocation $default$22 (
-            (simple-var-ref $desugar$41))))))
-      (var-def
-        (variable $desugar$43 (expr
-          (remote-method-call head expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$41)
-            (simple-var-ref $desugar$42))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$43))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$43))) ())
+            (simple-var-ref $desugar$33))))))
       (var-def
         (variable headResp (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$43))))
+          (checked-expr
+            (remote-method-call head expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$33)
+              (simple-var-ref $desugar$34)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref headResp)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$44 (expr
-          (remote-method-call post expr:
-            (simple-var-ref c) (
-            (literal /path)
-            (literal req)
-            (mapping-constructor-expr
-              (key-value
-                (literal X-Custom)
-                (literal value)))
-            (literal text/plain)
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$44))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$44))) ())
-      (var-def
         (variable withHeaders (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$44))))
+          (checked-expr
+            (remote-method-call post expr:
+              (simple-var-ref c) (
+              (literal /path)
+              (literal req)
+              (mapping-constructor-expr
+                (key-value
+                  (literal X-Custom)
+                  (literal value)))
+              (literal text/plain)
+              (typedesc-expr)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (

--- a/corpus/desugared/library/subset3/http-client-databind-v.txt
+++ b/corpus/desugared/library/subset3/http-client-databind-v.txt
@@ -21,86 +21,84 @@
           (invocation $default$15 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (new (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable c (type
           (user-defined-type http Client)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$2 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$4 (expr
+        (variable $desugar$3 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$3))))))
+            (simple-var-ref $desugar$2))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$4 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$6 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4)
-            (simple-var-ref $desugar$5))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
       (var-def
         (variable r (type
           (user-defined-type http Response)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$2)
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
             (simple-var-ref r)
             (literal statusCode)))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$5 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$6 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$7))))))
+            (simple-var-ref $desugar$5))))))
       (var-def
-        (variable $desugar$9 (expr
+        (variable $desugar$7 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$10 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8)
-            (simple-var-ref $desugar$9))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
       (var-def
         (variable ru (type
           (union-type
             (user-defined-type http Response)
             (value-type string))) (expr
-          (simple-var-ref $desugar$10))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$5)
+              (simple-var-ref $desugar$6)
+              (simple-var-ref $desugar$7)))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref ru)
             (value-type string)))))
+      (var-def
+        (variable $desugar$8 (expr
+          (literal /path))))
+      (var-def
+        (variable $desugar$9 (expr
+          (invocation $default$21 (
+            (simple-var-ref $desugar$8))))))
+      (var-def
+        (variable $desugar$10 (expr
+          (typedesc-expr))))
+      (var-def
+        (variable text (type
+          (value-type string)) (expr
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$8)
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref text))))
       (var-def
         (variable $desugar$11 (expr
           (literal /path))))
@@ -112,89 +110,93 @@
         (variable $desugar$13 (expr
           (typedesc-expr))))
       (var-def
-        (variable $desugar$14 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
-      (var-def
-        (variable text (type
-          (value-type string)) (expr
-          (simple-var-ref $desugar$14))))
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref text))))
-      (var-def
-        (variable $desugar$15 (expr
-          (literal /path))))
-      (var-def
-        (variable $desugar$16 (expr
-          (invocation $default$21 (
-            (simple-var-ref $desugar$15))))))
-      (var-def
-        (variable $desugar$17 (expr
-          (typedesc-expr))))
-      (var-def
-        (variable $desugar$18 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
-      (var-def
         (variable optText (type
           (union-type
             (value-type string)
             (value-type null))) (expr
-          (simple-var-ref $desugar$18))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$11)
+              (simple-var-ref $desugar$12)
+              (simple-var-ref $desugar$13)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref optText))))
       (var-def
-        (variable $desugar$19 (expr
+        (variable $desugar$14 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$20 (expr
+        (variable $desugar$15 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$19))))))
+            (simple-var-ref $desugar$14))))))
       (var-def
-        (variable $desugar$21 (expr
+        (variable $desugar$16 (expr
           (typedesc-expr))))
-      (var-def
-        (variable $desugar$22 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$19)
-            (simple-var-ref $desugar$20)
-            (simple-var-ref $desugar$21))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
       (var-def
         (variable bytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$22))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$14)
+              (simple-var-ref $desugar$15)
+              (simple-var-ref $desugar$16)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (simple-var-ref bytes))))))
+      (var-def
+        (variable $desugar$17 (expr
+          (literal /path))))
+      (var-def
+        (variable $desugar$18 (expr
+          (invocation $default$21 (
+            (simple-var-ref $desugar$17))))))
+      (var-def
+        (variable $desugar$19 (expr
+          (typedesc-expr))))
+      (var-def
+        (variable optBytes (type
+          (union-type
+            (array-type
+              (value-type byte) dimensions: 1 ([]))
+            (value-type null))) (expr
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$17)
+              (simple-var-ref $desugar$18)
+              (simple-var-ref $desugar$19)))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref optBytes)
+            (array-type
+              (value-type byte) dimensions: 1 ([]))))))
+      (var-def
+        (variable $desugar$20 (expr
+          (literal /path))))
+      (var-def
+        (variable $desugar$21 (expr
+          (invocation $default$21 (
+            (simple-var-ref $desugar$20))))))
+      (var-def
+        (variable $desugar$22 (expr
+          (typedesc-expr))))
+      (var-def
+        (variable nothing (type
+          (value-type null)) (expr
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$20)
+              (simple-var-ref $desugar$21)
+              (simple-var-ref $desugar$22)))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref nothing))))
       (var-def
         (variable $desugar$23 (expr
           (literal /path))))
@@ -204,102 +206,28 @@
             (simple-var-ref $desugar$23))))))
       (var-def
         (variable $desugar$25 (expr
-          (typedesc-expr))))
-      (var-def
-        (variable $desugar$26 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$23)
-            (simple-var-ref $desugar$24)
-            (simple-var-ref $desugar$25))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$26))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$26))) ())
-      (var-def
-        (variable optBytes (type
-          (union-type
-            (array-type
-              (value-type byte) dimensions: 1 ([]))
-            (value-type null))) (expr
-          (simple-var-ref $desugar$26))))
-      (expression-stmt
-        (invocation io println (
-          (type-test-expr is
-            (simple-var-ref optBytes)
-            (array-type
-              (value-type byte) dimensions: 1 ([]))))))
-      (var-def
-        (variable $desugar$27 (expr
-          (literal /path))))
-      (var-def
-        (variable $desugar$28 (expr
-          (invocation $default$21 (
-            (simple-var-ref $desugar$27))))))
-      (var-def
-        (variable $desugar$29 (expr
-          (typedesc-expr))))
-      (var-def
-        (variable $desugar$30 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$27)
-            (simple-var-ref $desugar$28)
-            (simple-var-ref $desugar$29))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$30))) ())
-      (var-def
-        (variable nothing (type
-          (value-type null)) (expr
-          (simple-var-ref $desugar$30))))
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref nothing))))
-      (var-def
-        (variable $desugar$31 (expr
-          (literal /path))))
-      (var-def
-        (variable $desugar$32 (expr
-          (invocation $default$21 (
-            (simple-var-ref $desugar$31))))))
-      (var-def
-        (variable $desugar$33 (expr
           (typedesc-expr
             (value-type string)))))
       (var-def
-        (variable $desugar$34 (expr
-          (remote-method-call get expr:
-            (simple-var-ref c) (
-            (simple-var-ref $desugar$31)
-            (simple-var-ref $desugar$32)
-            (simple-var-ref $desugar$33))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$34))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$34))) ())
-      (var-def
         (variable explicitText (expr
-          (simple-var-ref $desugar$34))))
+          (checked-expr
+            (remote-method-call get expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$23)
+              (simple-var-ref $desugar$24)
+              (simple-var-ref $desugar$25)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref explicitText))))
       (var-def
-        (variable $desugar$35 (expr
+        (variable $desugar$26 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$36 (expr
+        (variable $desugar$27 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$35))))))
+            (simple-var-ref $desugar$26))))))
       (var-def
-        (variable $desugar$37 (expr
+        (variable $desugar$28 (expr
           (typedesc-expr))))
       (var-def
         (variable person (type
@@ -308,23 +236,23 @@
             (error-type))) (expr
           (remote-method-call get expr:
             (simple-var-ref c) (
-            (simple-var-ref $desugar$35)
-            (simple-var-ref $desugar$36)
-            (simple-var-ref $desugar$37))))))
+            (simple-var-ref $desugar$26)
+            (simple-var-ref $desugar$27)
+            (simple-var-ref $desugar$28))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
             (simple-var-ref person)
             (error-type)))))
       (var-def
-        (variable $desugar$38 (expr
+        (variable $desugar$29 (expr
           (literal /path))))
       (var-def
-        (variable $desugar$39 (expr
+        (variable $desugar$30 (expr
           (invocation $default$21 (
-            (simple-var-ref $desugar$38))))))
+            (simple-var-ref $desugar$29))))))
       (var-def
-        (variable $desugar$40 (expr
+        (variable $desugar$31 (expr
           (typedesc-expr))))
       (var-def
         (variable asXml (type
@@ -333,9 +261,9 @@
             (error-type))) (expr
           (remote-method-call get expr:
             (simple-var-ref c) (
-            (simple-var-ref $desugar$38)
-            (simple-var-ref $desugar$39)
-            (simple-var-ref $desugar$40))))))
+            (simple-var-ref $desugar$29)
+            (simple-var-ref $desugar$30)
+            (simple-var-ref $desugar$31))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is

--- a/corpus/desugared/library/subset3/io-byte-channel-base64-p.txt
+++ b/corpus/desugared/library/subset3/io-byte-channel-base64-p.txt
@@ -6,49 +6,25 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation io createReadableChannel (
-            (list-constructor-expr
-              (literal 33)
-              (literal 64)
-              (literal 35)
-              (literal 36)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable bad (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation base64Decode expr:
-            (simple-var-ref bad) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+          (checked-expr
+            (invocation io createReadableChannel (
+              (list-constructor-expr
+                (literal 33)
+                (literal 64)
+                (literal 35)
+                (literal 36))))))))
       (var-def
         (variable dec (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation readAll expr:
-            (simple-var-ref dec) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (invocation base64Decode expr:
+              (simple-var-ref bad) ())))))
       (var-def
         (variable _ (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$2)))))))
+          (checked-expr
+            (invocation readAll expr:
+              (simple-var-ref dec) ()))))))))

--- a/corpus/desugared/library/subset3/io-byte-channel-base64-v.txt
+++ b/corpus/desugared/library/subset3/io-byte-channel-base64-v.txt
@@ -8,341 +8,165 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation io createReadableChannel (
-            (list-constructor-expr
-              (literal 72)
-              (literal 105)
-              (literal 33)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable src (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation base64Encode expr:
-            (simple-var-ref src) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
+          (checked-expr
+            (invocation io createReadableChannel (
+              (list-constructor-expr
+                (literal 72)
+                (literal 105)
+                (literal 33))))))))
       (var-def
         (variable enc (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation readAll expr:
-            (simple-var-ref enc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+          (checked-expr
+            (invocation base64Encode expr:
+              (simple-var-ref src) ())))))
       (var-def
         (variable encBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation string fromBytes (
-            (simple-var-ref encBytes))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+          (checked-expr
+            (invocation readAll expr:
+              (simple-var-ref enc) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io createReadableChannel (
-            (simple-var-ref encBytes))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (invocation string fromBytes (
+              (simple-var-ref encBytes)))))))
       (var-def
         (variable back (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation base64Decode expr:
-            (simple-var-ref back) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+          (checked-expr
+            (invocation io createReadableChannel (
+              (simple-var-ref encBytes)))))))
       (var-def
         (variable dec (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (invocation readAll expr:
-            (simple-var-ref dec) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
+          (checked-expr
+            (invocation base64Decode expr:
+              (simple-var-ref back) ())))))
       (var-def
         (variable decBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$6))))
-      (var-def
-        (variable $desugar$7 (expr
-          (invocation string fromBytes (
-            (simple-var-ref decBytes))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
+          (checked-expr
+            (invocation readAll expr:
+              (simple-var-ref dec) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$7))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation base64Encode expr:
-            (simple-var-ref src) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+          (checked-expr
+            (invocation string fromBytes (
+              (simple-var-ref decBytes)))))))
       (var-def
         (variable drainedEnc (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$8))))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation readAll expr:
-            (simple-var-ref drainedEnc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+          (checked-expr
+            (invocation base64Encode expr:
+              (simple-var-ref src) ())))))
       (var-def
         (variable emptyBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation readAll expr:
+              (simple-var-ref drainedEnc) ())))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (simple-var-ref emptyBytes))))))
       (var-def
-        (variable $desugar$10 (expr
-          (invocation io createReadableChannel (
-            (list-constructor-expr
-              (literal 83)
-              (literal 71)
-              (literal 107)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
-      (var-def
         (variable unpadded (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$10))))
-      (var-def
-        (variable $desugar$11 (expr
-          (invocation base64Decode expr:
-            (simple-var-ref unpadded) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
+          (checked-expr
+            (invocation io createReadableChannel (
+              (list-constructor-expr
+                (literal 83)
+                (literal 71)
+                (literal 107))))))))
       (var-def
         (variable dec2 (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$11))))
-      (var-def
-        (variable $desugar$12 (expr
-          (invocation readAll expr:
-            (simple-var-ref dec2) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$12))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$12))) ())
+          (checked-expr
+            (invocation base64Decode expr:
+              (simple-var-ref unpadded) ())))))
       (var-def
         (variable unpaddedBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$12))))
-      (var-def
-        (variable $desugar$13 (expr
-          (invocation string fromBytes (
-            (simple-var-ref unpaddedBytes))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
+          (checked-expr
+            (invocation readAll expr:
+              (simple-var-ref dec2) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$13))))
+          (checked-expr
+            (invocation string fromBytes (
+              (simple-var-ref unpaddedBytes)))))))
       (var-def
         (variable path (type
           (value-type string)) (expr
           (literal /tmp/bal_io_byte_channel_base64.bin))))
       (var-def
-        (variable $desugar$14 (expr
+        (variable $desugar$0 (expr
           (simple-var-ref path))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$1 (expr
           (list-constructor-expr
             (literal 72)
             (literal 105)
             (literal 33)))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$2 (expr
           (invocation $default$4 (
-            (simple-var-ref $desugar$14)
-            (simple-var-ref $desugar$15))))))
-      (var-def
-        (variable $desugar$17 (expr
-          (invocation io fileWriteBytes (
-            (simple-var-ref $desugar$14)
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
+            (simple-var-ref $desugar$0)
+            (simple-var-ref $desugar$1))))))
       (expression-stmt
-        (simple-var-ref $desugar$17))
-      (var-def
-        (variable $desugar$18 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
+        (checked-expr
+          (invocation io fileWriteBytes (
+            (simple-var-ref $desugar$0)
+            (simple-var-ref $desugar$1)
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable fileCh (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$18))))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation base64Encode expr:
-            (simple-var-ref fileCh) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$19))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$19))) ())
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref path)))))))
       (var-def
         (variable fileEnc (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$19))))
-      (var-def
-        (variable $desugar$20 (expr
-          (invocation readAll expr:
-            (simple-var-ref fileEnc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
+          (checked-expr
+            (invocation base64Encode expr:
+              (simple-var-ref fileCh) ())))))
       (var-def
         (variable fileEncBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (invocation string fromBytes (
-            (simple-var-ref fileEncBytes))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$21))) ())
+          (checked-expr
+            (invocation readAll expr:
+              (simple-var-ref fileEnc) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$21))))
-      (var-def
-        (variable $desugar$22 (expr
-          (invocation close expr:
-            (simple-var-ref fileCh) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
+          (checked-expr
+            (invocation string fromBytes (
+              (simple-var-ref fileEncBytes)))))))
       (expression-stmt
-        (simple-var-ref $desugar$22))
-      (var-def
-        (variable $desugar$23 (expr
-          (invocation io createReadableChannel (
-            (list-constructor-expr
-              (literal 1)
-              (literal 2)
-              (literal 3)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$23))) ())
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref fileCh) ())))
       (var-def
         (variable closedCh (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$23))))
-      (var-def
-        (variable $desugar$24 (expr
-          (invocation close expr:
-            (simple-var-ref closedCh) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$24))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$24))) ())
+          (checked-expr
+            (invocation io createReadableChannel (
+              (list-constructor-expr
+                (literal 1)
+                (literal 2)
+                (literal 3))))))))
       (expression-stmt
-        (simple-var-ref $desugar$24))
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref closedCh) ())))
       (var-def
         (variable encClosed (type
           (union-type

--- a/corpus/desugared/library/subset3/io-byte-channel-blockstream-v.txt
+++ b/corpus/desugared/library/subset3/io-byte-channel-blockstream-v.txt
@@ -28,34 +28,18 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable channel (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref path)))))))
       (var-def
         (variable s (type
           (union-type
@@ -186,18 +170,10 @@
                       (invocation io println (
                         (literal done))))) ())
                 (block-stmt
-                  (var-def
-                    (variable $desugar$5 (expr
-                      (invocation close expr:
-                        (simple-var-ref s) ()))))
-                  (if
-                    (type-test-expr is
-                      (simple-var-ref $desugar$5))
-                    (block-stmt
-                      (return
-                        (simple-var-ref $desugar$5))) ())
                   (expression-stmt
-                    (simple-var-ref $desugar$5))))))) ())
+                    (checked-expr
+                      (invocation close expr:
+                        (simple-var-ref s) ())))))))) ())
       (block-stmt
         (var-def
           (variable closeResult (type

--- a/corpus/desugared/library/subset3/io-byte-channel-closed-v.txt
+++ b/corpus/desugared/library/subset3/io-byte-channel-closed-v.txt
@@ -24,46 +24,22 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable reader (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation close expr:
-            (simple-var-ref reader) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref path)))))))
       (expression-stmt
-        (simple-var-ref $desugar$5))
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref reader) ())))
       (var-def
         (variable secondClose (type
           (union-type
@@ -101,39 +77,23 @@
               (simple-var-ref readAfterClose)
               (user-defined-type io Error)))))
         (var-def
-          (variable $desugar$6 (expr
+          (variable $desugar$3 (expr
             (simple-var-ref path))))
         (var-def
-          (variable $desugar$7 (expr
+          (variable $desugar$4 (expr
             (invocation $default$11 (
-              (simple-var-ref $desugar$6))))))
-        (var-def
-          (variable $desugar$8 (expr
-            (invocation io openWritableFile (
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$8))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$8))) ())
+              (simple-var-ref $desugar$3))))))
         (var-def
           (variable writer (type
             (user-defined-type io WritableByteChannel)) (expr
-            (simple-var-ref $desugar$8))))
-        (var-def
-          (variable $desugar$9 (expr
-            (invocation close expr:
-              (simple-var-ref writer) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$9))) ())
+            (checked-expr
+              (invocation io openWritableFile (
+                (simple-var-ref $desugar$3)
+                (simple-var-ref $desugar$4)))))))
         (expression-stmt
-          (simple-var-ref $desugar$9))
+          (checked-expr
+            (invocation close expr:
+              (simple-var-ref writer) ())))
         (var-def
           (variable writeAfterClose (type
             (union-type

--- a/corpus/desugared/library/subset3/io-byte-channel-inmem-v.txt
+++ b/corpus/desugared/library/subset3/io-byte-channel-inmem-v.txt
@@ -16,19 +16,11 @@
             (literal 33)
             (literal 44)))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation io createReadableChannel (
-            (simple-var-ref content))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable channel (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation io createReadableChannel (
+              (simple-var-ref content)))))))
       (var-def
         (variable result (type
           (union-type
@@ -58,18 +50,10 @@
                 (simple-var-ref result)
                 (literal 3)))))) ())
       (block-stmt
-        (var-def
-          (variable $desugar$1 (expr
-            (invocation close expr:
-              (simple-var-ref channel) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$1))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$1))) ())
         (expression-stmt
-          (simple-var-ref $desugar$1))
+          (checked-expr
+            (invocation close expr:
+              (simple-var-ref channel) ())))
         (var-def
           (variable second (type
             (union-type

--- a/corpus/desugared/library/subset3/io-byte-channel-read-v.txt
+++ b/corpus/desugared/library/subset3/io-byte-channel-read-v.txt
@@ -28,34 +28,18 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable channel (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -150,15 +134,7 @@
                 (type-test-expr is
                   (simple-var-ref r4)
                   (user-defined-type io Error)))))
-            (var-def
-              (variable $desugar$5 (expr
-                (invocation close expr:
-                  (simple-var-ref channel) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$5))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$5))) ())
             (expression-stmt
-              (simple-var-ref $desugar$5))))))))
+              (checked-expr
+                (invocation close expr:
+                  (simple-var-ref channel) ())))))))))

--- a/corpus/desugared/library/subset3/io-byte-channel-readall-v.txt
+++ b/corpus/desugared/library/subset3/io-byte-channel-readall-v.txt
@@ -26,34 +26,18 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable channel (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref path)))))))
       (var-def
         (variable content (type
           (union-type
@@ -83,15 +67,7 @@
                 (simple-var-ref content)
                 (literal 4)))))) ())
       (block-stmt
-        (var-def
-          (variable $desugar$5 (expr
-            (invocation close expr:
-              (simple-var-ref channel) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$5))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$5))) ())
         (expression-stmt
-          (simple-var-ref $desugar$5))))))
+          (checked-expr
+            (invocation close expr:
+              (simple-var-ref channel) ())))))))

--- a/corpus/desugared/library/subset3/io-byte-channel-write-v.txt
+++ b/corpus/desugared/library/subset3/io-byte-channel-write-v.txt
@@ -18,20 +18,12 @@
           (invocation $default$11 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable writer (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
         (variable n1 (type
           (union-type
@@ -55,33 +47,17 @@
             (invocation io println (
               (simple-var-ref n1))))) ())
       (block-stmt
-        (var-def
-          (variable $desugar$3 (expr
-            (invocation close expr:
-              (simple-var-ref writer) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$3))) ())
         (expression-stmt
-          (simple-var-ref $desugar$3))
-        (var-def
-          (variable $desugar$4 (expr
-            (invocation io fileReadBytes (
-              (simple-var-ref path))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$4))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$4))) ())
+          (checked-expr
+            (invocation close expr:
+              (simple-var-ref writer) ())))
         (var-def
           (variable written (type
             (array-type
               (value-type byte) dimensions: 1 ([]))) (expr
-            (simple-var-ref $desugar$4))))
+            (checked-expr
+              (invocation io fileReadBytes (
+                (simple-var-ref path)))))))
         (expression-stmt
           (invocation io println (
             (invocation lang.array length (
@@ -97,64 +73,32 @@
               (simple-var-ref written)
               (literal 2)))))
         (var-def
-          (variable $desugar$5 (expr
-            (invocation io openWritableFile (
-              (simple-var-ref path)
-              (literal APPEND))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$5))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$5))) ())
-        (var-def
           (variable appender (type
             (user-defined-type io WritableByteChannel)) (expr
-            (simple-var-ref $desugar$5))))
-        (var-def
-          (variable $desugar$6 (expr
+            (checked-expr
+              (invocation io openWritableFile (
+                (simple-var-ref path)
+                (literal APPEND)))))))
+        (assignment
+          (wildcard-binding-pattern)
+          (checked-expr
             (invocation write expr:
               (simple-var-ref appender) (
               (list-constructor-expr
                 (literal 9)
                 (literal 8))
-              (literal 0))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$6))) ())
-        (assignment
-          (wildcard-binding-pattern)
-          (simple-var-ref $desugar$6))
-        (var-def
-          (variable $desugar$7 (expr
-            (invocation close expr:
-              (simple-var-ref appender) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$7))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$7))) ())
+              (literal 0)))))
         (expression-stmt
-          (simple-var-ref $desugar$7))
-        (var-def
-          (variable $desugar$8 (expr
-            (invocation io fileReadBytes (
-              (simple-var-ref path))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$8))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$8))) ())
+          (checked-expr
+            (invocation close expr:
+              (simple-var-ref appender) ())))
         (var-def
           (variable appended (type
             (array-type
               (value-type byte) dimensions: 1 ([]))) (expr
-            (simple-var-ref $desugar$8))))
+            (checked-expr
+              (invocation io fileReadBytes (
+                (simple-var-ref path)))))))
         (expression-stmt
           (invocation io println (
             (invocation lang.array length (

--- a/corpus/desugared/library/subset3/io-byte-readonly-v.txt
+++ b/corpus/desugared/library/subset3/io-byte-readonly-v.txt
@@ -26,37 +26,21 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadBytes (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable bytes (type
           (intersection-type
             (value-type readonly)
             (array-type
               (value-type byte) dimensions: 1 ([])))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -70,24 +54,16 @@
           (invocation lang.array length (
             (simple-var-ref bytes))))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation io fileReadBlocksAsStream (
-            (simple-var-ref path)
-            (literal 2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable blocks (type
           (stream-type
             (user-defined-type io Block)
             (union-type
               (user-defined-type io Error)
               (value-type null)))) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation io fileReadBlocksAsStream (
+              (simple-var-ref path)
+              (literal 2)))))))
       (var-def
         (variable first (type
           (union-type
@@ -117,49 +93,25 @@
                   (array-type
                     (value-type byte) dimensions: 1 ([])))))))) ())
       (block-stmt
-        (var-def
-          (variable $desugar$6 (expr
-            (invocation close expr:
-              (simple-var-ref blocks) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$6))) ())
         (expression-stmt
-          (simple-var-ref $desugar$6))
-        (var-def
-          (variable $desugar$7 (expr
-            (invocation io openReadableFile (
-              (simple-var-ref path))))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$7))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$7))) ())
+          (checked-expr
+            (invocation close expr:
+              (simple-var-ref blocks) ())))
         (var-def
           (variable channel (type
             (user-defined-type io ReadableByteChannel)) (expr
-            (simple-var-ref $desugar$7))))
-        (var-def
-          (variable $desugar$8 (expr
-            (invocation readAll expr:
-              (simple-var-ref channel) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$8))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$8))) ())
+            (checked-expr
+              (invocation io openReadableFile (
+                (simple-var-ref path)))))))
         (var-def
           (variable all (type
             (intersection-type
               (value-type readonly)
               (array-type
                 (value-type byte) dimensions: 1 ([])))) (expr
-            (simple-var-ref $desugar$8))))
+            (checked-expr
+              (invocation readAll expr:
+                (simple-var-ref channel) ())))))
         (expression-stmt
           (invocation io println (
             (type-test-expr is
@@ -173,15 +125,7 @@
             (index-based-access
               (simple-var-ref all)
               (literal 4)))))
-        (var-def
-          (variable $desugar$9 (expr
-            (invocation close expr:
-              (simple-var-ref channel) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$9))) ())
         (expression-stmt
-          (simple-var-ref $desugar$9))))))
+          (checked-expr
+            (invocation close expr:
+              (simple-var-ref channel) ())))))))

--- a/corpus/desugared/library/subset3/io-char-channel-badcharset-p.txt
+++ b/corpus/desugared/library/subset3/io-char-channel-badcharset-p.txt
@@ -6,21 +6,13 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation io createReadableChannel (
-            (list-constructor-expr
-              (literal 1)
-              (literal 2)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable rb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation io createReadableChannel (
+              (list-constructor-expr
+                (literal 1)
+                (literal 2))))))))
       (var-def
         (variable rc (type
           (user-defined-type io ReadableCharacterChannel)) (expr
@@ -28,17 +20,9 @@
             (simple-var-ref rb)
             (literal NOT-A-CHARSET))))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation read expr:
-            (simple-var-ref rc) (
-            (literal 1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable _ (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$1)))))))
+          (checked-expr
+            (invocation read expr:
+              (simple-var-ref rc) (
+              (literal 1))))))))))

--- a/corpus/desugared/library/subset3/io-char-channel-json-xml-v.txt
+++ b/corpus/desugared/library/subset3/io-char-channel-json-xml-v.txt
@@ -17,28 +17,20 @@
           (invocation $default$11 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable wjb (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
         (variable wjc (type
           (user-defined-type io WritableCharacterChannel)) (expr
           (new (
             (simple-var-ref wjb)
             (literal UTF-8))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation writeJson expr:
             (simple-var-ref wjc) (
             (mapping-constructor-expr
@@ -47,41 +39,17 @@
                 (literal Ballerina))
               (key-value
                 (literal age)
-                (literal 12))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+                (literal 12)))))))
       (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref wjc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$4))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref jpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+            (simple-var-ref wjc) ())))
       (var-def
         (variable rjb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref jpath)))))))
       (var-def
         (variable rjc (type
           (user-defined-type io ReadableCharacterChannel)) (expr
@@ -89,19 +57,11 @@
             (simple-var-ref rjb)
             (literal UTF-8))))))
       (var-def
-        (variable $desugar$6 (expr
-          (invocation readJson expr:
-            (simple-var-ref rjc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (var-def
         (variable j (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation readJson expr:
+              (simple-var-ref rjc) ())))))
       (var-def
         (variable jm (type
           (constrained-type
@@ -122,61 +82,37 @@
           (index-based-access
             (simple-var-ref jm)
             (literal age)))))
-      (var-def
-        (variable $desugar$7 (expr
-          (invocation close expr:
-            (simple-var-ref rjc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
       (expression-stmt
-        (simple-var-ref $desugar$7))
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref rjc) ())))
       (var-def
         (variable bpath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_char_json_bad.json))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$2 (expr
           (simple-var-ref bpath))))
       (var-def
-        (variable $desugar$9 (expr
+        (variable $desugar$3 (expr
           (literal {oops))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$4 (expr
           (invocation $default$1 (
-            (simple-var-ref $desugar$8)
-            (simple-var-ref $desugar$9))))))
-      (var-def
-        (variable $desugar$11 (expr
-          (invocation io fileWriteString (
-            (simple-var-ref $desugar$8)
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$10))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
+            (simple-var-ref $desugar$2)
+            (simple-var-ref $desugar$3))))))
       (expression-stmt
-        (simple-var-ref $desugar$11))
-      (var-def
-        (variable $desugar$12 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref bpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$12))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$12))) ())
+        (checked-expr
+          (invocation io fileWriteString (
+            (simple-var-ref $desugar$2)
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4)))))
       (var-def
         (variable bjb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$12))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref bpath)))))))
       (var-def
         (variable bjc (type
           (user-defined-type io ReadableCharacterChannel)) (expr
@@ -195,18 +131,10 @@
           (type-test-expr is
             (simple-var-ref bad)
             (user-defined-type io Error)))))
-      (var-def
-        (variable $desugar$13 (expr
-          (invocation close expr:
-            (simple-var-ref bjc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
       (expression-stmt
-        (simple-var-ref $desugar$13))
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref bjc) ())))
       (var-def
         (variable note (type
           (value-type xml)) (expr
@@ -218,105 +146,65 @@
           (value-type string)) (expr
           (literal /tmp/bal_io_char_xml.xml))))
       (var-def
-        (variable $desugar$14 (expr
+        (variable $desugar$5 (expr
           (simple-var-ref xpath))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$6 (expr
           (invocation $default$11 (
-            (simple-var-ref $desugar$14))))))
-      (var-def
-        (variable $desugar$16 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$14)
-            (simple-var-ref $desugar$15))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$16))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$16))) ())
+            (simple-var-ref $desugar$5))))))
       (var-def
         (variable wxb1 (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$16))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$5)
+              (simple-var-ref $desugar$6)))))))
       (var-def
         (variable wxc1 (type
           (user-defined-type io WritableCharacterChannel)) (expr
           (new (
             (simple-var-ref wxb1)
             (literal UTF-8))))))
-      (var-def
-        (variable $desugar$17 (expr
+      (expression-stmt
+        (checked-expr
           (invocation writeXml expr:
             (simple-var-ref wxc1) (
             (simple-var-ref note)
             (mapping-constructor-expr
               (key-value
                 (literal system)
-                (literal note.dtd))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
+                (literal note.dtd)))))))
       (expression-stmt
-        (simple-var-ref $desugar$17))
-      (var-def
-        (variable $desugar$18 (expr
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref wxc1) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$18))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation io fileReadString (
-            (simple-var-ref xpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$19))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$19))) ())
+            (simple-var-ref wxc1) ())))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$19))))
+          (checked-expr
+            (invocation io fileReadString (
+              (simple-var-ref xpath)))))))
       (var-def
-        (variable $desugar$20 (expr
+        (variable $desugar$7 (expr
           (simple-var-ref xpath))))
       (var-def
-        (variable $desugar$21 (expr
+        (variable $desugar$8 (expr
           (invocation $default$11 (
-            (simple-var-ref $desugar$20))))))
-      (var-def
-        (variable $desugar$22 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$20)
-            (simple-var-ref $desugar$21))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
+            (simple-var-ref $desugar$7))))))
       (var-def
         (variable wxb2 (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$22))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$7)
+              (simple-var-ref $desugar$8)))))))
       (var-def
         (variable wxc2 (type
           (user-defined-type io WritableCharacterChannel)) (expr
           (new (
             (simple-var-ref wxb2)
             (literal UTF-8))))))
-      (var-def
-        (variable $desugar$23 (expr
+      (expression-stmt
+        (checked-expr
           (invocation writeXml expr:
             (simple-var-ref wxc2) (
             (simple-var-ref note)
@@ -326,132 +214,68 @@
                 (literal -//W3C//DTD//EN))
               (key-value
                 (literal system)
-                (literal note.dtd))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$23))) ())
+                (literal note.dtd)))))))
       (expression-stmt
-        (simple-var-ref $desugar$23))
-      (var-def
-        (variable $desugar$24 (expr
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref wxc2) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$24))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$24))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$24))
-      (var-def
-        (variable $desugar$25 (expr
-          (invocation io fileReadString (
-            (simple-var-ref xpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$25))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$25))) ())
+            (simple-var-ref wxc2) ())))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$25))))
+          (checked-expr
+            (invocation io fileReadString (
+              (simple-var-ref xpath)))))))
       (var-def
-        (variable $desugar$26 (expr
+        (variable $desugar$9 (expr
           (simple-var-ref xpath))))
       (var-def
-        (variable $desugar$27 (expr
+        (variable $desugar$10 (expr
           (invocation $default$11 (
-            (simple-var-ref $desugar$26))))))
-      (var-def
-        (variable $desugar$28 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$26)
-            (simple-var-ref $desugar$27))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$28))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$28))) ())
+            (simple-var-ref $desugar$9))))))
       (var-def
         (variable wxb3 (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$28))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)))))))
       (var-def
         (variable wxc3 (type
           (user-defined-type io WritableCharacterChannel)) (expr
           (new (
             (simple-var-ref wxb3)
             (literal UTF-8))))))
-      (var-def
-        (variable $desugar$29 (expr
+      (expression-stmt
+        (checked-expr
           (invocation writeXml expr:
             (simple-var-ref wxc3) (
             (simple-var-ref note)
             (mapping-constructor-expr
               (key-value
                 (literal internalSubset)
-                (literal [<!ELEMENT to (#PCDATA)>]))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$29))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$29))) ())
+                (literal [<!ELEMENT to (#PCDATA)>])))))))
       (expression-stmt
-        (simple-var-ref $desugar$29))
-      (var-def
-        (variable $desugar$30 (expr
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref wxc3) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$30))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$30))
-      (var-def
-        (variable $desugar$31 (expr
-          (invocation io fileReadString (
-            (simple-var-ref xpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$31))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$31))) ())
+            (simple-var-ref wxc3) ())))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$31))))
+          (checked-expr
+            (invocation io fileReadString (
+              (simple-var-ref xpath)))))))
       (var-def
-        (variable $desugar$32 (expr
+        (variable $desugar$11 (expr
           (simple-var-ref xpath))))
       (var-def
-        (variable $desugar$33 (expr
+        (variable $desugar$12 (expr
           (invocation $default$11 (
-            (simple-var-ref $desugar$32))))))
-      (var-def
-        (variable $desugar$34 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$32)
-            (simple-var-ref $desugar$33))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$34))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$34))) ())
+            (simple-var-ref $desugar$11))))))
       (var-def
         (variable wxb4 (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$34))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$11)
+              (simple-var-ref $desugar$12)))))))
       (var-def
         (variable wxc4 (type
           (user-defined-type io WritableCharacterChannel)) (expr
@@ -459,65 +283,33 @@
             (simple-var-ref wxb4)
             (literal UTF-8))))))
       (var-def
-        (variable $desugar$35 (expr
+        (variable $desugar$13 (expr
           (simple-var-ref note))))
       (var-def
-        (variable $desugar$36 (expr
+        (variable $desugar$14 (expr
           (invocation $default$8 (
-            (simple-var-ref $desugar$35))))))
-      (var-def
-        (variable $desugar$37 (expr
+            (simple-var-ref $desugar$13))))))
+      (expression-stmt
+        (checked-expr
           (invocation writeXml expr:
             (simple-var-ref wxc4) (
-            (simple-var-ref $desugar$35)
-            (simple-var-ref $desugar$36))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$37))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$37))) ())
+            (simple-var-ref $desugar$13)
+            (simple-var-ref $desugar$14)))))
       (expression-stmt
-        (simple-var-ref $desugar$37))
-      (var-def
-        (variable $desugar$38 (expr
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref wxc4) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$38))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$38))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$38))
-      (var-def
-        (variable $desugar$39 (expr
-          (invocation io fileReadString (
-            (simple-var-ref xpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$39))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$39))) ())
+            (simple-var-ref wxc4) ())))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$39))))
-      (var-def
-        (variable $desugar$40 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref xpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$40))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$40))) ())
+          (checked-expr
+            (invocation io fileReadString (
+              (simple-var-ref xpath)))))))
       (var-def
         (variable rxb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$40))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref xpath)))))))
       (var-def
         (variable rxc (type
           (user-defined-type io ReadableCharacterChannel)) (expr
@@ -525,31 +317,15 @@
             (simple-var-ref rxb)
             (literal UTF-8))))))
       (var-def
-        (variable $desugar$41 (expr
-          (invocation readXml expr:
-            (simple-var-ref rxc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$41))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$41))) ())
-      (var-def
         (variable parsed (type
           (value-type xml)) (expr
-          (simple-var-ref $desugar$41))))
+          (checked-expr
+            (invocation readXml expr:
+              (simple-var-ref rxc) ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref parsed))))
-      (var-def
-        (variable $desugar$42 (expr
-          (invocation close expr:
-            (simple-var-ref rxc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$42))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$42))) ())
       (expression-stmt
-        (simple-var-ref $desugar$42)))))
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref rxc) ()))))))

--- a/corpus/desugared/library/subset3/io-char-channel-props-v.txt
+++ b/corpus/desugared/library/subset3/io-char-channel-props-v.txt
@@ -37,34 +37,18 @@ nl=a\nb
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable rb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref path)))))))
       (var-def
         (variable rc (type
           (user-defined-type io ReadableCharacterChannel)) (expr
@@ -72,197 +56,125 @@ nl=a\nb
             (simple-var-ref rb)
             (literal UTF-8))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$3 (expr
           (literal name))))
+      (var-def
+        (variable $desugar$4 (expr
+          (invocation $default$7 (
+            (simple-var-ref $desugar$3))))))
+      (expression-stmt
+        (invocation io println (
+          (checked-expr
+            (invocation readProperty expr:
+              (simple-var-ref rc) (
+              (simple-var-ref $desugar$3)
+              (simple-var-ref $desugar$4)))))))
+      (var-def
+        (variable $desugar$5 (expr
+          (literal spaced.key))))
       (var-def
         (variable $desugar$6 (expr
           (invocation $default$7 (
             (simple-var-ref $desugar$5))))))
-      (var-def
-        (variable $desugar$7 (expr
-          (invocation readProperty expr:
-            (simple-var-ref rc) (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$7))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal spaced.key))))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation $default$7 (
-            (simple-var-ref $desugar$8))))))
-      (var-def
-        (variable $desugar$10 (expr
-          (invocation readProperty expr:
-            (simple-var-ref rc) (
-            (simple-var-ref $desugar$8)
-            (simple-var-ref $desugar$9))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
       (expression-stmt
         (invocation io println (
           (literal [)
-          (simple-var-ref $desugar$10)
+          (checked-expr
+            (invocation readProperty expr:
+              (simple-var-ref rc) (
+              (simple-var-ref $desugar$5)
+              (simple-var-ref $desugar$6))))
           (literal ]))))
-      (var-def
-        (variable $desugar$11 (expr
-          (invocation readProperty expr:
-            (simple-var-ref rc) (
-            (literal missing)
-            (literal fallback))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$11))))
+          (checked-expr
+            (invocation readProperty expr:
+              (simple-var-ref rc) (
+              (literal missing)
+              (literal fallback)))))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$7 (expr
           (literal esc:aped))))
       (var-def
-        (variable $desugar$13 (expr
+        (variable $desugar$8 (expr
           (invocation $default$7 (
-            (simple-var-ref $desugar$12))))))
-      (var-def
-        (variable $desugar$14 (expr
-          (invocation readProperty expr:
-            (simple-var-ref rc) (
-            (simple-var-ref $desugar$12)
-            (simple-var-ref $desugar$13))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
+            (simple-var-ref $desugar$7))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (invocation readProperty expr:
+              (simple-var-ref rc) (
+              (simple-var-ref $desugar$7)
+              (simple-var-ref $desugar$8)))))))
+      (var-def
+        (variable $desugar$9 (expr
+          (literal multi))))
+      (var-def
+        (variable $desugar$10 (expr
+          (invocation $default$7 (
+            (simple-var-ref $desugar$9))))))
+      (expression-stmt
+        (invocation io println (
+          (checked-expr
+            (invocation readProperty expr:
+              (simple-var-ref rc) (
+              (simple-var-ref $desugar$9)
+              (simple-var-ref $desugar$10)))))))
+      (var-def
+        (variable $desugar$11 (expr
+          (literal tabbed))))
+      (var-def
+        (variable $desugar$12 (expr
+          (invocation $default$7 (
+            (simple-var-ref $desugar$11))))))
+      (expression-stmt
+        (invocation io println (
+          (checked-expr
+            (invocation readProperty expr:
+              (simple-var-ref rc) (
+              (simple-var-ref $desugar$11)
+              (simple-var-ref $desugar$12)))))))
+      (var-def
+        (variable $desugar$13 (expr
+          (literal uni))))
+      (var-def
+        (variable $desugar$14 (expr
+          (invocation $default$7 (
+            (simple-var-ref $desugar$13))))))
+      (expression-stmt
+        (invocation io println (
+          (checked-expr
+            (invocation readProperty expr:
+              (simple-var-ref rc) (
+              (simple-var-ref $desugar$13)
+              (simple-var-ref $desugar$14)))))))
       (var-def
         (variable $desugar$15 (expr
-          (literal multi))))
+          (literal nl))))
       (var-def
         (variable $desugar$16 (expr
           (invocation $default$7 (
             (simple-var-ref $desugar$15))))))
       (var-def
-        (variable $desugar$17 (expr
-          (invocation readProperty expr:
-            (simple-var-ref rc) (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$17))))
-      (var-def
-        (variable $desugar$18 (expr
-          (literal tabbed))))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation $default$7 (
-            (simple-var-ref $desugar$18))))))
-      (var-def
-        (variable $desugar$20 (expr
-          (invocation readProperty expr:
-            (simple-var-ref rc) (
-            (simple-var-ref $desugar$18)
-            (simple-var-ref $desugar$19))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (literal uni))))
-      (var-def
-        (variable $desugar$22 (expr
-          (invocation $default$7 (
-            (simple-var-ref $desugar$21))))))
-      (var-def
-        (variable $desugar$23 (expr
-          (invocation readProperty expr:
-            (simple-var-ref rc) (
-            (simple-var-ref $desugar$21)
-            (simple-var-ref $desugar$22))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$23))) ())
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$23))))
-      (var-def
-        (variable $desugar$24 (expr
-          (literal nl))))
-      (var-def
-        (variable $desugar$25 (expr
-          (invocation $default$7 (
-            (simple-var-ref $desugar$24))))))
-      (var-def
-        (variable $desugar$26 (expr
-          (invocation readProperty expr:
-            (simple-var-ref rc) (
-            (simple-var-ref $desugar$24)
-            (simple-var-ref $desugar$25))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$26))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$26))) ())
-      (var-def
         (variable nl (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$26))))
+          (checked-expr
+            (invocation readProperty expr:
+              (simple-var-ref rc) (
+              (simple-var-ref $desugar$15)
+              (simple-var-ref $desugar$16)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.string length (
             (simple-var-ref nl))))))
       (var-def
-        (variable $desugar$27 (expr
-          (invocation readAllProperties expr:
-            (simple-var-ref rc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$27))) ())
-      (var-def
         (variable all (type
           (constrained-type
             (builtin-ref-type map)
             (value-type string))) (expr
-          (simple-var-ref $desugar$27))))
+          (checked-expr
+            (invocation readAllProperties expr:
+              (simple-var-ref rc) ())))))
       (expression-stmt
         (invocation io println (
           (invocation lang.map length (
@@ -274,52 +186,36 @@ nl=a\nb
               (simple-var-ref all)
               (literal empty))
             (literal )))))
-      (var-def
-        (variable $desugar$28 (expr
-          (invocation close expr:
-            (simple-var-ref rc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$28))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$28))) ())
       (expression-stmt
-        (simple-var-ref $desugar$28))
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref rc) ())))
       (var-def
         (variable wpath (type
           (value-type string)) (expr
           (literal /tmp/bal_io_char_props_out.properties))))
       (var-def
-        (variable $desugar$29 (expr
+        (variable $desugar$17 (expr
           (simple-var-ref wpath))))
       (var-def
-        (variable $desugar$30 (expr
+        (variable $desugar$18 (expr
           (invocation $default$11 (
-            (simple-var-ref $desugar$29))))))
-      (var-def
-        (variable $desugar$31 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$29)
-            (simple-var-ref $desugar$30))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$31))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$31))) ())
+            (simple-var-ref $desugar$17))))))
       (var-def
         (variable wb (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$31))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$17)
+              (simple-var-ref $desugar$18)))))))
       (var-def
         (variable wc (type
           (user-defined-type io WritableCharacterChannel)) (expr
           (new (
             (simple-var-ref wb)
             (literal UTF-8))))))
-      (var-def
-        (variable $desugar$32 (expr
+      (expression-stmt
+        (checked-expr
           (invocation writeProperties expr:
             (simple-var-ref wc) (
             (mapping-constructor-expr
@@ -340,42 +236,18 @@ nl=a\nb
                 (literal a
 b)))
             (literal first line
-second line))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$32))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$32))) ())
+second line)))))
       (expression-stmt
-        (simple-var-ref $desugar$32))
-      (var-def
-        (variable $desugar$33 (expr
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref wc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$33))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$33))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$33))
-      (var-def
-        (variable $desugar$34 (expr
-          (invocation io fileReadLines (
-            (simple-var-ref wpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$34))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$34))) ())
+            (simple-var-ref wc) ())))
       (var-def
         (variable outLines (type
           (array-type
             (value-type string) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$34))))
+          (checked-expr
+            (invocation io fileReadLines (
+              (simple-var-ref wpath)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access
@@ -387,19 +259,11 @@ second line))))))
             (simple-var-ref outLines)
             (literal 1)))))
       (var-def
-        (variable $desugar$35 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref wpath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$35))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$35))) ())
-      (var-def
         (variable vb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$35))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref wpath)))))))
       (var-def
         (variable vc (type
           (user-defined-type io ReadableCharacterChannel)) (expr
@@ -407,21 +271,13 @@ second line))))))
             (simple-var-ref vb)
             (literal UTF-8))))))
       (var-def
-        (variable $desugar$36 (expr
-          (invocation readAllProperties expr:
-            (simple-var-ref vc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$36))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$36))) ())
-      (var-def
         (variable written (type
           (constrained-type
             (builtin-ref-type map)
             (value-type string))) (expr
-          (simple-var-ref $desugar$36))))
+          (checked-expr
+            (invocation readAllProperties expr:
+              (simple-var-ref vc) ())))))
       (expression-stmt
         (invocation io println (
           (invocation lang.map length (
@@ -456,15 +312,7 @@ second line))))))
               (literal line))
             (literal a
 b)))))
-      (var-def
-        (variable $desugar$37 (expr
-          (invocation close expr:
-            (simple-var-ref vc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$37))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$37))) ())
       (expression-stmt
-        (simple-var-ref $desugar$37)))))
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref vc) ()))))))

--- a/corpus/desugared/library/subset3/io-char-channel-read-v.txt
+++ b/corpus/desugared/library/subset3/io-char-channel-read-v.txt
@@ -24,64 +24,32 @@ wörld))))
           (invocation $default$1 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+            (simple-var-ref $desugar$2)))))
       (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref path)
             (list-constructor-expr
               (literal 13)
               (literal 10))
-            (literal APPEND))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (literal APPEND)))))
       (expression-stmt
-        (simple-var-ref $desugar$4))
-      (var-def
-        (variable $desugar$5 (expr
+        (checked-expr
           (invocation io fileWriteString (
             (simple-var-ref path)
             (literal last)
-            (literal APPEND))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$5))
-      (var-def
-        (variable $desugar$6 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
+            (literal APPEND)))))
       (var-def
         (variable rb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref path)))))))
       (var-def
         (variable rc (type
           (user-defined-type io ReadableCharacterChannel)) (expr
@@ -89,37 +57,21 @@ wörld))))
             (simple-var-ref rb)
             (literal UTF-8))))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation read expr:
-            (simple-var-ref rc) (
-            (literal 5))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable first (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation read expr:
+              (simple-var-ref rc) (
+              (literal 5)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref first))))
       (var-def
-        (variable $desugar$8 (expr
-          (invocation readString expr:
-            (simple-var-ref rc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
-      (var-def
         (variable rest (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (invocation readString expr:
+              (simple-var-ref rc) ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref rest))))
@@ -141,18 +93,10 @@ wörld))))
               (invocation lang.error message (
                 (simple-var-ref atEnd))))))) ())
       (block-stmt
-        (var-def
-          (variable $desugar$9 (expr
-            (invocation close expr:
-              (simple-var-ref rc) ()))))
-        (if
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (block-stmt
-            (return
-              (simple-var-ref $desugar$9))) ())
         (expression-stmt
-          (simple-var-ref $desugar$9))
+          (checked-expr
+            (invocation close expr:
+              (simple-var-ref rc) ())))
         (var-def
           (variable closedAgain (type
             (union-type
@@ -189,56 +133,32 @@ wörld))))
                     (simple-var-ref afterClose))))))) ())
           (block-stmt
             (var-def
-              (variable $desugar$10 (expr
-                (invocation io createReadableChannel (
-                  (list-constructor-expr
-                    (literal 97)
-                    (literal 98)))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$10))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$10))) ())
-            (var-def
               (variable mb (type
                 (user-defined-type io ReadableByteChannel)) (expr
-                (simple-var-ref $desugar$10))))
+                (checked-expr
+                  (invocation io createReadableChannel (
+                    (list-constructor-expr
+                      (literal 97)
+                      (literal 98))))))))
             (var-def
               (variable mc (type
                 (user-defined-type io ReadableCharacterChannel)) (expr
                 (new (
                   (simple-var-ref mb)
                   (literal UTF-8))))))
-            (var-def
-              (variable $desugar$11 (expr
-                (invocation read expr:
-                  (simple-var-ref mc) (
-                  (literal 2))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$11))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$11))) ())
             (expression-stmt
               (invocation io println (
-                (simple-var-ref $desugar$11))))
-            (var-def
-              (variable $desugar$12 (expr
-                (invocation read expr:
-                  (simple-var-ref mc) (
-                  (literal 1))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$12))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$12))) ())
+                (checked-expr
+                  (invocation read expr:
+                    (simple-var-ref mc) (
+                    (literal 2)))))))
             (var-def
               (variable empty (type
                 (value-type string)) (expr
-                (simple-var-ref $desugar$12))))
+                (checked-expr
+                  (invocation read expr:
+                    (simple-var-ref mc) (
+                    (literal 1)))))))
             (expression-stmt
               (invocation io println (
                 (invocation lang.string length (
@@ -261,32 +181,16 @@ wörld))))
                     (invocation lang.error message (
                       (simple-var-ref eof))))))) ())
             (block-stmt
-              (var-def
-                (variable $desugar$13 (expr
-                  (invocation close expr:
-                    (simple-var-ref mc) ()))))
-              (if
-                (type-test-expr is
-                  (simple-var-ref $desugar$13))
-                (block-stmt
-                  (return
-                    (simple-var-ref $desugar$13))) ())
               (expression-stmt
-                (simple-var-ref $desugar$13))
-              (var-def
-                (variable $desugar$14 (expr
-                  (invocation io openReadableFile (
-                    (simple-var-ref path))))))
-              (if
-                (type-test-expr is
-                  (simple-var-ref $desugar$14))
-                (block-stmt
-                  (return
-                    (simple-var-ref $desugar$14))) ())
+                (checked-expr
+                  (invocation close expr:
+                    (simple-var-ref mc) ())))
               (var-def
                 (variable lb (type
                   (user-defined-type io ReadableByteChannel)) (expr
-                  (simple-var-ref $desugar$14))))
+                  (checked-expr
+                    (invocation io openReadableFile (
+                      (simple-var-ref path)))))))
               (var-def
                 (variable lc (type
                   (user-defined-type io ReadableCharacterChannel)) (expr
@@ -294,20 +198,12 @@ wörld))))
                     (simple-var-ref lb)
                     (literal UTF-8))))))
               (var-def
-                (variable $desugar$15 (expr
-                  (invocation readAllLines expr:
-                    (simple-var-ref lc) ()))))
-              (if
-                (type-test-expr is
-                  (simple-var-ref $desugar$15))
-                (block-stmt
-                  (return
-                    (simple-var-ref $desugar$15))) ())
-              (var-def
                 (variable lines (type
                   (array-type
                     (value-type string) dimensions: 1 ([]))) (expr
-                  (simple-var-ref $desugar$15))))
+                  (checked-expr
+                    (invocation readAllLines expr:
+                      (simple-var-ref lc) ())))))
               (expression-stmt
                 (invocation io println (
                   (invocation lang.array length (
@@ -317,32 +213,16 @@ wörld))))
                   (index-based-access
                     (simple-var-ref lines)
                     (literal 1)))))
-              (var-def
-                (variable $desugar$16 (expr
-                  (invocation close expr:
-                    (simple-var-ref lc) ()))))
-              (if
-                (type-test-expr is
-                  (simple-var-ref $desugar$16))
-                (block-stmt
-                  (return
-                    (simple-var-ref $desugar$16))) ())
               (expression-stmt
-                (simple-var-ref $desugar$16))
-              (var-def
-                (variable $desugar$17 (expr
-                  (invocation io openReadableFile (
-                    (simple-var-ref path))))))
-              (if
-                (type-test-expr is
-                  (simple-var-ref $desugar$17))
-                (block-stmt
-                  (return
-                    (simple-var-ref $desugar$17))) ())
+                (checked-expr
+                  (invocation close expr:
+                    (simple-var-ref lc) ())))
               (var-def
                 (variable sb (type
                   (user-defined-type io ReadableByteChannel)) (expr
-                  (simple-var-ref $desugar$17))))
+                  (checked-expr
+                    (invocation io openReadableFile (
+                      (simple-var-ref path)))))))
               (var-def
                 (variable sc (type
                   (user-defined-type io ReadableCharacterChannel)) (expr
@@ -350,23 +230,15 @@ wörld))))
                     (simple-var-ref sb)
                     (literal UTF-8))))))
               (var-def
-                (variable $desugar$18 (expr
-                  (invocation lineStream expr:
-                    (simple-var-ref sc) ()))))
-              (if
-                (type-test-expr is
-                  (simple-var-ref $desugar$18))
-                (block-stmt
-                  (return
-                    (simple-var-ref $desugar$18))) ())
-              (var-def
                 (variable ls (type
                   (stream-type
                     (value-type string)
                     (union-type
                       (user-defined-type io Error)
                       (value-type null)))) (expr
-                  (simple-var-ref $desugar$18))))
+                  (checked-expr
+                    (invocation lineStream expr:
+                      (simple-var-ref sc) ())))))
               (var-def
                 (variable l1 (type
                   (union-type
@@ -455,15 +327,7 @@ wörld))))
                         (type-test-expr is
                           (simple-var-ref l4)
                           (value-type null)))))
-                    (var-def
-                      (variable $desugar$19 (expr
-                        (invocation close expr:
-                          (simple-var-ref ls) ()))))
-                    (if
-                      (type-test-expr is
-                        (simple-var-ref $desugar$19))
-                      (block-stmt
-                        (return
-                          (simple-var-ref $desugar$19))) ())
                     (expression-stmt
-                      (simple-var-ref $desugar$19))))))))))))
+                      (checked-expr
+                        (invocation close expr:
+                          (simple-var-ref ls) ())))))))))))))

--- a/corpus/desugared/library/subset3/io-char-channel-write-v.txt
+++ b/corpus/desugared/library/subset3/io-char-channel-write-v.txt
@@ -19,20 +19,12 @@
           (invocation $default$11 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable wb (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
         (variable wc (type
           (user-defined-type io WritableCharacterChannel)) (expr
@@ -40,68 +32,36 @@
             (simple-var-ref wb)
             (literal UTF-8))))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation write expr:
-            (simple-var-ref wc) (
-            (literal héllo wörld)
-            (literal 0))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable n1 (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation write expr:
+              (simple-var-ref wc) (
+              (literal héllo wörld)
+              (literal 0)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref n1))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation write expr:
-            (simple-var-ref wc) (
-            (literal abc)
-            (literal 1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable n2 (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation write expr:
+              (simple-var-ref wc) (
+              (literal abc)
+              (literal 1)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref n2))))
-      (var-def
-        (variable $desugar$5 (expr
+      (expression-stmt
+        (checked-expr
           (invocation writeLine expr:
             (simple-var-ref wc) (
-            (literal !))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+            (literal !)))))
       (expression-stmt
-        (simple-var-ref $desugar$5))
-      (var-def
-        (variable $desugar$6 (expr
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref wc) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$6))
+            (simple-var-ref wc) ())))
       (var-def
         (variable closedWrite (type
           (union-type
@@ -138,106 +98,58 @@
                 (invocation lang.error message (
                   (simple-var-ref afterClose))))))) ())
         (block-stmt
-          (var-def
-            (variable $desugar$7 (expr
-              (invocation io fileReadString (
-                (simple-var-ref path))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$7))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$7))) ())
           (expression-stmt
             (invocation io println (
-              (simple-var-ref $desugar$7))))
-          (var-def
-            (variable $desugar$8 (expr
-              (invocation io openWritableFile (
-                (simple-var-ref path)
-                (literal APPEND))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$8))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$8))) ())
+              (checked-expr
+                (invocation io fileReadString (
+                  (simple-var-ref path)))))))
           (var-def
             (variable ab (type
               (user-defined-type io WritableByteChannel)) (expr
-              (simple-var-ref $desugar$8))))
+              (checked-expr
+                (invocation io openWritableFile (
+                  (simple-var-ref path)
+                  (literal APPEND)))))))
           (var-def
             (variable ac (type
               (user-defined-type io WritableCharacterChannel)) (expr
               (new (
                 (simple-var-ref ab)
                 (literal UTF-8))))))
-          (var-def
-            (variable $desugar$9 (expr
+          (assignment
+            (wildcard-binding-pattern)
+            (checked-expr
               (invocation write expr:
                 (simple-var-ref ac) (
                 (literal +more)
-                (literal 0))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$9))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$9))) ())
-          (assignment
-            (wildcard-binding-pattern)
-            (simple-var-ref $desugar$9))
-          (var-def
-            (variable $desugar$10 (expr
-              (invocation close expr:
-                (simple-var-ref ac) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$10))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$10))) ())
+                (literal 0)))))
           (expression-stmt
-            (simple-var-ref $desugar$10))
-          (var-def
-            (variable $desugar$11 (expr
-              (invocation io fileReadString (
-                (simple-var-ref path))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$11))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$11))) ())
+            (checked-expr
+              (invocation close expr:
+                (simple-var-ref ac) ())))
           (expression-stmt
             (invocation io println (
-              (simple-var-ref $desugar$11))))
+              (checked-expr
+                (invocation io fileReadString (
+                  (simple-var-ref path)))))))
           (var-def
             (variable lpath (type
               (value-type string)) (expr
               (literal /tmp/bal_io_char_write_latin1.txt))))
           (var-def
-            (variable $desugar$12 (expr
+            (variable $desugar$2 (expr
               (simple-var-ref lpath))))
           (var-def
-            (variable $desugar$13 (expr
+            (variable $desugar$3 (expr
               (invocation $default$11 (
-                (simple-var-ref $desugar$12))))))
-          (var-def
-            (variable $desugar$14 (expr
-              (invocation io openWritableFile (
-                (simple-var-ref $desugar$12)
-                (simple-var-ref $desugar$13))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$14))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$14))) ())
+                (simple-var-ref $desugar$2))))))
           (var-def
             (variable lb (type
               (user-defined-type io WritableByteChannel)) (expr
-              (simple-var-ref $desugar$14))))
+              (checked-expr
+                (invocation io openWritableFile (
+                  (simple-var-ref $desugar$2)
+                  (simple-var-ref $desugar$3)))))))
           (var-def
             (variable lc (type
               (user-defined-type io WritableCharacterChannel)) (expr
@@ -245,185 +157,97 @@
                 (simple-var-ref lb)
                 (literal ISO-8859-1))))))
           (var-def
-            (variable $desugar$15 (expr
-              (invocation write expr:
-                (simple-var-ref lc) (
-                (literal café)
-                (literal 0))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$15))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$15))) ())
-          (var-def
             (variable n3 (type
               (value-type int)) (expr
-              (simple-var-ref $desugar$15))))
+              (checked-expr
+                (invocation write expr:
+                  (simple-var-ref lc) (
+                  (literal café)
+                  (literal 0)))))))
           (expression-stmt
             (invocation io println (
               (simple-var-ref n3))))
-          (var-def
-            (variable $desugar$16 (expr
-              (invocation close expr:
-                (simple-var-ref lc) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$16))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$16))) ())
           (expression-stmt
-            (simple-var-ref $desugar$16))
-          (var-def
-            (variable $desugar$17 (expr
-              (invocation io fileReadBytes (
-                (simple-var-ref lpath))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$17))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$17))) ())
+            (checked-expr
+              (invocation close expr:
+                (simple-var-ref lc) ())))
           (var-def
             (variable latinBytes (type
               (array-type
                 (value-type byte) dimensions: 1 ([]))) (expr
-              (simple-var-ref $desugar$17))))
+              (checked-expr
+                (invocation io fileReadBytes (
+                  (simple-var-ref lpath)))))))
           (expression-stmt
             (invocation io println (
               (invocation lang.array length (
                 (simple-var-ref latinBytes))))))
           (var-def
-            (variable $desugar$18 (expr
-              (invocation io openReadableFile (
-                (simple-var-ref lpath))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$18))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$18))) ())
-          (var-def
             (variable lrb (type
               (user-defined-type io ReadableByteChannel)) (expr
-              (simple-var-ref $desugar$18))))
+              (checked-expr
+                (invocation io openReadableFile (
+                  (simple-var-ref lpath)))))))
           (var-def
             (variable lrc (type
               (user-defined-type io ReadableCharacterChannel)) (expr
               (new (
                 (simple-var-ref lrb)
                 (literal ISO-8859-1))))))
-          (var-def
-            (variable $desugar$19 (expr
-              (invocation readString expr:
-                (simple-var-ref lrc) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$19))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$19))) ())
           (expression-stmt
             (invocation io println (
-              (simple-var-ref $desugar$19))))
-          (var-def
-            (variable $desugar$20 (expr
-              (invocation close expr:
-                (simple-var-ref lrc) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$20))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$20))) ())
+              (checked-expr
+                (invocation readString expr:
+                  (simple-var-ref lrc) ())))))
           (expression-stmt
-            (simple-var-ref $desugar$20))
+            (checked-expr
+              (invocation close expr:
+                (simple-var-ref lrc) ())))
           (var-def
             (variable upath (type
               (value-type string)) (expr
               (literal /tmp/bal_io_char_write_utf16.bin))))
           (var-def
-            (variable $desugar$21 (expr
+            (variable $desugar$4 (expr
               (simple-var-ref upath))))
           (var-def
-            (variable $desugar$22 (expr
+            (variable $desugar$5 (expr
               (invocation $default$11 (
-                (simple-var-ref $desugar$21))))))
-          (var-def
-            (variable $desugar$23 (expr
-              (invocation io openWritableFile (
-                (simple-var-ref $desugar$21)
-                (simple-var-ref $desugar$22))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$23))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$23))) ())
+                (simple-var-ref $desugar$4))))))
           (var-def
             (variable ub (type
               (user-defined-type io WritableByteChannel)) (expr
-              (simple-var-ref $desugar$23))))
+              (checked-expr
+                (invocation io openWritableFile (
+                  (simple-var-ref $desugar$4)
+                  (simple-var-ref $desugar$5)))))))
           (var-def
             (variable uc (type
               (user-defined-type io WritableCharacterChannel)) (expr
               (new (
                 (simple-var-ref ub)
                 (literal UTF-16))))))
-          (var-def
-            (variable $desugar$24 (expr
+          (expression-stmt
+            (checked-expr
               (invocation writeLine expr:
                 (simple-var-ref uc) (
-                (literal hi))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$24))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$24))) ())
+                (literal hi)))))
           (expression-stmt
-            (simple-var-ref $desugar$24))
-          (var-def
-            (variable $desugar$25 (expr
+            (checked-expr
               (invocation writeLine expr:
                 (simple-var-ref uc) (
-                (literal bye))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$25))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$25))) ())
+                (literal bye)))))
           (expression-stmt
-            (simple-var-ref $desugar$25))
-          (var-def
-            (variable $desugar$26 (expr
+            (checked-expr
               (invocation close expr:
-                (simple-var-ref uc) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$26))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$26))) ())
-          (expression-stmt
-            (simple-var-ref $desugar$26))
-          (var-def
-            (variable $desugar$27 (expr
-              (invocation io fileReadBytes (
-                (simple-var-ref upath))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$27))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$27))) ())
+                (simple-var-ref uc) ())))
           (var-def
             (variable utf16Bytes (type
               (array-type
                 (value-type byte) dimensions: 1 ([]))) (expr
-              (simple-var-ref $desugar$27))))
+              (checked-expr
+                (invocation io fileReadBytes (
+                  (simple-var-ref upath)))))))
           (expression-stmt
             (invocation io println (
               (invocation lang.array length (

--- a/corpus/desugared/library/subset3/io-char-channel-xml-nonelement-p.txt
+++ b/corpus/desugared/library/subset3/io-char-channel-xml-nonelement-p.txt
@@ -13,20 +13,12 @@
           (invocation $default$11 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable wb (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
         (variable wc (type
           (user-defined-type io WritableCharacterChannel)) (expr
@@ -39,23 +31,15 @@
           (xml-sequence-literal
             (xml-comment-literal c)
             (xml-element-literal note)))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation writeXml expr:
             (simple-var-ref wc) (
             (simple-var-ref seq)
             (mapping-constructor-expr
               (key-value
                 (literal system)
-                (literal note.dtd))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
+                (literal note.dtd)))))))
       (expression-stmt
         (invocation io println (
           (literal unreached)))))))

--- a/corpus/desugared/library/subset3/io-data-channel-edge-v.txt
+++ b/corpus/desugared/library/subset3/io-data-channel-edge-v.txt
@@ -8,46 +8,30 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation io createReadableChannel (
-            (list-constructor-expr
-              (literal 1)
-              (literal 2)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable cb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation io createReadableChannel (
+              (list-constructor-expr
+                (literal 1)
+                (literal 2))))))))
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (simple-var-ref cb))))
       (var-def
-        (variable $desugar$2 (expr
+        (variable $desugar$1 (expr
           (invocation $default$9 (
-            (simple-var-ref $desugar$1))))))
+            (simple-var-ref $desugar$0))))))
       (var-def
         (variable cd (type
           (user-defined-type io ReadableDataChannel)) (expr
           (new (
-            (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation close expr:
-            (simple-var-ref cd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+            (simple-var-ref $desugar$0)
+            (simple-var-ref $desugar$1))))))
       (expression-stmt
-        (simple-var-ref $desugar$3))
+        (checked-expr
+          (invocation close expr:
+            (simple-var-ref cd) ())))
       (var-def
         (variable closedAgain (type
           (union-type
@@ -83,48 +67,32 @@
                   (simple-var-ref closedRead))))))) ())
         (block-stmt
           (var-def
-            (variable $desugar$4 (expr
-              (invocation io createReadableChannel (
-                (list-constructor-expr))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$4))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$4))) ())
-          (var-def
             (variable eb (type
               (user-defined-type io ReadableByteChannel)) (expr
-              (simple-var-ref $desugar$4))))
+              (checked-expr
+                (invocation io createReadableChannel (
+                  (list-constructor-expr)))))))
           (var-def
-            (variable $desugar$5 (expr
+            (variable $desugar$2 (expr
               (simple-var-ref eb))))
           (var-def
-            (variable $desugar$6 (expr
+            (variable $desugar$3 (expr
               (invocation $default$9 (
-                (simple-var-ref $desugar$5))))))
+                (simple-var-ref $desugar$2))))))
           (var-def
             (variable ed (type
               (user-defined-type io ReadableDataChannel)) (expr
               (new (
-                (simple-var-ref $desugar$5)
-                (simple-var-ref $desugar$6))))))
-          (var-def
-            (variable $desugar$7 (expr
-              (invocation readString expr:
-                (simple-var-ref ed) (
-                (literal 3)
-                (literal UTF-8))))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$7))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$7))) ())
+                (simple-var-ref $desugar$2)
+                (simple-var-ref $desugar$3))))))
           (var-def
             (variable first (type
               (value-type string)) (expr
-              (simple-var-ref $desugar$7))))
+              (checked-expr
+                (invocation readString expr:
+                  (simple-var-ref ed) (
+                  (literal 3)
+                  (literal UTF-8)))))))
           (expression-stmt
             (invocation io println (
               (invocation lang.string length (
@@ -149,32 +117,24 @@
                     (simple-var-ref second))))))) ())
           (block-stmt
             (var-def
-              (variable $desugar$8 (expr
-                (invocation io createReadableChannel (
-                  (list-constructor-expr))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$8))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$8))) ())
-            (var-def
               (variable tb (type
                 (user-defined-type io ReadableByteChannel)) (expr
-                (simple-var-ref $desugar$8))))
+                (checked-expr
+                  (invocation io createReadableChannel (
+                    (list-constructor-expr)))))))
             (var-def
-              (variable $desugar$9 (expr
+              (variable $desugar$4 (expr
                 (simple-var-ref tb))))
             (var-def
-              (variable $desugar$10 (expr
+              (variable $desugar$5 (expr
                 (invocation $default$9 (
-                  (simple-var-ref $desugar$9))))))
+                  (simple-var-ref $desugar$4))))))
             (var-def
               (variable td (type
                 (user-defined-type io ReadableDataChannel)) (expr
                 (new (
-                  (simple-var-ref $desugar$9)
-                  (simple-var-ref $desugar$10))))))
+                  (simple-var-ref $desugar$4)
+                  (simple-var-ref $desugar$5))))))
             (var-def
               (variable trapped (type
                 (union-type
@@ -189,277 +149,149 @@
                   (simple-var-ref trapped)
                   (error-type)))))
             (var-def
-              (variable $desugar$11 (expr
-                (invocation io createReadableChannel (
-                  (list-constructor-expr
-                    (literal 1)
-                    (literal 2)))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$11))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$11))) ())
-            (var-def
               (variable sb (type
                 (user-defined-type io ReadableByteChannel)) (expr
-                (simple-var-ref $desugar$11))))
+                (checked-expr
+                  (invocation io createReadableChannel (
+                    (list-constructor-expr
+                      (literal 1)
+                      (literal 2))))))))
             (var-def
-              (variable $desugar$12 (expr
+              (variable $desugar$6 (expr
                 (simple-var-ref sb))))
             (var-def
-              (variable $desugar$13 (expr
+              (variable $desugar$7 (expr
                 (invocation $default$9 (
-                  (simple-var-ref $desugar$12))))))
+                  (simple-var-ref $desugar$6))))))
             (var-def
               (variable sd (type
                 (user-defined-type io ReadableDataChannel)) (expr
                 (new (
-                  (simple-var-ref $desugar$12)
-                  (simple-var-ref $desugar$13))))))
-            (var-def
-              (variable $desugar$14 (expr
-                (invocation readInt32 expr:
-                  (simple-var-ref sd) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$14))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$14))) ())
+                  (simple-var-ref $desugar$6)
+                  (simple-var-ref $desugar$7))))))
             (expression-stmt
               (invocation io println (
-                (simple-var-ref $desugar$14))))
-            (var-def
-              (variable $desugar$15 (expr
-                (invocation io createReadableChannel (
-                  (list-constructor-expr
-                    (literal 1)
-                    (literal 2)))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$15))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$15))) ())
+                (checked-expr
+                  (invocation readInt32 expr:
+                    (simple-var-ref sd) ())))))
             (var-def
               (variable lb (type
                 (user-defined-type io ReadableByteChannel)) (expr
-                (simple-var-ref $desugar$15))))
+                (checked-expr
+                  (invocation io createReadableChannel (
+                    (list-constructor-expr
+                      (literal 1)
+                      (literal 2))))))))
             (var-def
               (variable ld (type
                 (user-defined-type io ReadableDataChannel)) (expr
                 (new (
                   (simple-var-ref lb)
                   (literal LE))))))
-            (var-def
-              (variable $desugar$16 (expr
-                (invocation readInt32 expr:
-                  (simple-var-ref ld) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$16))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$16))) ())
             (expression-stmt
               (invocation io println (
-                (simple-var-ref $desugar$16))))
+                (checked-expr
+                  (invocation readInt32 expr:
+                    (simple-var-ref ld) ())))))
             (var-def
               (variable path (type
                 (value-type string)) (expr
                 (literal /tmp/bal_io_dc_varint.bin))))
             (var-def
-              (variable $desugar$17 (expr
+              (variable $desugar$8 (expr
                 (simple-var-ref path))))
             (var-def
-              (variable $desugar$18 (expr
+              (variable $desugar$9 (expr
                 (invocation $default$11 (
-                  (simple-var-ref $desugar$17))))))
-            (var-def
-              (variable $desugar$19 (expr
-                (invocation io openWritableFile (
-                  (simple-var-ref $desugar$17)
-                  (simple-var-ref $desugar$18))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$19))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$19))) ())
+                  (simple-var-ref $desugar$8))))))
             (var-def
               (variable wb (type
                 (user-defined-type io WritableByteChannel)) (expr
-                (simple-var-ref $desugar$19))))
+                (checked-expr
+                  (invocation io openWritableFile (
+                    (simple-var-ref $desugar$8)
+                    (simple-var-ref $desugar$9)))))))
             (var-def
-              (variable $desugar$20 (expr
+              (variable $desugar$10 (expr
                 (simple-var-ref wb))))
             (var-def
-              (variable $desugar$21 (expr
+              (variable $desugar$11 (expr
                 (invocation $default$10 (
-                  (simple-var-ref $desugar$20))))))
+                  (simple-var-ref $desugar$10))))))
             (var-def
               (variable wd (type
                 (user-defined-type io WritableDataChannel)) (expr
                 (new (
-                  (simple-var-ref $desugar$20)
-                  (simple-var-ref $desugar$21))))))
-            (var-def
-              (variable $desugar$22 (expr
+                  (simple-var-ref $desugar$10)
+                  (simple-var-ref $desugar$11))))))
+            (expression-stmt
+              (checked-expr
                 (invocation writeVarInt expr:
                   (simple-var-ref wd) (
-                  (literal 1))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$22))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$22))) ())
+                  (literal 1)))))
             (expression-stmt
-              (simple-var-ref $desugar$22))
-            (var-def
-              (variable $desugar$23 (expr
+              (checked-expr
                 (invocation writeVarInt expr:
                   (simple-var-ref wd) (
                   (unary-expr -
-                    (literal 1)))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$23))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$23))) ())
+                    (literal 1))))))
             (expression-stmt
-              (simple-var-ref $desugar$23))
-            (var-def
-              (variable $desugar$24 (expr
+              (checked-expr
                 (invocation writeVarInt expr:
                   (simple-var-ref wd) (
-                  (literal 9223372036854775807))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$24))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$24))) ())
+                  (literal 9223372036854775807)))))
             (expression-stmt
-              (simple-var-ref $desugar$24))
-            (var-def
-              (variable $desugar$25 (expr
+              (checked-expr
                 (invocation writeVarInt expr:
                   (simple-var-ref wd) (
                   (binary-expr -
                     (unary-expr -
                       (literal 9223372036854775807))
-                    (literal 1)))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$25))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$25))) ())
+                    (literal 1))))))
             (expression-stmt
-              (simple-var-ref $desugar$25))
-            (var-def
-              (variable $desugar$26 (expr
+              (checked-expr
                 (invocation close expr:
-                  (simple-var-ref wd) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$26))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$26))) ())
-            (expression-stmt
-              (simple-var-ref $desugar$26))
-            (var-def
-              (variable $desugar$27 (expr
-                (invocation io openReadableFile (
-                  (simple-var-ref path))))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$27))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$27))) ())
+                  (simple-var-ref wd) ())))
             (var-def
               (variable rb (type
                 (user-defined-type io ReadableByteChannel)) (expr
-                (simple-var-ref $desugar$27))))
+                (checked-expr
+                  (invocation io openReadableFile (
+                    (simple-var-ref path)))))))
             (var-def
-              (variable $desugar$28 (expr
+              (variable $desugar$12 (expr
                 (simple-var-ref rb))))
             (var-def
-              (variable $desugar$29 (expr
+              (variable $desugar$13 (expr
                 (invocation $default$9 (
-                  (simple-var-ref $desugar$28))))))
+                  (simple-var-ref $desugar$12))))))
             (var-def
               (variable rd (type
                 (user-defined-type io ReadableDataChannel)) (expr
                 (new (
-                  (simple-var-ref $desugar$28)
-                  (simple-var-ref $desugar$29))))))
-            (var-def
-              (variable $desugar$30 (expr
-                (invocation readVarInt expr:
-                  (simple-var-ref rd) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$30))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$30))) ())
+                  (simple-var-ref $desugar$12)
+                  (simple-var-ref $desugar$13))))))
             (expression-stmt
               (invocation io println (
-                (simple-var-ref $desugar$30))))
-            (var-def
-              (variable $desugar$31 (expr
-                (invocation readVarInt expr:
-                  (simple-var-ref rd) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$31))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$31))) ())
+                (checked-expr
+                  (invocation readVarInt expr:
+                    (simple-var-ref rd) ())))))
             (expression-stmt
               (invocation io println (
-                (simple-var-ref $desugar$31))))
-            (var-def
-              (variable $desugar$32 (expr
-                (invocation readVarInt expr:
-                  (simple-var-ref rd) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$32))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$32))) ())
+                (checked-expr
+                  (invocation readVarInt expr:
+                    (simple-var-ref rd) ())))))
             (expression-stmt
               (invocation io println (
-                (simple-var-ref $desugar$32))))
-            (var-def
-              (variable $desugar$33 (expr
-                (invocation readVarInt expr:
-                  (simple-var-ref rd) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$33))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$33))) ())
+                (checked-expr
+                  (invocation readVarInt expr:
+                    (simple-var-ref rd) ())))))
             (expression-stmt
               (invocation io println (
-                (simple-var-ref $desugar$33))))
-            (var-def
-              (variable $desugar$34 (expr
+                (checked-expr
+                  (invocation readVarInt expr:
+                    (simple-var-ref rd) ())))))
+            (expression-stmt
+              (checked-expr
                 (invocation close expr:
-                  (simple-var-ref rd) ()))))
-            (if
-              (type-test-expr is
-                (simple-var-ref $desugar$34))
-              (block-stmt
-                (return
-                  (simple-var-ref $desugar$34))) ())
-            (expression-stmt
-              (simple-var-ref $desugar$34))))))))
+                  (simple-var-ref rd) ())))))))))

--- a/corpus/desugared/library/subset3/io-data-channel-eof-p.txt
+++ b/corpus/desugared/library/subset3/io-data-channel-eof-p.txt
@@ -6,46 +6,30 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation io createReadableChannel (
-            (list-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable rb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation io createReadableChannel (
+              (list-constructor-expr)))))))
       (var-def
-        (variable $desugar$1 (expr
+        (variable $desugar$0 (expr
           (simple-var-ref rb))))
       (var-def
-        (variable $desugar$2 (expr
+        (variable $desugar$1 (expr
           (invocation $default$9 (
-            (simple-var-ref $desugar$1))))))
+            (simple-var-ref $desugar$0))))))
       (var-def
         (variable rd (type
           (user-defined-type io ReadableDataChannel)) (expr
           (new (
-            (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation readInt64 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+            (simple-var-ref $desugar$0)
+            (simple-var-ref $desugar$1))))))
       (var-def
         (variable n (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation readInt64 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref n)))))))

--- a/corpus/desugared/library/subset3/io-data-channel-rw-v.txt
+++ b/corpus/desugared/library/subset3/io-data-channel-rw-v.txt
@@ -17,487 +17,207 @@
           (invocation $default$11 (
             (simple-var-ref $desugar$0))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation io openWritableFile (
-            (simple-var-ref $desugar$0)
-            (simple-var-ref $desugar$1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable wb (type
           (user-defined-type io WritableByteChannel)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation io openWritableFile (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (var-def
         (variable wd (type
           (user-defined-type io WritableDataChannel)) (expr
           (new (
             (simple-var-ref wb)
             (simple-var-ref ord))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation writeInt16 expr:
             (simple-var-ref wd) (
-            (literal 4660))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
+            (literal 4660)))))
       (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
+        (checked-expr
           (invocation writeInt16 expr:
             (simple-var-ref wd) (
             (unary-expr -
-              (literal 2)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+              (literal 2))))))
       (expression-stmt
-        (simple-var-ref $desugar$4))
-      (var-def
-        (variable $desugar$5 (expr
+        (checked-expr
           (invocation writeInt32 expr:
             (simple-var-ref wd) (
-            (literal 305419896))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
+            (literal 305419896)))))
       (expression-stmt
-        (simple-var-ref $desugar$5))
-      (var-def
-        (variable $desugar$6 (expr
+        (checked-expr
           (invocation writeInt32 expr:
             (simple-var-ref wd) (
             (unary-expr -
-              (literal 40000)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
+              (literal 40000))))))
       (expression-stmt
-        (simple-var-ref $desugar$6))
-      (var-def
-        (variable $desugar$7 (expr
+        (checked-expr
           (invocation writeInt64 expr:
             (simple-var-ref wd) (
-            (literal 81985529216486895))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
+            (literal 81985529216486895)))))
       (expression-stmt
-        (simple-var-ref $desugar$7))
-      (var-def
-        (variable $desugar$8 (expr
+        (checked-expr
           (invocation writeInt64 expr:
             (simple-var-ref wd) (
             (unary-expr -
-              (literal 5)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+              (literal 5))))))
       (expression-stmt
-        (simple-var-ref $desugar$8))
-      (var-def
-        (variable $desugar$9 (expr
+        (checked-expr
           (invocation writeFloat32 expr:
             (simple-var-ref wd) (
-            (literal 3.5))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+            (literal 3.5)))))
       (expression-stmt
-        (simple-var-ref $desugar$9))
-      (var-def
-        (variable $desugar$10 (expr
+        (checked-expr
           (invocation writeFloat64 expr:
             (simple-var-ref wd) (
-            (literal 2.718281828459045))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
+            (literal 2.718281828459045)))))
       (expression-stmt
-        (simple-var-ref $desugar$10))
-      (var-def
-        (variable $desugar$11 (expr
+        (checked-expr
           (invocation writeBool expr:
             (simple-var-ref wd) (
-            (literal true))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
+            (literal true)))))
       (expression-stmt
-        (simple-var-ref $desugar$11))
-      (var-def
-        (variable $desugar$12 (expr
+        (checked-expr
           (invocation writeBool expr:
             (simple-var-ref wd) (
-            (literal false))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$12))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$12))) ())
+            (literal false)))))
       (expression-stmt
-        (simple-var-ref $desugar$12))
-      (var-def
-        (variable $desugar$13 (expr
+        (checked-expr
           (invocation writeString expr:
             (simple-var-ref wd) (
             (literal héllo)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
+            (literal UTF-8)))))
       (expression-stmt
-        (simple-var-ref $desugar$13))
-      (var-def
-        (variable $desugar$14 (expr
+        (checked-expr
           (invocation writeVarInt expr:
             (simple-var-ref wd) (
-            (literal 0))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
+            (literal 0)))))
       (expression-stmt
-        (simple-var-ref $desugar$14))
-      (var-def
-        (variable $desugar$15 (expr
+        (checked-expr
           (invocation writeVarInt expr:
             (simple-var-ref wd) (
-            (literal 300))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$15))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$15))) ())
+            (literal 300)))))
       (expression-stmt
-        (simple-var-ref $desugar$15))
-      (var-def
-        (variable $desugar$16 (expr
+        (checked-expr
           (invocation writeVarInt expr:
             (simple-var-ref wd) (
             (unary-expr -
-              (literal 300)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$16))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$16))) ())
+              (literal 300))))))
       (expression-stmt
-        (simple-var-ref $desugar$16))
-      (var-def
-        (variable $desugar$17 (expr
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref wd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$17))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$17))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$17))
-      (var-def
-        (variable $desugar$18 (expr
-          (invocation io openReadableFile (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
+            (simple-var-ref wd) ())))
       (var-def
         (variable rb (type
           (user-defined-type io ReadableByteChannel)) (expr
-          (simple-var-ref $desugar$18))))
+          (checked-expr
+            (invocation io openReadableFile (
+              (simple-var-ref path)))))))
       (var-def
         (variable rd (type
           (user-defined-type io ReadableDataChannel)) (expr
           (new (
             (simple-var-ref rb)
             (simple-var-ref ord))))))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation readInt16 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$19))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$19))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$19))))
-      (var-def
-        (variable $desugar$20 (expr
-          (invocation readInt16 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$20))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$20))) ())
+          (checked-expr
+            (invocation readInt16 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (invocation readInt32 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$21))) ())
+          (checked-expr
+            (invocation readInt16 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$21))))
-      (var-def
-        (variable $desugar$22 (expr
-          (invocation readInt32 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$22))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$22))) ())
+          (checked-expr
+            (invocation readInt32 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$22))))
-      (var-def
-        (variable $desugar$23 (expr
-          (invocation readInt64 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$23))) ())
+          (checked-expr
+            (invocation readInt32 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$23))))
-      (var-def
-        (variable $desugar$24 (expr
-          (invocation readInt64 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$24))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$24))) ())
+          (checked-expr
+            (invocation readInt64 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$24))))
-      (var-def
-        (variable $desugar$25 (expr
-          (invocation readFloat32 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$25))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$25))) ())
+          (checked-expr
+            (invocation readInt64 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$25))))
-      (var-def
-        (variable $desugar$26 (expr
-          (invocation readFloat64 expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$26))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$26))) ())
+          (checked-expr
+            (invocation readFloat32 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$26))))
-      (var-def
-        (variable $desugar$27 (expr
-          (invocation readBool expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$27))) ())
+          (checked-expr
+            (invocation readFloat64 expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$27))))
-      (var-def
-        (variable $desugar$28 (expr
-          (invocation readBool expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$28))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$28))) ())
+          (checked-expr
+            (invocation readBool expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$28))))
-      (var-def
-        (variable $desugar$29 (expr
-          (invocation readString expr:
-            (simple-var-ref rd) (
-            (literal 6)
-            (literal UTF-8))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$29))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$29))) ())
+          (checked-expr
+            (invocation readBool expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$29))))
-      (var-def
-        (variable $desugar$30 (expr
-          (invocation readVarInt expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$30))) ())
+          (checked-expr
+            (invocation readString expr:
+              (simple-var-ref rd) (
+              (literal 6)
+              (literal UTF-8)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$30))))
-      (var-def
-        (variable $desugar$31 (expr
-          (invocation readVarInt expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$31))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$31))) ())
+          (checked-expr
+            (invocation readVarInt expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$31))))
-      (var-def
-        (variable $desugar$32 (expr
-          (invocation readVarInt expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$32))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$32))) ())
+          (checked-expr
+            (invocation readVarInt expr:
+              (simple-var-ref rd) ())))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$32))))
-      (var-def
-        (variable $desugar$33 (expr
+          (checked-expr
+            (invocation readVarInt expr:
+              (simple-var-ref rd) ())))))
+      (expression-stmt
+        (checked-expr
           (invocation close expr:
-            (simple-var-ref rd) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$33))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$33))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$33))))
+            (simple-var-ref rd) ())))))
   (function main () (
     (union-type
       (error-type)
       (value-type null)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation roundtrip (
             (literal BE)
-            (literal /tmp/bal_io_dc_be.bin))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
+            (literal /tmp/bal_io_dc_be.bin)))))
       (expression-stmt
-        (simple-var-ref $desugar$0))
-      (var-def
-        (variable $desugar$1 (expr
+        (checked-expr
           (invocation roundtrip (
             (literal LE)
-            (literal /tmp/bal_io_dc_le.bin))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$1))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation io fileReadBytes (
-            (literal /tmp/bal_io_dc_be.bin))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
+            (literal /tmp/bal_io_dc_le.bin)))))
       (var-def
         (variable beBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (literal /tmp/bal_io_dc_be.bin)))))))
       (var-def
         (variable beExpected (type
           (array-type
@@ -562,20 +282,12 @@
             (simple-var-ref beBytes)
             (simple-var-ref beExpected)))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation io fileReadBytes (
-            (literal /tmp/bal_io_dc_le.bin))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable leBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (literal /tmp/bal_io_dc_le.bin)))))))
       (var-def
         (variable leExpected (type
           (array-type

--- a/corpus/desugared/library/subset3/io-stream-errors-v.txt
+++ b/corpus/desugared/library/subset3/io-stream-errors-v.txt
@@ -131,20 +131,12 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$2)
             (simple-var-ref $desugar$3))))))
-      (var-def
-        (variable $desugar$5 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$2)
             (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$4))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$5))
+            (simple-var-ref $desugar$4)))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -167,25 +159,25 @@
             (new
               (user-defined-type FailingLineProvider) ()))))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$5 (expr
           (simple-var-ref linesPath))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$6 (expr
           (simple-var-ref lineStream))))
       (var-def
-        (variable $desugar$8 (expr
+        (variable $desugar$7 (expr
           (invocation $default$3 (
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
+            (simple-var-ref $desugar$5)
+            (simple-var-ref $desugar$6))))))
       (var-def
         (variable lineResult (type
           (union-type
             (user-defined-type io Error)
             (value-type null))) (expr
           (invocation io fileWriteLinesFromStream (
+            (simple-var-ref $desugar$5)
             (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7)
-            (simple-var-ref $desugar$8))))))
+            (simple-var-ref $desugar$7))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -217,25 +209,25 @@
               (new
                 (user-defined-type FailingBlockProvider) ()))))))
         (var-def
-          (variable $desugar$9 (expr
+          (variable $desugar$8 (expr
             (simple-var-ref blocksPath))))
         (var-def
-          (variable $desugar$10 (expr
+          (variable $desugar$9 (expr
             (simple-var-ref blockStream))))
         (var-def
-          (variable $desugar$11 (expr
+          (variable $desugar$10 (expr
             (invocation $default$5 (
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
+              (simple-var-ref $desugar$8)
+              (simple-var-ref $desugar$9))))))
         (var-def
           (variable blockResult (type
             (union-type
               (user-defined-type io Error)
               (value-type null))) (expr
             (invocation io fileWriteBlocksFromStream (
+              (simple-var-ref $desugar$8)
               (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10)
-              (simple-var-ref $desugar$11))))))
+              (simple-var-ref $desugar$10))))))
         (expression-stmt
           (invocation io println (
             (type-test-expr is

--- a/corpus/desugared/library/subset3/io-stream-generic-completion1-v.txt
+++ b/corpus/desugared/library/subset3/io-stream-generic-completion1-v.txt
@@ -30,31 +30,12 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadBlocksAsStream (
-            (simple-var-ref inPath)
-            (literal 2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable blocks (type
           (stream-type
@@ -63,88 +44,57 @@
             (union-type
               (error-type)
               (value-type null)))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadBlocksAsStream (
+              (simple-var-ref inPath)
+              (literal 2)))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$3 (expr
           (simple-var-ref outPath))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$4 (expr
           (simple-var-ref blocks))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$5 (expr
           (invocation $default$5 (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6))))))
-      (var-def
-        (variable $desugar$8 (expr
-          (invocation io fileWriteBlocksFromStream (
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$6)
-            (simple-var-ref $desugar$7))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4))))))
       (expression-stmt
-        (simple-var-ref $desugar$8))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation io fileReadBytes (
-            (simple-var-ref outPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+        (checked-expr
+          (invocation io fileWriteBlocksFromStream (
+            (simple-var-ref $desugar$3)
+            (simple-var-ref $desugar$4)
+            (simple-var-ref $desugar$5)))))
       (var-def
         (variable outBytes (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (simple-var-ref outPath)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
             (simple-var-ref outBytes))))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$6 (expr
           (simple-var-ref inPath))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$7 (expr
           (list-constructor-expr
             (literal Alpha)
             (literal Beta)))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$8 (expr
           (invocation $default$2 (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11))))))
-      (var-def
-        (variable $desugar$13 (expr
-          (invocation io fileWriteLines (
-            (simple-var-ref $desugar$10)
-            (simple-var-ref $desugar$11)
-            (simple-var-ref $desugar$12))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7))))))
       (expression-stmt
-        (simple-var-ref $desugar$13))
-      (var-def
-        (variable $desugar$14 (expr
-          (invocation io fileReadLinesAsStream (
-            (simple-var-ref inPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
+        (checked-expr
+          (invocation io fileWriteLines (
+            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$7)
+            (simple-var-ref $desugar$8)))))
       (var-def
         (variable lines (type
           (stream-type
@@ -152,47 +102,33 @@
             (union-type
               (error-type)
               (value-type null)))) (expr
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (invocation io fileReadLinesAsStream (
+              (simple-var-ref inPath)))))))
       (var-def
-        (variable $desugar$15 (expr
+        (variable $desugar$9 (expr
           (simple-var-ref outPath))))
       (var-def
-        (variable $desugar$16 (expr
+        (variable $desugar$10 (expr
           (simple-var-ref lines))))
       (var-def
-        (variable $desugar$17 (expr
+        (variable $desugar$11 (expr
           (invocation $default$3 (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16))))))
-      (var-def
-        (variable $desugar$18 (expr
-          (invocation io fileWriteLinesFromStream (
-            (simple-var-ref $desugar$15)
-            (simple-var-ref $desugar$16)
-            (simple-var-ref $desugar$17))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$18))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$18))) ())
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10))))))
       (expression-stmt
-        (simple-var-ref $desugar$18))
-      (var-def
-        (variable $desugar$19 (expr
-          (invocation io fileReadLines (
-            (simple-var-ref outPath))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$19))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$19))) ())
+        (checked-expr
+          (invocation io fileWriteLinesFromStream (
+            (simple-var-ref $desugar$9)
+            (simple-var-ref $desugar$10)
+            (simple-var-ref $desugar$11)))))
       (var-def
         (variable outLines (type
           (array-type
             (value-type string) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$19))))
+          (checked-expr
+            (invocation io fileReadLines (
+              (simple-var-ref outPath)))))))
       (expression-stmt
         (invocation io println (
           (index-based-access

--- a/corpus/desugared/library/subset3/io-stream-read-blocks1-v.txt
+++ b/corpus/desugared/library/subset3/io-stream-read-blocks1-v.txt
@@ -33,31 +33,12 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadBlocksAsStream (
-            (simple-var-ref blockPath)
-            (literal 3))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable s (type
           (stream-type
@@ -65,7 +46,10 @@
             (union-type
               (user-defined-type io Error)
               (value-type null)))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadBlocksAsStream (
+              (simple-var-ref blockPath)
+              (literal 3)))))))
       (var-def
         (variable r1 (type
           (union-type
@@ -180,51 +164,32 @@
                   (value-type string)) (expr
                   (literal /tmp/bal_io_stream_read_blocks_default.bin))))
               (var-def
-                (variable $desugar$5 (expr
+                (variable $desugar$3 (expr
                   (simple-var-ref defaultPath))))
               (var-def
-                (variable $desugar$6 (expr
+                (variable $desugar$4 (expr
                   (list-constructor-expr
                     (literal 9)
                     (literal 8)
                     (literal 7)))))
               (var-def
-                (variable $desugar$7 (expr
+                (variable $desugar$5 (expr
                   (invocation $default$4 (
-                    (simple-var-ref $desugar$5)
-                    (simple-var-ref $desugar$6))))))
-              (var-def
-                (variable $desugar$8 (expr
-                  (invocation io fileWriteBytes (
-                    (simple-var-ref $desugar$5)
-                    (simple-var-ref $desugar$6)
-                    (simple-var-ref $desugar$7))))))
-              (if
-                (type-test-expr is
-                  (simple-var-ref $desugar$8))
-                (block-stmt
-                  (return
-                    (simple-var-ref $desugar$8))) ())
+                    (simple-var-ref $desugar$3)
+                    (simple-var-ref $desugar$4))))))
               (expression-stmt
-                (simple-var-ref $desugar$8))
+                (checked-expr
+                  (invocation io fileWriteBytes (
+                    (simple-var-ref $desugar$3)
+                    (simple-var-ref $desugar$4)
+                    (simple-var-ref $desugar$5)))))
               (var-def
-                (variable $desugar$9 (expr
+                (variable $desugar$6 (expr
                   (simple-var-ref defaultPath))))
               (var-def
-                (variable $desugar$10 (expr
+                (variable $desugar$7 (expr
                   (invocation $default$0 (
-                    (simple-var-ref $desugar$9))))))
-              (var-def
-                (variable $desugar$11 (expr
-                  (invocation io fileReadBlocksAsStream (
-                    (simple-var-ref $desugar$9)
-                    (simple-var-ref $desugar$10))))))
-              (if
-                (type-test-expr is
-                  (simple-var-ref $desugar$11))
-                (block-stmt
-                  (return
-                    (simple-var-ref $desugar$11))) ())
+                    (simple-var-ref $desugar$6))))))
               (var-def
                 (variable defaultStream (type
                   (stream-type
@@ -232,7 +197,10 @@
                     (union-type
                       (user-defined-type io Error)
                       (value-type null)))) (expr
-                  (simple-var-ref $desugar$11))))
+                  (checked-expr
+                    (invocation io fileReadBlocksAsStream (
+                      (simple-var-ref $desugar$6)
+                      (simple-var-ref $desugar$7)))))))
               (var-def
                 (variable d1 (type
                   (union-type

--- a/corpus/desugared/library/subset3/io-stream-read-lines1-v.txt
+++ b/corpus/desugared/library/subset3/io-stream-read-lines1-v.txt
@@ -23,30 +23,12 @@
           (invocation $default$2 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteLines (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadLinesAsStream (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable s (type
           (stream-type
@@ -54,7 +36,9 @@
             (union-type
               (user-defined-type io Error)
               (value-type null)))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadLinesAsStream (
+              (simple-var-ref path)))))))
       (var-def
         (variable r1 (type
           (union-type

--- a/corpus/desugared/library/subset3/io-stream-read-lines2-v.txt
+++ b/corpus/desugared/library/subset3/io-stream-read-lines2-v.txt
@@ -26,30 +26,12 @@
           (invocation $default$4 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBytes (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadLinesAsStream (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable s (type
           (stream-type
@@ -57,7 +39,9 @@
             (union-type
               (user-defined-type io Error)
               (value-type null)))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadLinesAsStream (
+              (simple-var-ref path)))))))
       (var-def
         (variable r1 (type
           (union-type

--- a/corpus/desugared/library/subset3/io-stream-write-blocks1-v.txt
+++ b/corpus/desugared/library/subset3/io-stream-write-blocks1-v.txt
@@ -108,35 +108,19 @@
           (invocation $default$5 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBlocksFromStream (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadBytes (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable readBack (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (
@@ -166,35 +150,19 @@
                 (list-constructor-expr
                   (literal 7)
                   (literal 8))))))))))
-      (var-def
-        (variable $desugar$5 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteBlocksFromStream (
             (simple-var-ref path)
             (simple-var-ref appendStream)
-            (literal APPEND))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$5))
-      (var-def
-        (variable $desugar$6 (expr
-          (invocation io fileReadBytes (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
+            (literal APPEND)))))
       (var-def
         (variable combined (type
           (array-type
             (value-type byte) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation io fileReadBytes (
+              (simple-var-ref path)))))))
       (expression-stmt
         (invocation io println (
           (invocation lang.array length (

--- a/corpus/desugared/library/subset3/io-stream-write-lines1-v.txt
+++ b/corpus/desugared/library/subset3/io-stream-write-lines1-v.txt
@@ -100,63 +100,47 @@
           (invocation $default$3 (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteLinesFromStream (
             (simple-var-ref $desugar$0)
             (simple-var-ref $desugar$1)
-            (simple-var-ref $desugar$2))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$3))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation io fileReadLines (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$2)))))
       (var-def
         (variable lines (type
           (array-type
             (value-type string) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation io fileReadLines (
+              (simple-var-ref path)))))))
       (var-def
-        (variable $desugar$5 (expr
+        (variable $desugar$3 (expr
           (simple-var-ref lines))))
       (var-def
-        (variable $desugar$6 (expr
+        (variable $desugar$4 (expr
           (numeric-literal 0))))
       (var-def
-        (variable $desugar$7 (expr
+        (variable $desugar$5 (expr
           (invocation lang.array length (
-            (simple-var-ref $desugar$5))))))
+            (simple-var-ref $desugar$3))))))
       (while
         (binary-expr <
-          (simple-var-ref $desugar$6)
-          (simple-var-ref $desugar$7))
+          (simple-var-ref $desugar$4)
+          (simple-var-ref $desugar$5))
         (block-stmt
           (var-def
             (variable line (type
               (value-type string)) (expr
               (index-based-access
-                (simple-var-ref $desugar$5)
-                (simple-var-ref $desugar$6)))))
+                (simple-var-ref $desugar$3)
+                (simple-var-ref $desugar$4)))))
           (expression-stmt
             (invocation io println (
               (simple-var-ref line))))
           (assignment
-            (simple-var-ref $desugar$6)
+            (simple-var-ref $desugar$4)
             (binary-expr +
-              (simple-var-ref $desugar$6)
+              (simple-var-ref $desugar$4)
               (numeric-literal 1)))))
       (var-def
         (variable appendStream (type
@@ -170,61 +154,45 @@
               (user-defined-type LineProvider) (
               (list-constructor-expr
                 (literal Four)))))))))
-      (var-def
-        (variable $desugar$8 (expr
+      (expression-stmt
+        (checked-expr
           (invocation io fileWriteLinesFromStream (
             (simple-var-ref path)
             (simple-var-ref appendStream)
-            (literal APPEND))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$8))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation io fileReadLines (
-            (simple-var-ref path))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
+            (literal APPEND)))))
       (var-def
         (variable allLines (type
           (array-type
             (value-type string) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation io fileReadLines (
+              (simple-var-ref path)))))))
       (var-def
-        (variable $desugar$10 (expr
+        (variable $desugar$6 (expr
           (simple-var-ref allLines))))
       (var-def
-        (variable $desugar$11 (expr
+        (variable $desugar$7 (expr
           (numeric-literal 0))))
       (var-def
-        (variable $desugar$12 (expr
+        (variable $desugar$8 (expr
           (invocation lang.array length (
-            (simple-var-ref $desugar$10))))))
+            (simple-var-ref $desugar$6))))))
       (while
         (binary-expr <
-          (simple-var-ref $desugar$11)
-          (simple-var-ref $desugar$12))
+          (simple-var-ref $desugar$7)
+          (simple-var-ref $desugar$8))
         (block-stmt
           (var-def
             (variable line (type
               (value-type string)) (expr
               (index-based-access
-                (simple-var-ref $desugar$10)
-                (simple-var-ref $desugar$11)))))
+                (simple-var-ref $desugar$6)
+                (simple-var-ref $desugar$7)))))
           (expression-stmt
             (invocation io println (
               (simple-var-ref line))))
           (assignment
-            (simple-var-ref $desugar$11)
+            (simple-var-ref $desugar$7)
             (binary-expr +
-              (simple-var-ref $desugar$11)
+              (simple-var-ref $desugar$7)
               (numeric-literal 1))))))))

--- a/corpus/desugared/subset5/05-error/check-v.txt
+++ b/corpus/desugared/subset5/05-error/check-v.txt
@@ -18,18 +18,10 @@
     (error-type))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (invocation foo ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable a (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation foo ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a))))

--- a/corpus/desugared/subset5/05-error/check1-v.txt
+++ b/corpus/desugared/subset5/05-error/check1-v.txt
@@ -22,20 +22,12 @@
       (value-type int)
       (error-type)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation nonZero (
-            (simple-var-ref y))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (return
         (binary-expr /
           (simple-var-ref x)
-          (simple-var-ref $desugar$0)))))
+          (checked-expr
+            (invocation nonZero (
+              (simple-var-ref y))))))))
   (function nonZero (
     (variable n (type
       (value-type int)))) (

--- a/corpus/desugared/subset5/05-error/check2-v.txt
+++ b/corpus/desugared/subset5/05-error/check2-v.txt
@@ -3,15 +3,7 @@
   (function main () (
     (value-type null))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (literal 1))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$0)))))))
+          (checked-expr
+            (literal 1))))))))

--- a/corpus/desugared/subset5/05-error/check3-p.txt
+++ b/corpus/desugared/subset5/05-error/check3-p.txt
@@ -15,20 +15,12 @@
       (value-type int)))) (
     (value-type int))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation nonZero (
-            (simple-var-ref y))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
       (return
         (binary-expr /
           (simple-var-ref x)
-          (simple-var-ref $desugar$0)))))
+          (check-panicked-expr
+            (invocation nonZero (
+              (simple-var-ref y))))))))
   (function nonZero (
     (variable n (type
       (value-type int)))) (

--- a/corpus/desugared/subset5/05-error/check4-p.txt
+++ b/corpus/desugared/subset5/05-error/check4-p.txt
@@ -12,22 +12,14 @@
             (key-value
               (literal x)
               (literal 1))))))
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation nonNil (
-            (index-based-access
-              (simple-var-ref m)
-              (literal y)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
           (unary-expr -
-            (simple-var-ref $desugar$0)))))))
+            (check-panicked-expr
+              (invocation nonNil (
+                (index-based-access
+                  (simple-var-ref m)
+                  (literal y)))))))))))
   (function nonNil (
     (variable n (type
       (union-type

--- a/corpus/desugared/subset5/05-error/check5-v.txt
+++ b/corpus/desugared/subset5/05-error/check5-v.txt
@@ -12,22 +12,14 @@
             (key-value
               (literal x)
               (literal 3))))))
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation nonNil (
-            (index-based-access
-              (simple-var-ref m)
-              (literal x)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
           (unary-expr -
-            (simple-var-ref $desugar$0)))))))
+            (check-panicked-expr
+              (invocation nonNil (
+                (index-based-access
+                  (simple-var-ref m)
+                  (literal x)))))))))))
   (function nonNil (
     (variable n (type
       (union-type

--- a/corpus/desugared/subset6/06-object/implicit-new-check-v.txt
+++ b/corpus/desugared/subset6/06-object/implicit-new-check-v.txt
@@ -42,19 +42,11 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new (
-            (literal 5))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable c (type
           (user-defined-type Counter)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new (
+              (literal 5)))))))
       (expression-stmt
         (invocation io println (
           (invocation get expr:

--- a/corpus/desugared/subset6/06-object/init-error-check-v.txt
+++ b/corpus/desugared/subset6/06-object/init-error-check-v.txt
@@ -44,20 +44,12 @@
       (error-type)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new
-            (user-defined-type Foo) (
-            (simple-var-ref v))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable f (type
           (user-defined-type Foo)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new
+              (user-defined-type Foo) (
+              (simple-var-ref v)))))))
       (return
         (invocation getVal expr:
           (simple-var-ref f) ()))))

--- a/corpus/desugared/subset7/07-function/error2-p.txt
+++ b/corpus/desugared/subset7/07-function/error2-p.txt
@@ -26,23 +26,15 @@
   (function bar () (
     (value-type int))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
+      (return
+        (check-panicked-expr
           (invocation foo (
             (index-based-access
               (simple-var-ref vals)
               (literal 0))
             (index-based-access
               (simple-var-ref vals)
-              (literal 1)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
-      (return
-        (simple-var-ref $desugar$0))))
+              (literal 1))))))))
   (function foo () (
     (union-type
       (value-type int)

--- a/corpus/desugared/subset8/08-error/check1-v.txt
+++ b/corpus/desugared/subset8/08-error/check1-v.txt
@@ -11,17 +11,9 @@
       (error-type)
       (value-type null)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation newError ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
-        (simple-var-ref $desugar$0))))
+        (checked-expr
+          (invocation newError ())))))
   (function newError () (
     (union-type
       (error-type)

--- a/corpus/desugared/subset8/08-error/check10-v.txt
+++ b/corpus/desugared/subset8/08-error/check10-v.txt
@@ -11,26 +11,10 @@
       (error-type)
       (value-type null)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation alwaysErr ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref $desugar$0))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$1))) ())
       (expression-stmt
-        (simple-var-ref $desugar$1))))
+        (check-panicked-expr
+          (checked-expr
+            (invocation alwaysErr ()))))))
   (function alwaysErr () (
     (union-type
       (error-type)

--- a/corpus/desugared/subset8/08-error/check11-p.txt
+++ b/corpus/desugared/subset8/08-error/check11-p.txt
@@ -9,26 +9,10 @@
   (function doPanic () (
     (value-type null))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation alwaysErr ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref $desugar$0))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
       (expression-stmt
-        (simple-var-ref $desugar$1))))
+        (checked-expr
+          (check-panicked-expr
+            (invocation alwaysErr ()))))))
   (function alwaysErr () (
     (union-type
       (error-type)

--- a/corpus/desugared/subset8/08-error/check13-v.txt
+++ b/corpus/desugared/subset8/08-error/check13-v.txt
@@ -4,18 +4,10 @@
     (value-type int)))
   (function init () ()
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation mayFail ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (assignment
         (simple-var-ref moduleValue)
-        (simple-var-ref $desugar$0))))
+        (checked-expr
+          (invocation mayFail ())))))
   (function mayFail () (
     (union-type
       (value-type int)

--- a/corpus/desugared/subset8/08-error/check14-p.txt
+++ b/corpus/desugared/subset8/08-error/check14-p.txt
@@ -3,18 +3,10 @@
     (value-type int)))
   (function init () ()
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation mayFail ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (assignment
         (simple-var-ref moduleValue)
-        (simple-var-ref $desugar$0))))
+        (checked-expr
+          (invocation mayFail ())))))
   (function mayFail () (
     (union-type
       (value-type int)

--- a/corpus/desugared/subset8/08-error/check15-v.txt
+++ b/corpus/desugared/subset8/08-error/check15-v.txt
@@ -1,0 +1,37 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable result (type
+          (union-type
+            (error-type)
+            (value-type null))) (expr
+          (trap-expr
+            (invocation nestedScopeCheckpanic ())))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref result))))))
+  (function nestedScopeCheckpanic () (
+    (value-type null))
+    (block-function-body
+      (if
+        (literal true)
+        (block-stmt
+          (if
+            (literal true)
+            (block-stmt
+              (expression-stmt
+                (check-panicked-expr
+                  (invocation alwaysErr ())))) ())
+          (block-stmt)) ())
+      (block-stmt)))
+  (function alwaysErr () (
+    (union-type
+      (error-type)
+      (value-type null)))
+    (block-function-body
+      (return
+        (error-constructor-expr (
+          (literal original error)))))))

--- a/corpus/desugared/subset8/08-error/check2-v.txt
+++ b/corpus/desugared/subset8/08-error/check2-v.txt
@@ -11,17 +11,9 @@
       (value-type int)
       (error-type)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation neverErr ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
-        (simple-var-ref $desugar$0))
+        (checked-expr
+          (invocation neverErr ())))
       (return
         (literal 22))))
   (function neverErr () (

--- a/corpus/desugared/subset8/08-error/check3-v.txt
+++ b/corpus/desugared/subset8/08-error/check3-v.txt
@@ -9,17 +9,9 @@
   (function errorViaCheck () (
     (error-type))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation newError ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
-        (simple-var-ref $desugar$0))))
+        (checked-expr
+          (invocation newError ())))))
   (function newError () (
     (error-type))
     (block-function-body

--- a/corpus/desugared/subset8/08-error/check5-v.txt
+++ b/corpus/desugared/subset8/08-error/check5-v.txt
@@ -6,26 +6,10 @@
       (expression-stmt
         (invocation io println (
           (literal before))))
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation noOp ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref $desugar$0))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
       (expression-stmt
-        (simple-var-ref $desugar$1))
+        (checked-expr
+          (checked-expr
+            (invocation noOp ()))))
       (expression-stmt
         (invocation io println (
           (literal after))))))

--- a/corpus/desugared/subset8/08-error/check6-p.txt
+++ b/corpus/desugared/subset8/08-error/check6-p.txt
@@ -3,17 +3,9 @@
   (function main () (
     (value-type null))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation newError ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
-        (simple-var-ref $desugar$0))
+        (check-panicked-expr
+          (invocation newError ())))
       (expression-stmt
         (invocation io println (
           (literal may not reach))))))

--- a/corpus/desugared/subset8/08-error/check7-p.txt
+++ b/corpus/desugared/subset8/08-error/check7-p.txt
@@ -2,17 +2,9 @@
   (function main () (
     (value-type null))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation newError ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
-        (simple-var-ref $desugar$0))))
+        (check-panicked-expr
+          (invocation newError ())))))
   (function newError () (
     (error-type))
     (block-function-body

--- a/corpus/desugared/subset9/09-bug/listener-union-attach-point1-v.txt
+++ b/corpus/desugared/subset9/09-bug/listener-union-attach-point1-v.txt
@@ -82,40 +82,24 @@
       (var-def
         (variable $desugar$0 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref l) (
             (simple-var-ref $desugar$0)
             (list-constructor-expr
-              (literal foo)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))
+              (literal foo))))))
       (var-def
         (variable $desugar$1 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$1 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref l) (
             (simple-var-ref $desugar$1)
             (list-constructor-expr
               (literal foo)
-              (literal bar)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$1))))
+              (literal bar))))))))
   (function main () (
     (value-type null))
     (block-function-body))
@@ -141,18 +125,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -180,18 +156,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -219,18 +187,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-bug/string-literal-service-attach-point-v.txt
+++ b/corpus/desugared/subset9/09-bug/string-literal-service-attach-point-v.txt
@@ -130,56 +130,32 @@
       (var-def
         (variable $desugar$3 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref $desugar$0) (
             (simple-var-ref $desugar$3)
-            (literal watch))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))
+            (literal watch)))))
       (var-def
         (variable $desugar$4 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$1 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref $desugar$1) (
             (simple-var-ref $desugar$4)
             (list-constructor-expr
               (literal foo)
-              (literal bar)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$1))
+              (literal bar))))))
       (var-def
         (variable $desugar$5 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$2 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref $desugar$2) (
             (simple-var-ref $desugar$5)
-            (literal <nil>))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$2))))
+            (literal <nil>)))))))
   (function main () (
     (value-type null))
     (block-function-body))
@@ -211,18 +187,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -250,18 +218,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -289,18 +249,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-langlibs/boolean-from-string-v.txt
+++ b/corpus/desugared/subset9/09-langlibs/boolean-from-string-v.txt
@@ -3,84 +3,36 @@
   (function main () (
     (value-type null))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation boolean fromString (
-            (literal true))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$0))))
-      (var-def
-        (variable $desugar$1 (expr
-          (invocation boolean fromString (
-            (literal false))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$1))) ())
+          (check-panicked-expr
+            (invocation boolean fromString (
+              (literal true)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (invocation boolean fromString (
-            (literal TRUE))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$2))) ())
+          (check-panicked-expr
+            (invocation boolean fromString (
+              (literal false)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (invocation boolean fromString (
-            (literal False))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$3))) ())
+          (check-panicked-expr
+            (invocation boolean fromString (
+              (literal TRUE)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$3))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation boolean fromString (
-            (literal 1))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$4))) ())
+          (check-panicked-expr
+            (invocation boolean fromString (
+              (literal False)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$4))))
-      (var-def
-        (variable $desugar$5 (expr
-          (invocation boolean fromString (
-            (literal 0))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$5))) ())
+          (check-panicked-expr
+            (invocation boolean fromString (
+              (literal 1)))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$5))))
+          (check-panicked-expr
+            (invocation boolean fromString (
+              (literal 0)))))))
       (var-def
         (variable invalidWord (type
           (union-type

--- a/corpus/desugared/subset9/09-langlibs/string-from-to-bytes-v.txt
+++ b/corpus/desugared/subset9/09-langlibs/string-from-to-bytes-v.txt
@@ -15,19 +15,11 @@
             (literal 108)
             (literal 108)
             (literal 111)))))
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation string fromBytes (
-            (simple-var-ref bytes))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation string fromBytes (
+              (simple-var-ref bytes)))))))
       (expression-stmt
         (invocation io println (
           (invocation string toBytes (

--- a/corpus/desugared/subset9/09-object/attach-error1-p.txt
+++ b/corpus/desugared/subset9/09-object/attach-error1-p.txt
@@ -70,20 +70,12 @@
       (var-def
         (variable $desugar$0 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref l) (
             (simple-var-ref $desugar$0)
-            (literal <nil>))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))))
+            (literal <nil>)))))))
   (function main () (
     (value-type null))
     (block-function-body))
@@ -115,18 +107,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -154,18 +138,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -193,18 +169,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/documented-listener-service1-v.txt
+++ b/corpus/desugared/subset9/09-object/documented-listener-service1-v.txt
@@ -101,18 +101,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -140,18 +132,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -179,18 +163,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/init-incl-record-named-args-v.txt
+++ b/corpus/desugared/subset9/09-object/init-incl-record-named-args-v.txt
@@ -53,25 +53,17 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new (
-            (mapping-constructor-expr
-              (key-value
-                (literal path)
-                (literal /tmp))
-              (key-value
-                (literal recursive)
-                (literal true))))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable instance (type
           (user-defined-type Listener)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new (
+              (mapping-constructor-expr
+                (key-value
+                  (literal path)
+                  (literal /tmp))
+                (key-value
+                  (literal recursive)
+                  (literal true)))))))))
       (expression-stmt
         (invocation io println (
           (invocation describe expr:

--- a/corpus/desugared/subset9/09-object/init-named-args-v.txt
+++ b/corpus/desugared/subset9/09-object/init-named-args-v.txt
@@ -45,65 +45,41 @@
       (value-type null)))
     (block-function-body
       (var-def
-        (variable $desugar$0 (expr
-          (new (
-            (literal /tmp)
-            (literal true))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable named (type
           (user-defined-type Listener)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (new (
+              (literal /tmp)
+              (literal true)))))))
       (expression-stmt
         (invocation io println (
           (invocation describe expr:
             (simple-var-ref named) ()))))
       (var-def
-        (variable $desugar$1 (expr
-          (new (
-            (literal /var)
-            (literal true))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable mixed (type
           (user-defined-type Listener)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (new (
+              (literal /var)
+              (literal true)))))))
       (expression-stmt
         (invocation io println (
           (invocation describe expr:
             (simple-var-ref mixed) ()))))
       (var-def
-        (variable $desugar$2 (expr
+        (variable $desugar$0 (expr
           (literal /etc))))
       (var-def
-        (variable $desugar$3 (expr
+        (variable $desugar$1 (expr
           (invocation $default$0 (
-            (simple-var-ref $desugar$2))))))
-      (var-def
-        (variable $desugar$4 (expr
-          (new (
-            (simple-var-ref $desugar$2)
-            (simple-var-ref $desugar$3))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
+            (simple-var-ref $desugar$0))))))
       (var-def
         (variable defaulted (type
           (user-defined-type Listener)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (new (
+              (simple-var-ref $desugar$0)
+              (simple-var-ref $desugar$1)))))))
       (expression-stmt
         (invocation io println (
           (invocation describe expr:

--- a/corpus/desugared/subset9/09-object/listener-init-error1-p.txt
+++ b/corpus/desugared/subset9/09-object/listener-init-error1-p.txt
@@ -55,18 +55,10 @@
       (assignment
         (simple-var-ref $moduleListeners)
         (list-constructor-expr))
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation makeListener ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (assignment
         (simple-var-ref l)
-        (simple-var-ref $desugar$0))
+        (checked-expr
+          (invocation makeListener ())))
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
@@ -118,18 +110,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -157,18 +141,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -196,18 +172,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/listener-lifecycle1-v.txt
+++ b/corpus/desugared/subset9/09-object/listener-lifecycle1-v.txt
@@ -108,18 +108,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -147,18 +139,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -186,18 +170,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/listener-new-init-error1-p.txt
+++ b/corpus/desugared/subset9/09-object/listener-new-init-error1-p.txt
@@ -61,18 +61,10 @@
       (assignment
         (simple-var-ref $moduleListeners)
         (list-constructor-expr))
-      (var-def
-        (variable $desugar$0 (expr
-          (new ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (assignment
         (simple-var-ref l)
-        (simple-var-ref $desugar$0))
+        (checked-expr
+          (new ())))
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
@@ -116,18 +108,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -155,18 +139,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -194,18 +170,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/listener-new-init1-v.txt
+++ b/corpus/desugared/subset9/09-object/listener-new-init1-v.txt
@@ -64,18 +64,10 @@
       (assignment
         (simple-var-ref $moduleListeners)
         (list-constructor-expr))
-      (var-def
-        (variable $desugar$0 (expr
-          (new ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (assignment
         (simple-var-ref l)
-        (simple-var-ref $desugar$0))
+        (checked-expr
+          (new ())))
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
@@ -119,18 +111,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -158,18 +142,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -197,18 +173,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/listener-two-services1-v.txt
+++ b/corpus/desugared/subset9/09-object/listener-two-services1-v.txt
@@ -125,18 +125,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -164,18 +156,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -203,18 +187,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/listener-without-service1-v.txt
+++ b/corpus/desugared/subset9/09-object/listener-without-service1-v.txt
@@ -96,18 +96,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -135,18 +127,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -174,18 +158,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/listener1-v.txt
+++ b/corpus/desugared/subset9/09-object/listener1-v.txt
@@ -105,18 +105,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -144,18 +136,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -183,18 +167,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-distinct-type1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-distinct-type1-v.txt
@@ -200,37 +200,21 @@
       (var-def
         (variable $desugar$0 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref l) (
             (simple-var-ref $desugar$0)
-            (list-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))
+            (list-constructor-expr)))))
       (var-def
         (variable $desugar$1 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$1 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref explicitListener) (
             (simple-var-ref $desugar$1)
-            (list-constructor-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$1))))
+            (list-constructor-expr)))))))
   (function main () (
     (value-type null))
     (block-function-body))
@@ -256,18 +240,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -295,18 +271,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -334,18 +302,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-init-error1-p.txt
+++ b/corpus/desugared/subset9/09-object/service-init-error1-p.txt
@@ -70,16 +70,8 @@
           (simple-var-ref l))))
       (var-def
         (variable $desugar$0 (expr
-          (service-init))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (service-init)))))
       (expression-stmt
         (invocation attach expr:
           (simple-var-ref l) (
@@ -116,18 +108,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -155,18 +139,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -194,18 +170,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-init-multiple-listeners1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-init-multiple-listeners1-v.txt
@@ -100,34 +100,18 @@
       (var-def
         (variable $desugar$0 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref l1) (
             (simple-var-ref $desugar$0)
-            (literal <nil>))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
+            (literal <nil>)))))
       (expression-stmt
-        (simple-var-ref $desugar$0))
-      (var-def
-        (variable $desugar$1 (expr
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref l2) (
             (simple-var-ref $desugar$0)
-            (literal <nil>))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$1))))
+            (literal <nil>)))))))
   (function main () (
     (value-type null))
     (block-function-body))
@@ -159,18 +143,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -198,18 +174,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -237,18 +205,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-init1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-init1-v.txt
@@ -73,16 +73,8 @@
           (simple-var-ref l))))
       (var-def
         (variable $desugar$0 (expr
-          (service-init))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (service-init)))))
       (expression-stmt
         (invocation attach expr:
           (simple-var-ref l) (
@@ -119,18 +111,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -158,18 +142,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -197,18 +173,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-isolated-final-field-access-1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-isolated-final-field-access-1-v.txt
@@ -163,18 +163,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -202,18 +194,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -241,18 +225,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-isolated-resource-remote-1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-isolated-resource-remote-1-v.txt
@@ -139,18 +139,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -178,18 +170,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -217,18 +201,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-lock-field-1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-lock-field-1-v.txt
@@ -210,18 +210,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -249,18 +241,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -288,18 +272,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-on-call-listener1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-on-call-listener1-v.txt
@@ -113,18 +113,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -152,18 +144,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -191,18 +175,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
+++ b/corpus/desugared/subset9/09-object/service-on-distinct-listeners-distinct-v.txt
@@ -140,34 +140,18 @@
       (var-def
         (variable $desugar$0 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref first) (
             (simple-var-ref $desugar$0)
-            (literal <nil>))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
+            (literal <nil>)))))
       (expression-stmt
-        (simple-var-ref $desugar$0))
-      (var-def
-        (variable $desugar$1 (expr
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref second) (
             (simple-var-ref $desugar$0)
-            (literal <nil>))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$1))))
+            (literal <nil>)))))))
   (function main () (
     (value-type null))
     (block-function-body))
@@ -205,18 +189,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -244,18 +220,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -283,18 +251,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-on-listener-type-alias1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-on-listener-type-alias1-v.txt
@@ -92,20 +92,12 @@
       (var-def
         (variable $desugar$0 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref l) (
             (simple-var-ref $desugar$0)
-            (literal <nil>))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))))
+            (literal <nil>)))))))
   (function main () (
     (value-type null))
     (block-function-body))
@@ -143,18 +135,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -182,18 +166,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -221,18 +197,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-on-multiple-listeners1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-on-multiple-listeners1-v.txt
@@ -159,18 +159,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -198,18 +190,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -237,18 +221,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-on-new-listener-attach-error1-p.txt
+++ b/corpus/desugared/subset9/09-object/service-on-new-listener-attach-error1-p.txt
@@ -70,20 +70,12 @@
       (var-def
         (variable $desugar$1 (expr
           (service-init))))
-      (var-def
-        (variable $desugar$0 (expr
+      (expression-stmt
+        (checked-expr
           (invocation attach expr:
             (simple-var-ref $desugar$0) (
             (simple-var-ref $desugar$1)
-            (literal <nil>))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (expression-stmt
-        (simple-var-ref $desugar$0))))
+            (literal <nil>)))))))
   (function main () (
     (value-type null))
     (block-function-body))
@@ -115,18 +107,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -154,18 +138,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -193,18 +169,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-on-new-listener-init-error1-p.txt
+++ b/corpus/desugared/subset9/09-object/service-on-new-listener-init-error1-p.txt
@@ -60,19 +60,11 @@
       (assignment
         (simple-var-ref $moduleListeners)
         (list-constructor-expr))
-      (var-def
-        (variable $desugar$0 (expr
-          (new
-            (user-defined-type SimpleListener) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (assignment
         (simple-var-ref $desugar$0)
-        (simple-var-ref $desugar$0))
+        (checked-expr
+          (new
+            (user-defined-type SimpleListener) ())))
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
@@ -116,18 +108,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -155,18 +139,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -194,18 +170,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service-on-new-listener1-v.txt
+++ b/corpus/desugared/subset9/09-object/service-on-new-listener1-v.txt
@@ -66,19 +66,11 @@
       (assignment
         (simple-var-ref $moduleListeners)
         (list-constructor-expr))
-      (var-def
-        (variable $desugar$0 (expr
-          (new
-            (user-defined-type SimpleListener) ()))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (assignment
         (simple-var-ref $desugar$0)
-        (simple-var-ref $desugar$0))
+        (checked-expr
+          (new
+            (user-defined-type SimpleListener) ())))
       (expression-stmt
         (invocation lang.array push (
           (simple-var-ref $moduleListeners)
@@ -122,18 +114,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -161,18 +145,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -200,18 +176,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-object/service1-v.txt
+++ b/corpus/desugared/subset9/09-object/service1-v.txt
@@ -206,18 +206,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation start expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation start expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -245,18 +237,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation gracefulStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation gracefulStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +
@@ -284,18 +268,10 @@
               (index-based-access
                 (simple-var-ref $desugar$0)
                 (simple-var-ref $desugar$1)))))
-          (var-def
-            (variable $desugar$3 (expr
-              (invocation immediateStop expr:
-                (simple-var-ref $listener) ()))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$3))
-            (block-stmt
-              (return
-                (simple-var-ref $desugar$3))) ())
           (expression-stmt
-            (simple-var-ref $desugar$3))
+            (checked-expr
+              (invocation immediateStop expr:
+                (simple-var-ref $listener) ())))
           (assignment
             (simple-var-ref $desugar$1)
             (binary-expr +

--- a/corpus/desugared/subset9/09-template-expr/check-v.txt
+++ b/corpus/desugared/subset9/09-template-expr/check-v.txt
@@ -18,20 +18,12 @@
       (value-type string)
       (error-type)))
     (block-function-body
-      (var-def
-        (variable $desugar$0 (expr
-          (invocation validate (
-            (simple-var-ref s))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
       (return
         (string-template-literal
           (template-string "hello ")
-          (simple-var-ref $desugar$0)
+          (checked-expr
+            (invocation validate (
+              (simple-var-ref s))))
           (template-string "")))))
   (function validate (
     (variable s (type

--- a/corpus/desugared/subset9/09-value/clonewithtype-numeric-v.txt
+++ b/corpus/desugared/subset9/09-value/clonewithtype-numeric-v.txt
@@ -43,21 +43,13 @@
           (value-type anydata)) (expr
           (literal 1234))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref i)
-            (typedesc-expr
-              (value-type float)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable f (type
           (value-type float)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref i)
+              (typedesc-expr
+                (value-type float))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref f))))
@@ -66,21 +58,13 @@
           (value-type anydata)) (expr
           (literal 1234.6))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref fv)
-            (typedesc-expr
-              (value-type int)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable iv (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref fv)
+              (typedesc-expr
+                (value-type int))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref iv))))
@@ -89,21 +73,13 @@
           (value-type anydata)) (expr
           (literal 2.5))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref half)
-            (typedesc-expr
-              (value-type int)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable halfInt (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref half)
+              (typedesc-expr
+                (value-type int))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref halfInt))))
@@ -112,21 +88,13 @@
           (value-type anydata)) (expr
           (literal 7))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref di)
-            (typedesc-expr
-              (value-type decimal)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable d (type
           (value-type decimal)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref di)
+              (typedesc-expr
+                (value-type decimal))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref d))))
@@ -135,21 +103,13 @@
           (value-type anydata)) (expr
           (literal 1.5))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref fdv)
-            (typedesc-expr
-              (value-type decimal)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable fd (type
           (value-type decimal)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref fdv)
+              (typedesc-expr
+                (value-type decimal))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref fd))))
@@ -162,21 +122,13 @@
           (value-type anydata)) (expr
           (simple-var-ref decVal))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref decAny)
-            (typedesc-expr
-              (value-type int)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable fromDec (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref decAny)
+              (typedesc-expr
+                (value-type int))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref fromDec))))
@@ -189,21 +141,13 @@
           (value-type anydata)) (expr
           (simple-var-ref decF))))
       (var-def
-        (variable $desugar$6 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref decFAny)
-            (typedesc-expr
-              (value-type float)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (var-def
         (variable floatFromDec (type
           (value-type float)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref decFAny)
+              (typedesc-expr
+                (value-type float))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref floatFromDec))))
@@ -212,21 +156,13 @@
           (value-type anydata)) (expr
           (literal 200))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref bv)
-            (typedesc-expr
-              (value-type byte)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable b (type
           (value-type byte)) (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref bv)
+              (typedesc-expr
+                (value-type byte))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref b))))
@@ -235,21 +171,13 @@
           (value-type anydata)) (expr
           (literal 200))))
       (var-def
-        (variable $desugar$8 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref fbv)
-            (typedesc-expr
-              (value-type byte)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
-      (var-def
         (variable fb (type
           (value-type byte)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref fbv)
+              (typedesc-expr
+                (value-type byte))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref fb))))
@@ -262,21 +190,13 @@
           (value-type anydata)) (expr
           (simple-var-ref decByte))))
       (var-def
-        (variable $desugar$9 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref decByteAny)
-            (typedesc-expr
-              (value-type byte)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
-      (var-def
         (variable dby (type
           (value-type byte)) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref decByteAny)
+              (typedesc-expr
+                (value-type byte))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref dby))))
@@ -288,38 +208,22 @@
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$10 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref ints)
-            (simple-var-ref FloatArray))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
-      (var-def
         (variable fa (type
           (user-defined-type FloatArray)) (expr
-          (simple-var-ref $desugar$10))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref ints)
+              (simple-var-ref FloatArray)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref fa))))
       (var-def
-        (variable $desugar$11 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref ints)
-            (simple-var-ref DecimalArray))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$11))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$11))) ())
-      (var-def
         (variable da (type
           (user-defined-type DecimalArray)) (expr
-          (simple-var-ref $desugar$11))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref ints)
+              (simple-var-ref DecimalArray)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref da))))
@@ -331,20 +235,12 @@
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$12 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref floats)
-            (simple-var-ref IntArray))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$12))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$12))) ())
-      (var-def
         (variable ia (type
           (user-defined-type IntArray)) (expr
-          (simple-var-ref $desugar$12))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref floats)
+              (simple-var-ref IntArray)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref ia))))
@@ -356,20 +252,12 @@
             (literal 200)
             (literal 255)))))
       (var-def
-        (variable $desugar$13 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref floatBytes)
-            (simple-var-ref ByteArray))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$13))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$13))) ())
-      (var-def
         (variable ba (type
           (user-defined-type ByteArray)) (expr
-          (simple-var-ref $desugar$13))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref floatBytes)
+              (simple-var-ref ByteArray)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref ba))))
@@ -386,20 +274,12 @@
           (value-type anydata)) (expr
           (simple-var-ref decArr))))
       (var-def
-        (variable $desugar$14 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref decArrAny)
-            (simple-var-ref IntArray))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$14))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$14))) ())
-      (var-def
         (variable fromDecArr (type
           (user-defined-type IntArray)) (expr
-          (simple-var-ref $desugar$14))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref decArrAny)
+              (simple-var-ref IntArray)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref fromDecArr))))
@@ -414,20 +294,12 @@
               (literal b)
               (literal 2.7))))))
       (var-def
-        (variable $desugar$15 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref mf)
-            (simple-var-ref IntMap))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$15))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$15))) ())
-      (var-def
         (variable mi (type
           (user-defined-type IntMap)) (expr
-          (simple-var-ref $desugar$15))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref mf)
+              (simple-var-ref IntMap)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref mi))))
@@ -445,20 +317,12 @@
               (literal c)
               (literal 1000))))))
       (var-def
-        (variable $desugar$16 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref r)
-            (simple-var-ref FloatRec))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$16))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$16))) ())
-      (var-def
         (variable fr (type
           (user-defined-type FloatRec)) (expr
-          (simple-var-ref $desugar$16))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref r)
+              (simple-var-ref FloatRec)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref fr))))

--- a/corpus/desugared/subset9/09-value/clonewithtype-p.txt
+++ b/corpus/desugared/subset9/09-value/clonewithtype-p.txt
@@ -19,17 +19,9 @@
           (literal self))
         (simple-var-ref cyclic))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref cyclic)
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable _ (type
           (value-type anydata)) (expr
-          (simple-var-ref $desugar$0)))))))
+          (check-panicked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref cyclic)
+              (typedesc-expr))))))))))

--- a/corpus/desugared/subset9/09-value/clonewithtype-union-order-v.txt
+++ b/corpus/desugared/subset9/09-value/clonewithtype-union-order-v.txt
@@ -63,38 +63,22 @@
                   (literal f3)
                   (simple-var-ref d))))))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref v1)
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable r1 (type
           (user-defined-type R)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref v1)
+              (typedesc-expr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref r1))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref v1)
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable r1b (type
           (user-defined-type Rb)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref v1)
+              (typedesc-expr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref r1b))))
@@ -109,20 +93,12 @@
                   (literal f3)
                   (simple-var-ref d))))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref v2)
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable r2 (type
           (user-defined-type R)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref v2)
+              (typedesc-expr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref r2))))

--- a/corpus/desugared/subset9/09-value/clonewithtype-union-v.txt
+++ b/corpus/desugared/subset9/09-value/clonewithtype-union-v.txt
@@ -53,20 +53,12 @@
           (value-type anydata)) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref nilVal)
-            (simple-var-ref IntNilable))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable n (type
           (user-defined-type IntNilable)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref nilVal)
+              (simple-var-ref IntNilable)))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -84,20 +76,12 @@
           (value-type anydata)) (expr
           (literal 42))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref num)
-            (simple-var-ref IntOrString))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable asInt (type
           (user-defined-type IntOrString)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref num)
+              (simple-var-ref IntOrString)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref asInt))))
@@ -106,20 +90,12 @@
           (value-type anydata)) (expr
           (literal hello))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref str)
-            (simple-var-ref IntOrString))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable asStr (type
           (user-defined-type IntOrString)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref str)
+              (simple-var-ref IntOrString)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref asStr))))
@@ -128,20 +104,12 @@
           (value-type anydata)) (expr
           (literal 2))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref fv)
-            (simple-var-ref IntOrString))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable coerced (type
           (user-defined-type IntOrString)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref fv)
+              (simple-var-ref IntOrString)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref coerced))))
@@ -150,20 +118,12 @@
           (value-type anydata)) (expr
           (literal 3))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref iv)
-            (simple-var-ref OptFloat))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable optF (type
           (user-defined-type OptFloat)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref iv)
+              (simple-var-ref OptFloat)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref optF))))
@@ -172,20 +132,12 @@
           (value-type anydata)) (expr
           (literal 10))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref dv)
-            (simple-var-ref DecimalOrString))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable ds (type
           (user-defined-type DecimalOrString)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref dv)
+              (simple-var-ref DecimalOrString)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref ds))))
@@ -200,20 +152,12 @@
               (literal age)
               (literal 30))))))
       (var-def
-        (variable $desugar$6 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref pMap)
-            (simple-var-ref PersonUnion))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (var-def
         (variable pu (type
           (user-defined-type PersonUnion)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref pMap)
+              (simple-var-ref PersonUnion)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref pu))))
@@ -228,20 +172,12 @@
               (literal role)
               (literal admin))))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref pMap2)
-            (simple-var-ref PersonUnion))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable pu2 (type
           (user-defined-type PersonUnion)) (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref pMap2)
+              (simple-var-ref PersonUnion)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref pu2))))
@@ -253,20 +189,12 @@
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$8 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref intArr)
-            (simple-var-ref IntStrArr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
-      (var-def
         (variable arrVal (type
           (user-defined-type IntStrArr)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref intArr)
+              (simple-var-ref IntStrArr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref arrVal))))
@@ -277,20 +205,12 @@
             (literal a)
             (literal b)))))
       (var-def
-        (variable $desugar$9 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref strArr)
-            (simple-var-ref IntStrArr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
-      (var-def
         (variable strArrVal (type
           (user-defined-type IntStrArr)) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref strArr)
+              (simple-var-ref IntStrArr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref strArrVal))))
@@ -299,20 +219,12 @@
           (value-type anydata)) (expr
           (literal 200))))
       (var-def
-        (variable $desugar$10 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref bv)
-            (simple-var-ref ByteOrString))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
-      (var-def
         (variable asByte (type
           (user-defined-type ByteOrString)) (expr
-          (simple-var-ref $desugar$10))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref bv)
+              (simple-var-ref ByteOrString)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref asByte))))

--- a/corpus/desugared/subset9/09-value/clonewithtype-v.txt
+++ b/corpus/desugared/subset9/09-value/clonewithtype-v.txt
@@ -55,21 +55,13 @@
           (value-type anydata)) (expr
           (literal 42))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref n)
-            (typedesc-expr
-              (value-type int)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable i (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref n)
+              (typedesc-expr
+                (value-type int))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref i))))
@@ -78,21 +70,13 @@
           (value-type anydata)) (expr
           (literal hello))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref s)
-            (typedesc-expr
-              (value-type string)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable str (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref s)
+              (typedesc-expr
+                (value-type string))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref str))))
@@ -101,21 +85,13 @@
           (value-type anydata)) (expr
           (literal 7))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref intVal)
-            (typedesc-expr
-              (value-type float)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable f (type
           (value-type float)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref intVal)
+              (typedesc-expr
+                (value-type float))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref f))))
@@ -130,20 +106,12 @@
               (literal age)
               (literal 30))))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref raw)
-            (simple-var-ref Person))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable p (type
           (user-defined-type Person)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref raw)
+              (simple-var-ref Person)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref p))))
@@ -155,20 +123,12 @@
             (literal 2)
             (literal 3)))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref nums)
-            (simple-var-ref IntArray))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable ia (type
           (user-defined-type IntArray)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref nums)
+              (simple-var-ref IntArray)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref ia))))
@@ -180,20 +140,12 @@
             (literal 20)
             (literal 30)))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref ints)
-            (simple-var-ref FloatArray))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable fa (type
           (user-defined-type FloatArray)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref ints)
+              (simple-var-ref FloatArray)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref fa))))
@@ -208,20 +160,12 @@
               (literal y)
               (literal 4))))))
       (var-def
-        (variable $desugar$6 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref coords)
-            (simple-var-ref Point))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (var-def
         (variable pt (type
           (user-defined-type Point)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref coords)
+              (simple-var-ref Point)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref pt))))
@@ -242,20 +186,12 @@
                   (literal y)
                   (literal 0))))))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref shapeRaw)
-            (simple-var-ref Shape))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable sh (type
           (user-defined-type Shape)) (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref shapeRaw)
+              (simple-var-ref Shape)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref sh))))
@@ -270,20 +206,12 @@
               (literal age)
               (literal 25))))))
       (var-def
-        (variable $desugar$8 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref personMap)
-            (simple-var-ref PersonOrInt))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$8))) ())
-      (var-def
         (variable poi (type
           (user-defined-type PersonOrInt)) (expr
-          (simple-var-ref $desugar$8))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref personMap)
+              (simple-var-ref PersonOrInt)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref poi))))
@@ -298,20 +226,12 @@
               (literal age)
               (literal <nil>))))))
       (var-def
-        (variable $desugar$9 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref withNull)
-            (simple-var-ref PersonNilAge))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$9))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$9))) ())
-      (var-def
         (variable nilAge (type
           (user-defined-type PersonNilAge)) (expr
-          (simple-var-ref $desugar$9))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref withNull)
+              (simple-var-ref PersonNilAge)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref nilAge))))
@@ -323,20 +243,12 @@
               (literal name)
               (literal Dave))))))
       (var-def
-        (variable $desugar$10 (expr
-          (invocation lang.value cloneWithType (
-            (simple-var-ref partial)
-            (simple-var-ref PersonOptAge))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$10))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$10))) ())
-      (var-def
         (variable optAge (type
           (user-defined-type PersonOptAge)) (expr
-          (simple-var-ref $desugar$10))))
+          (checked-expr
+            (invocation lang.value cloneWithType (
+              (simple-var-ref partial)
+              (simple-var-ref PersonOptAge)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref optAge))))

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-closed-union-v.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-closed-union-v.txt
@@ -36,20 +36,12 @@
               (literal age)
               (literal 5))))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref ageOnly)
-            (simple-var-ref Pet))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable ageOnlyPet (type
           (user-defined-type Pet)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref ageOnly)
+              (simple-var-ref Pet)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref ageOnlyPet))))
@@ -61,20 +53,12 @@
               (literal pet_type)
               (literal Cat))))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref typeOnly)
-            (simple-var-ref Pet))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable typeOnlyPet (type
           (user-defined-type Pet)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref typeOnly)
+              (simple-var-ref Pet)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref typeOnlyPet))))

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-json-v.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-json-v.txt
@@ -11,21 +11,13 @@
           (builtin-ref-type json)) (expr
           (literal hello))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref strJson)
-            (typedesc-expr
-              (builtin-ref-type json)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable strOut (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref strJson)
+              (typedesc-expr
+                (builtin-ref-type json))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref strOut))))
@@ -34,21 +26,13 @@
           (builtin-ref-type json)) (expr
           (literal 42))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref intJson)
-            (typedesc-expr
-              (builtin-ref-type json)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable intOut (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref intJson)
+              (typedesc-expr
+                (builtin-ref-type json))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref intOut))))
@@ -57,21 +41,13 @@
           (builtin-ref-type json)) (expr
           (literal true))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref boolJson)
-            (typedesc-expr
-              (builtin-ref-type json)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable boolOut (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref boolJson)
+              (typedesc-expr
+                (builtin-ref-type json))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref boolOut))))
@@ -83,21 +59,13 @@
             (literal <nil>)
             (literal 3)))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref arr)
-            (typedesc-expr
-              (builtin-ref-type json)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable arrOut (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref arr)
+              (typedesc-expr
+                (builtin-ref-type json))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref arrOut))))
@@ -112,21 +80,13 @@
               (literal b)
               (literal <nil>))))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref m)
-            (typedesc-expr
-              (builtin-ref-type json)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable mapOut (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref m)
+              (typedesc-expr
+                (builtin-ref-type json))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref mapOut))))
@@ -141,21 +101,13 @@
               (literal 3)
               (literal 4))))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref nested)
-            (typedesc-expr
-              (builtin-ref-type json)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable nestedOut (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref nested)
+              (typedesc-expr
+                (builtin-ref-type json))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref nestedOut))))
@@ -175,21 +127,13 @@
                   (literal n)
                   (literal 2))))))))
       (var-def
-        (variable $desugar$6 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref rec)
-            (typedesc-expr
-              (builtin-ref-type json)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (var-def
         (variable recOut (type
           (builtin-ref-type json)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref rec)
+              (typedesc-expr
+                (builtin-ref-type json))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref recOut))))

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-numeric-v.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-numeric-v.txt
@@ -11,21 +11,13 @@
           (builtin-ref-type json)) (expr
           (literal 255))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref maxByte)
-            (typedesc-expr
-              (value-type byte)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable b (type
           (value-type byte)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref maxByte)
+              (typedesc-expr
+                (value-type byte))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref b))))

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-open-record-v.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-open-record-v.txt
@@ -45,20 +45,12 @@
               (literal lives)
               (literal 9))))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref catJson)
-            (simple-var-ref Animal))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable cat (type
           (user-defined-type Animal)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref catJson)
+              (simple-var-ref Animal)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref cat))))
@@ -73,20 +65,12 @@
               (literal breed)
               (literal Labrador))))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref dogJson)
-            (simple-var-ref Animal))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable dog (type
           (user-defined-type Animal)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref dogJson)
+              (simple-var-ref Animal)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref dog))))
@@ -101,20 +85,12 @@
               (literal b)
               (literal world))))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref strMapJson)
-            (simple-var-ref StrOrInt))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable strMap (type
           (user-defined-type StrOrInt)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref strMapJson)
+              (simple-var-ref StrOrInt)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref strMap))))
@@ -129,20 +105,12 @@
               (literal y)
               (literal 2))))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref intMapJson)
-            (simple-var-ref StrOrInt))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable intMap (type
           (user-defined-type StrOrInt)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref intMapJson)
+              (simple-var-ref StrOrInt)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref intMap))))

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-p.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-p.txt
@@ -17,17 +17,9 @@
               (literal name)
               (literal Alice))))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref missing)
-            (simple-var-ref Person))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (panic
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable _ (type
           (user-defined-type Person)) (expr
-          (simple-var-ref $desugar$0)))))))
+          (check-panicked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref missing)
+              (simple-var-ref Person))))))))))

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-union-open-v.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-union-open-v.txt
@@ -54,20 +54,12 @@
               (literal age)
               (literal 4))))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref petJson)
-            (simple-var-ref Pet))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable pet (type
           (user-defined-type Pet)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref petJson)
+              (simple-var-ref Pet)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref pet))))
@@ -78,20 +70,12 @@
             (literal 1)
             (literal 2)))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref arrJson)
-            (simple-var-ref IntStrArr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable arrVal (type
           (user-defined-type IntStrArr)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref arrJson)
+              (simple-var-ref IntStrArr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref arrVal))))
@@ -102,20 +86,12 @@
             (literal a)
             (literal b)))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref strArrJson)
-            (simple-var-ref IntStrArr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable strArrVal (type
           (user-defined-type IntStrArr)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref strArrJson)
+              (simple-var-ref IntStrArr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref strArrVal))))
@@ -124,20 +100,12 @@
           (builtin-ref-type json)) (expr
           (literal 12))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref floatJson)
-            (simple-var-ref IntFloat))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable numVal (type
           (user-defined-type IntFloat)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref floatJson)
+              (simple-var-ref IntFloat)))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -148,20 +116,12 @@
           (builtin-ref-type json)) (expr
           (literal 200))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref floatAsByte)
-            (simple-var-ref ByteOrString))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable asByte (type
           (user-defined-type ByteOrString)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref floatAsByte)
+              (simple-var-ref ByteOrString)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref asByte))))

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-union-v.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-union-v.txt
@@ -55,20 +55,12 @@
           (builtin-ref-type json)) (expr
           (literal 42))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref num)
-            (simple-var-ref IntOrString))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable asUnion (type
           (user-defined-type IntOrString)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref num)
+              (simple-var-ref IntOrString)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref asUnion))))
@@ -77,20 +69,12 @@
           (builtin-ref-type json)) (expr
           (literal hello))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref str)
-            (simple-var-ref IntOrString))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable asStr (type
           (user-defined-type IntOrString)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref str)
+              (simple-var-ref IntOrString)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref asStr))))
@@ -101,20 +85,12 @@
             (literal 1)
             (literal 2)))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref arr)
-            (simple-var-ref JsonOrInt))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable asJson (type
           (user-defined-type JsonOrInt)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref arr)
+              (simple-var-ref JsonOrInt)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref asJson))))
@@ -123,20 +99,12 @@
           (builtin-ref-type json)) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref nilVal)
-            (simple-var-ref IntNilable))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable asNilable (type
           (user-defined-type IntNilable)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref nilVal)
+              (simple-var-ref IntNilable)))))))
       (expression-stmt
         (invocation io println (
           (type-test-expr is
@@ -150,20 +118,12 @@
               (literal name)
               (literal Bob))))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref partial)
-            (simple-var-ref PersonOpt))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable withOptional (type
           (user-defined-type PersonOpt)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref partial)
+              (simple-var-ref PersonOpt)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref withOptional))))
@@ -192,20 +152,12 @@
               (literal score)
               (literal <nil>))))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref explicitNull)
-            (simple-var-ref WithNilable))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable withScore (type
           (user-defined-type WithNilable)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref explicitNull)
+              (simple-var-ref WithNilable)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref withScore))))
@@ -220,20 +172,12 @@
               (literal age)
               (literal <nil>))))))
       (var-def
-        (variable $desugar$6 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref withNullAge)
-            (simple-var-ref PersonNilAge))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (var-def
         (variable withAge (type
           (user-defined-type PersonNilAge)) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref withNullAge)
+              (simple-var-ref PersonNilAge)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref withAge))))
@@ -245,20 +189,12 @@
               (literal a)
               (literal 1))))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref openMap)
-            (simple-var-ref AnyMap))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable anyMap (type
           (user-defined-type AnyMap)) (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref openMap)
+              (simple-var-ref AnyMap)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref anyMap))))

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-v.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-v.txt
@@ -30,21 +30,13 @@
             (literal 1)
             (literal 2)))))
       (var-def
-        (variable $desugar$0 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref arrForAny)
-            (typedesc-expr
-              (value-type anydata)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$0))) ())
-      (var-def
         (variable ad (type
           (value-type anydata)) (expr
-          (simple-var-ref $desugar$0))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref arrForAny)
+              (typedesc-expr
+                (value-type anydata))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref ad))))
@@ -53,59 +45,35 @@
           (builtin-ref-type json)) (expr
           (literal 2022))))
       (var-def
-        (variable $desugar$1 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref num)
-            (typedesc-expr
-              (value-type int)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$1))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$1))) ())
-      (var-def
         (variable n (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$1))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref num)
+              (typedesc-expr
+                (value-type int))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref n))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lang.value fromJsonWithType (
-            (literal true)
-            (typedesc-expr
-              (value-type boolean)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$2))) ())
-      (var-def
         (variable b (type
           (value-type boolean)) (expr
-          (simple-var-ref $desugar$2))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (literal true)
+              (typedesc-expr
+                (value-type boolean))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref b))))
       (var-def
-        (variable $desugar$3 (expr
-          (invocation lang.value fromJsonWithType (
-            (literal false)
-            (typedesc-expr
-              (value-type boolean)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$3))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$3))) ())
-      (var-def
         (variable f (type
           (value-type boolean)) (expr
-          (simple-var-ref $desugar$3))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (literal false)
+              (typedesc-expr
+                (value-type boolean))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref f))))
@@ -114,21 +82,13 @@
           (builtin-ref-type json)) (expr
           (literal hello))))
       (var-def
-        (variable $desugar$4 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref strVal)
-            (typedesc-expr
-              (value-type string)))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$4))) ())
-      (var-def
         (variable s (type
           (value-type string)) (expr
-          (simple-var-ref $desugar$4))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref strVal)
+              (typedesc-expr
+                (value-type string))))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref s))))
@@ -157,20 +117,12 @@
               (literal age)
               (literal <nil>))))))
       (var-def
-        (variable $desugar$5 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref nullAge)
-            (simple-var-ref PersonNilAge))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$5))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$5))) ())
-      (var-def
         (variable nilAgePerson (type
           (user-defined-type PersonNilAge)) (expr
-          (simple-var-ref $desugar$5))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref nullAge)
+              (simple-var-ref PersonNilAge)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref nilAgePerson))))
@@ -183,21 +135,13 @@
             (literal 3)
             (literal 4)))))
       (var-def
-        (variable $desugar$6 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref arr)
-            (typedesc-expr))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$6))) ())
-      (var-def
         (variable inferred (type
           (array-type
             (value-type int) dimensions: 1 ([]))) (expr
-          (simple-var-ref $desugar$6))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref arr)
+              (typedesc-expr)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref inferred))))
@@ -212,20 +156,12 @@
               (literal age)
               (literal 30))))))
       (var-def
-        (variable $desugar$7 (expr
-          (invocation lang.value fromJsonWithType (
-            (simple-var-ref p)
-            (simple-var-ref Person))))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$7))
-        (block-stmt
-          (return
-            (simple-var-ref $desugar$7))) ())
-      (var-def
         (variable person (type
           (user-defined-type Person)) (expr
-          (simple-var-ref $desugar$7))))
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref p)
+              (simple-var-ref Person)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref person))))

--- a/corpus/integration/subset8/08-error/check15-v.txtar
+++ b/corpus/integration/subset8/08-error/check15-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+error("original error")
+-- stderr --

--- a/desugar/expression.go
+++ b/desugar/expression.go
@@ -933,11 +933,21 @@ func walkErrorConstructorExpr(cx *functionContext, expr *ast.BLangErrorConstruct
 }
 
 func walkCheckedExpr(cx *functionContext, expr *ast.BLangCheckedExpr) desugaredNode[ast.BLangActionOrExpression] {
-	return desugarCheckedExpr(cx, expr, false)
+	result := walkExpression(cx, expr.Expr)
+	expr.Expr = result.replacementNode
+	return desugaredNode[ast.BLangActionOrExpression]{
+		initStmts:       result.initStmts,
+		replacementNode: expr,
+	}
 }
 
 func walkCheckPanickedExpr(cx *functionContext, expr *ast.BLangCheckPanickedExpr) desugaredNode[ast.BLangActionOrExpression] {
-	return desugarCheckedExpr(cx, &expr.BLangCheckedExpr, true)
+	result := walkExpression(cx, expr.Expr)
+	expr.Expr = result.replacementNode
+	return desugaredNode[ast.BLangActionOrExpression]{
+		initStmts:       result.initStmts,
+		replacementNode: expr,
+	}
 }
 
 func walkTrapExpr(cx *functionContext, expr *ast.BLangTrapExpr) desugaredNode[ast.BLangActionOrExpression] {
@@ -949,91 +959,6 @@ func walkTrapExpr(cx *functionContext, expr *ast.BLangTrapExpr) desugaredNode[as
 	}
 	expr.Expr = result.replacementNode.(ast.BLangExpression)
 	return desugaredNode[ast.BLangActionOrExpression]{initStmts: nil, replacementNode: expr}
-}
-
-func desugarCheckedExpr(cx *functionContext, expr *ast.BLangCheckedExpr, isPanic bool) desugaredNode[ast.BLangActionOrExpression] {
-	var initStmts []ast.StatementNode
-
-	// Walk the inner expression first
-	if expr.Expr != nil {
-		result := walkExpression(cx, expr.Expr)
-		initStmts = append(initStmts, result.initStmts...)
-		expr.Expr = result.replacementNode
-	}
-
-	innerTy := expr.Expr.GetDeterminedType()
-	resultTy := expr.GetDeterminedType()
-
-	basePos := expr.Expr.GetPosition()
-
-	// TODO: extract util to add definition and get reference
-	// Create temp var: $desugar$N = <inner expr>
-	tempName, tempSymbol := cx.addDesugardSymbol(innerTy, model.SymbolKindVariable, false, basePos)
-	tempVarName := newIdentifier(tempName)
-	tempVarName.SetPosition(basePos)
-	tempVar := &ast.BLangVariable{Name: tempVarName}
-	tempVar.Name.SetDeterminedType(semtypes.Never)
-	tempVar.SetDeterminedType(semtypes.Never)
-	tempVar.SetInitialExpression(expr.Expr)
-	tempVar.SetSymbol(tempSymbol)
-	tempVar.SetPosition(basePos)
-	tempVarDef := &ast.BLangVariableDef{Var: tempVar}
-	tempVarDef.SetDeterminedType(semtypes.Never)
-	tempVarDef.SetPosition(basePos)
-	initStmts = append(initStmts, tempVarDef)
-
-	// Type test: $desugar$N is error
-	tempVarRefForTest := &ast.BLangVarRef{VariableName: tempVarName}
-	tempVarRefForTest.SetSymbol(tempSymbol)
-	tempVarRefForTest.SetDeterminedType(innerTy)
-	tempVarRefForTest.SetPosition(basePos)
-
-	typeTestExpr := ast.NewBLangTypeTestExpr(
-		basePos,
-		tempVarRefForTest,
-		ast.TypeData{Type: semtypes.Error},
-		false,
-	)
-	typeTestExpr.SetDeterminedType(semtypes.Boolean)
-
-	// If body: return or panic
-	tempVarRefForBody := &ast.BLangVarRef{VariableName: tempVarName}
-	tempVarRefForBody.SetSymbol(tempSymbol)
-	tempVarRefForBody.SetDeterminedType(innerTy)
-	tempVarRefForBody.SetPosition(basePos)
-
-	var bodyStmt ast.StatementNode
-	if isPanic {
-		panicStmt := &ast.BLangPanic{Expr: tempVarRefForBody}
-		panicStmt.SetPosition(expr.GetPosition())
-		bodyStmt = panicStmt
-	} else {
-		returnStmt := &ast.BLangReturn{Expr: tempVarRefForBody}
-		returnStmt.SetPosition(basePos)
-		bodyStmt = returnStmt
-	}
-
-	ifBody := ast.BLangBlockStmt{
-		Stmts: []ast.StatementNode{bodyStmt},
-	}
-	ifBody.SetPosition(basePos)
-	ifStmt := &ast.BLangIf{
-		Expr: typeTestExpr,
-		Body: ifBody,
-	}
-	ifStmt.SetPosition(basePos)
-	initStmts = append(initStmts, ifStmt)
-
-	// Replacement: var ref typed as non-error type
-	replacementVarRef := &ast.BLangVarRef{VariableName: tempVarName}
-	replacementVarRef.SetSymbol(tempSymbol)
-	replacementVarRef.SetDeterminedType(resultTy)
-	replacementVarRef.SetPosition(basePos)
-
-	return desugaredNode[ast.BLangActionOrExpression]{
-		initStmts:       initStmts,
-		replacementNode: replacementVarRef,
-	}
 }
 
 func walkLambdaFunction(cx *functionContext, expr *ast.BLangLambdaFunction) desugaredNode[ast.BLangActionOrExpression] {


### PR DESCRIPTION
Lowering check expression in desugar is introducing problems when those expressions become part of other expressions such as ternary expressions




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Checked expressions now return evaluation errors correctly.
  * Check-panicked expressions now panic while preserving the original error.
  * Successful evaluations continue normally with their results available.

* **Bug Fixes**
  * Improved error propagation through nested evaluation scopes.
  * Nested check-panic failures now surface the original error without unexpected output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->