### PR TITLE
fix(bir): lower nil-lifted expressions as control flow

### DIFF
--- a/birgen/bir_gen.go
+++ b/birgen/bir_gen.go
@@ -74,6 +74,11 @@ func (fn *functionContext) addBB() *bir.BIRBasicBlock {
 	return &bb
 }
 
+// lastBBNumber returns the number assigned to the most recently allocated basic block.
+func (fn *functionContext) lastBBNumber() int {
+	return len(fn.bbs) - 1
+}
+
 func (fn *functionContext) loc(pos diagnostics.Location) bir.Location {
 	return birLoc(fn.pkgCtx.CompilerContext.DiagnosticEnv(), pos)
 }
@@ -1724,16 +1729,67 @@ func wildcardBindingPattern(ctx context, curBB *bir.BIRBasicBlock) (expressionEf
 	}, true
 }
 
-func unaryExpression(ctx context, bb *bir.BIRBasicBlock, expr *ast.BLangUnaryExpr) (expressionEffect, bool) {
-	var kind bir.InstructionKind
-	switch expr.Operator {
+// operatorKindToUnaryInstructionKind maps an AST unary operator to its BIR instruction kind.
+func operatorKindToUnaryInstructionKind(op model.OperatorKind) (bir.InstructionKind, bool) {
+	switch op {
 	case model.OperatorKind_NOT:
-		kind = bir.InstructionKindNot
+		return bir.InstructionKindNot, true
 	case model.OperatorKind_SUB:
-		kind = bir.InstructionKindNegate
+		return bir.InstructionKindNegate, true
 	case model.OperatorKind_BITWISE_COMPLEMENT:
-		kind = bir.InstructionKindBitwiseComplement
+		return bir.InstructionKindBitwiseComplement, true
 	default:
+		return 0, false
+	}
+}
+
+// isNilLiftableUnaryOp reports whether an operator propagates a nil operand as nil.
+// Unary + is absent because desugar replaces it with its operand before BIR gen.
+func isNilLiftableUnaryOp(op model.OperatorKind) bool {
+	switch op {
+	case model.OperatorKind_SUB, model.OperatorKind_BITWISE_COMPLEMENT:
+		return true
+	default:
+		return false
+	}
+}
+
+// nilLiftedUnaryExpression evaluates a nullable operand and applies the operator only when it is non-nil.
+func nilLiftedUnaryExpression(ctx context, bb *bir.BIRBasicBlock, expr *ast.BLangUnaryExpr) (expressionEffect, bool) {
+	kind, ok := operatorKindToUnaryInstructionKind(expr.Operator)
+	if !ok {
+		ctx.internalError(fmt.Sprintf("unexpected unary operator kind: %v", expr.Operator), expr.GetPosition())
+		return expressionEffect{}, false
+	}
+	pos := ctx.function().loc(expr.GetPosition())
+	opEffect, ok := handleActionOrExpression(ctx, bb, expr.Expr)
+	if !ok {
+		return opEffect, false
+	}
+	isNil := nilTest(ctx, opEffect.block, opEffect.result, pos)
+
+	nilBB := ctx.function().addBB()
+	opBB := ctx.function().addBB()
+	doneBB := ctx.function().addBB()
+	opEffect.block.Terminator = bir.NewBranch(isNil, nilBB, opBB, pos)
+
+	result := ctx.addTempVar(expr.GetDeterminedType())
+	nilBB.Instructions = append(nilBB.Instructions, bir.NewConstantLoad(result, nil, pos))
+	nilBB.Terminator = bir.NewGoto(doneBB, pos)
+	opBB.Instructions = append(opBB.Instructions, bir.NewUnaryOp(kind, result, opEffect.result, pos))
+	opBB.Terminator = bir.NewGoto(doneBB, pos)
+	return expressionEffect{result: result, block: doneBB}, true
+}
+
+func unaryExpression(ctx context, bb *bir.BIRBasicBlock, expr *ast.BLangUnaryExpr) (expressionEffect, bool) {
+	if isNilLiftableUnaryOp(expr.Operator) {
+		ty := expr.Expr.GetDeterminedType()
+		if semtypes.ContainsBasicType(ty, semtypes.Nil) {
+			return nilLiftedUnaryExpression(ctx, bb, expr)
+		}
+	}
+	kind, ok := operatorKindToUnaryInstructionKind(expr.Operator)
+	if !ok {
 		ctx.internalError(fmt.Sprintf("unexpected unary operator kind: %v", expr.Operator), expr.GetPosition())
 		return expressionEffect{}, false
 	}
@@ -1989,7 +2045,95 @@ func binaryExpressionInner(ctx context, curBB *bir.BIRBasicBlock, opKind model.O
 	}, true
 }
 
+// isNilLiftableBinaryOp reports whether an operator propagates a nil operand as nil.
+func isNilLiftableBinaryOp(op model.OperatorKind) bool {
+	switch op {
+	case model.OperatorKind_ADD, model.OperatorKind_SUB, // additive-expr
+		model.OperatorKind_MUL, model.OperatorKind_DIV, model.OperatorKind_MOD, // multiplicative-expr
+		model.OperatorKind_BITWISE_LEFT_SHIFT, model.OperatorKind_BITWISE_RIGHT_SHIFT,
+		model.OperatorKind_BITWISE_UNSIGNED_RIGHT_SHIFT,                                               //shift-expr
+		model.OperatorKind_BITWISE_AND, model.OperatorKind_BITWISE_OR, model.OperatorKind_BITWISE_XOR: // binary-bitwise-expr
+		return true
+	default:
+		return false
+	}
+}
+
+// nilLiftedOperands reports which operands are nullable and whether the operation needs lifting.
+func nilLiftedOperands(op model.OperatorKind, lhsTy, rhsTy semtypes.SemType) (lhsNullable, rhsNullable, lifted bool) {
+	if !isNilLiftableBinaryOp(op) {
+		return false, false, false
+	}
+	lhsNullable = semtypes.ContainsBasicType(lhsTy, semtypes.Nil)
+	rhsNullable = semtypes.ContainsBasicType(rhsTy, semtypes.Nil)
+	return lhsNullable, rhsNullable, lhsNullable || rhsNullable
+}
+
+// pinOperand create a copy of value before evaluating a later, potentially mutating operand.
+func pinOperand(ctx context, effect expressionEffect, ty semtypes.SemType, pos bir.Location) expressionEffect {
+	temp := ctx.addTempVar(ty)
+	effect.block.Instructions = append(effect.block.Instructions, bir.NewMove(effect.result, temp, pos))
+	return expressionEffect{result: temp, block: effect.block}
+}
+
+// nilTest emits a nil type test and returns its boolean result.
+func nilTest(ctx context, bb *bir.BIRBasicBlock, operand *bir.BIROperand, pos bir.Location) *bir.BIROperand {
+	result := ctx.addTempVar(semtypes.Boolean)
+	bb.Instructions = append(bb.Instructions, bir.NewTypeTest(semtypes.Nil, result, operand, pos))
+	return result
+}
+
+// nilLiftedBinaryExpression evaluates both operands in source order and branches around the operation when either is nil.
+func nilLiftedBinaryExpression(ctx context, curBB *bir.BIRBasicBlock, expr *ast.BLangBinaryExpr, lhsNullable, rhsNullable bool) (expressionEffect, bool) {
+	pos := ctx.function().loc(expr.GetPosition())
+	kind, ok := operatorKindToBinaryInstructionKind(expr.OpKind)
+	if !ok {
+		ctx.internalError(fmt.Sprintf("unexpected binary operator kind: %v", expr.OpKind), expr.GetPosition())
+		return expressionEffect{}, false
+	}
+	lhsEffect, ok := handleActionOrExpression(ctx, curBB, expr.LhsExpr)
+	if !ok {
+		return lhsEffect, false
+	}
+	lhsEffect = pinOperand(ctx, lhsEffect, expr.LhsExpr.GetDeterminedType(), pos)
+	rhsEffect, ok := handleActionOrExpression(ctx, lhsEffect.block, expr.RhsExpr)
+	if !ok {
+		return rhsEffect, false
+	}
+	curBB = rhsEffect.block
+
+	var nilOperand *bir.BIROperand
+	if lhsNullable {
+		nilOperand = nilTest(ctx, curBB, lhsEffect.result, pos)
+	}
+	if rhsNullable {
+		rhsNil := nilTest(ctx, curBB, rhsEffect.result, pos)
+		if nilOperand == nil {
+			nilOperand = rhsNil
+		} else {
+			anyNil := ctx.addTempVar(semtypes.Boolean)
+			curBB.Instructions = append(curBB.Instructions, bir.NewBinaryOp(bir.InstructionKindOr, anyNil, nilOperand, rhsNil, pos))
+			nilOperand = anyNil
+		}
+	}
+
+	nilBB := ctx.function().addBB()
+	opBB := ctx.function().addBB()
+	doneBB := ctx.function().addBB()
+	curBB.Terminator = bir.NewBranch(nilOperand, nilBB, opBB, pos)
+
+	result := ctx.addTempVar(expr.GetDeterminedType())
+	nilBB.Instructions = append(nilBB.Instructions, bir.NewConstantLoad(result, nil, pos))
+	nilBB.Terminator = bir.NewGoto(doneBB, pos)
+	opBB.Instructions = append(opBB.Instructions, bir.NewBinaryOp(kind, result, lhsEffect.result, rhsEffect.result, pos))
+	opBB.Terminator = bir.NewGoto(doneBB, pos)
+	return expressionEffect{result: result, block: doneBB}, true
+}
+
 func binaryExpression(ctx context, curBB *bir.BIRBasicBlock, expr *ast.BLangBinaryExpr) (expressionEffect, bool) {
+	if lhsNullable, rhsNullable, lifted := nilLiftedOperands(expr.OpKind, expr.LhsExpr.GetDeterminedType(), expr.RhsExpr.GetDeterminedType()); lifted {
+		return nilLiftedBinaryExpression(ctx, curBB, expr, lhsNullable, rhsNullable)
+	}
 	switch expr.OpKind {
 	case model.OperatorKind_AND, model.OperatorKind_OR:
 		return logicalExpression(ctx, curBB, expr)
@@ -2194,13 +2338,16 @@ func trapExpression(ctx context, curBB *bir.BIRBasicBlock, expr *ast.BLangTrapEx
 	mov := bir.NewMove(innerEffect.result, resultOperand, ctx.function().loc(expr.GetPosition()))
 	trapEndBB.Instructions = append(trapEndBB.Instructions, mov)
 
+	// Operand lowering can allocate blocks after its returned join block, so capture the
+	// allocation frontier before afterTrapBB is added and include every operand block.
+	regionEnd := ctx.function().lastBBNumber()
 	afterTrapBB := ctx.function().addBB()
 	trapEndBB.Terminator = bir.NewGoto(afterTrapBB, ctx.function().loc(expr.GetPosition()))
 
 	fn := ctx.function()
 	fn.errorEntries = append(fn.errorEntries, bir.BIRErrorEntry{
 		Start:   trapStartBB.Number,
-		End:     trapEndBB.Number,
+		End:     regionEnd,
 		Target:  afterTrapBB.Number,
 		ErrorOp: resultOperand,
 	})

--- a/common/tomlparser/toml.go
+++ b/common/tomlparser/toml.go
@@ -287,7 +287,7 @@ func (t *Toml) To(target any) {
 // json.Unmarshal can resolve it.
 func remapForTarget(m map[string]any, targetType reflect.Type) map[string]any {
 	// Dereference pointer types (target is typically a *Struct).
-	for targetType != nil && targetType.Kind() == reflect.Ptr {
+	for targetType != nil && targetType.Kind() == reflect.Pointer {
 		targetType = targetType.Elem()
 	}
 	if targetType == nil || targetType.Kind() != reflect.Struct {
@@ -371,7 +371,7 @@ func remapForTarget(m map[string]any, targetType reflect.Type) map[string]any {
 // sliceElemType returns the element type of a slice/array type, or the type
 // itself if it is not a slice/array.
 func sliceElemType(t reflect.Type) reflect.Type {
-	for t != nil && (t.Kind() == reflect.Slice || t.Kind() == reflect.Array || t.Kind() == reflect.Ptr) {
+	for t != nil && (t.Kind() == reflect.Slice || t.Kind() == reflect.Array || t.Kind() == reflect.Pointer) {
 		t = t.Elem()
 	}
 	return t

--- a/corpus/ast/subset8/08-nillifting/match-guard1-v.txt
+++ b/corpus/ast/subset8/08-nillifting/match-guard1-v.txt
@@ -1,0 +1,45 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable value (type
+          (value-type int)) (expr
+          (literal 1))))
+      (var-def
+        (variable n (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 0))))
+      (match
+        (simple-var-ref value)
+        (match-clause
+          (const-pattern
+            (literal 1))
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (literal first))))))
+        (match-clause
+          (wildcard-match-pattern)
+          (match-guard
+            (binary-expr ==
+              (binary-expr +
+                (invocation guardValue ())
+                (simple-var-ref n))
+              (literal 1)))
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (literal guarded)))))))))
+  (function guardValue () (
+    (value-type int))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (literal guard))))
+      (return
+        (literal 1)))))

--- a/corpus/ast/subset8/08-nillifting/mutate1-v.txt
+++ b/corpus/ast/subset8/08-nillifting/mutate1-v.txt
@@ -1,0 +1,46 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (variable number (type
+    (union-type
+      (value-type int)
+      (value-type null))) (expr
+    (literal 1)))
+  (variable text (type
+    (union-type
+      (value-type string)
+      (value-type null))) (expr
+    (literal a)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (binary-expr +
+            (simple-var-ref number)
+            (invocation mutateNumber ())))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr +
+            (simple-var-ref text)
+            (invocation mutateText ())))))))
+  (function mutateNumber () (
+    (union-type
+      (value-type int)
+      (value-type null)))
+    (block-function-body
+      (assignment
+        (simple-var-ref number)
+        (literal 100))
+      (return
+        (literal 1))))
+  (function mutateText () (
+    (union-type
+      (value-type string)
+      (value-type null)))
+    (block-function-body
+      (assignment
+        (simple-var-ref text)
+        (literal mutated))
+      (return
+        (literal b)))))

--- a/corpus/ast/subset8/08-nillifting/operand-eval1-v.txt
+++ b/corpus/ast/subset8/08-nillifting/operand-eval1-v.txt
@@ -1,0 +1,33 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable nilValue (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal <nil>))))
+      (var-def
+        (variable result (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (binary-expr +
+            (invocation sideEffect ())
+            (simple-var-ref nilValue)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref result)
+            (value-type null)))))))
+  (function sideEffect () (
+    (value-type int))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (literal side-effect))))
+      (return
+        (literal 1)))))

--- a/corpus/ast/subset8/08-nillifting/trap1-v.txt
+++ b/corpus/ast/subset8/08-nillifting/trap1-v.txt
@@ -1,0 +1,67 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable left (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 1))))
+      (var-def
+        (variable right (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 2))))
+      (var-def
+        (variable sum (expr
+          (trap-expr
+            (binary-expr +
+              (simple-var-ref left)
+              (simple-var-ref right))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref sum))))
+      (var-def
+        (variable negated (expr
+          (trap-expr
+            (unary-expr -
+              (simple-var-ref left))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref negated))))
+      (var-def
+        (variable nilValue (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal <nil>))))
+      (var-def
+        (variable nilSum (expr
+          (trap-expr
+            (binary-expr +
+              (simple-var-ref left)
+              (simple-var-ref nilValue))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref nilSum)
+            (value-type null)))))
+      (var-def
+        (variable zero (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 0))))
+      (var-def
+        (variable divided (expr
+          (trap-expr
+            (binary-expr /
+              (simple-var-ref left)
+              (simple-var-ref zero))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref divided)))))))

--- a/corpus/ast/subset8/08-nillifting/trap2-v.txt
+++ b/corpus/ast/subset8/08-nillifting/trap2-v.txt
@@ -1,0 +1,32 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable b (type
+          (value-type boolean)) (expr
+          (literal true))))
+      (var-def
+        (variable zero (type
+          (value-type int)) (expr
+          (literal 0))))
+      (var-def
+        (variable result (expr
+          (trap-expr
+            (binary-expr &&
+              (simple-var-ref b)
+              (binary-expr >
+                (binary-expr /
+                  (invocation value ())
+                  (simple-var-ref zero))
+                (literal 0)))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref result))))))
+  (function value () (
+    (value-type int))
+    (block-function-body
+      (return
+        (literal 1)))))

--- a/corpus/ast/subset8/08-nillifting/while-cond1-v.txt
+++ b/corpus/ast/subset8/08-nillifting/while-cond1-v.txt
@@ -1,0 +1,27 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable current (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 0))))
+      (while
+        (binary-expr !=
+          (binary-expr +
+            (simple-var-ref current)
+            (literal 1))
+          (literal 5))
+        (block-stmt
+          (assignment
+            (simple-var-ref current)
+            (binary-expr +
+              (simple-var-ref current)
+              (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref current)))))))

--- a/corpus/bal/subset8/08-nillifting/match-guard1-v.bal
+++ b/corpus/bal/subset8/08-nillifting/match-guard1-v.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    int value = 1;
+    int? n = 0;
+    match value {
+        1 => {
+            io:println("first"); // @output first
+        }
+        _ if guardValue() + n == 1 => {
+            io:println("guarded");
+        }
+    }
+}
+
+function guardValue() returns int {
+    io:println("guard");
+    return 1;
+}

--- a/corpus/bal/subset8/08-nillifting/mutate1-v.bal
+++ b/corpus/bal/subset8/08-nillifting/mutate1-v.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+int? number = 1;
+string? text = "a";
+
+public function main() {
+    io:println(number + mutateNumber()); // @output 2
+    io:println(text + mutateText()); // @output ab
+}
+
+function mutateNumber() returns int? {
+    number = 100;
+    return 1;
+}
+
+function mutateText() returns string? {
+    text = "mutated";
+    return "b";
+}

--- a/corpus/bal/subset8/08-nillifting/operand-eval1-v.bal
+++ b/corpus/bal/subset8/08-nillifting/operand-eval1-v.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    int? nilValue = ();
+    int? result = sideEffect() + nilValue; // @output side-effect
+    io:println(result is ()); // @output true
+}
+
+function sideEffect() returns int {
+    io:println("side-effect");
+    return 1;
+}

--- a/corpus/bal/subset8/08-nillifting/trap1-v.bal
+++ b/corpus/bal/subset8/08-nillifting/trap1-v.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    int? left = 1;
+    int? right = 2;
+    var sum = trap left + right;
+    io:println(sum); // @output 3
+
+    var negated = trap -left;
+    io:println(negated); // @output -1
+
+    int? nilValue = ();
+    var nilSum = trap left + nilValue;
+    io:println(nilSum is ()); // @output true
+
+    int? zero = 0;
+    var divided = trap left / zero;
+    io:println(divided); // @output error("divide by zero")
+}

--- a/corpus/bal/subset8/08-nillifting/trap2-v.bal
+++ b/corpus/bal/subset8/08-nillifting/trap2-v.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    boolean b = true;
+    int zero = 0;
+    var result = trap b && value() / zero > 0;
+    io:println(result); // @output error("divide by zero")
+}
+
+function value() returns int {
+    return 1;
+}

--- a/corpus/bal/subset8/08-nillifting/while-cond1-v.bal
+++ b/corpus/bal/subset8/08-nillifting/while-cond1-v.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    int? current = 0;
+    while current + 1 != 5 {
+        current = current + 1;
+    }
+    io:println(current); // @output 4
+}

--- a/corpus/bir/subset1/01-int/mul-nil-lift-v.txt
+++ b/corpus/bir/subset1/01-int/mul-nil-lift-v.txt
@@ -3,29 +3,21 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad <nil>
     x = %1;
-    $desugar$0 = x;
-    %4 = ConstantLoad <nil>
-    $desugar$1 = %4;
-    %6 = $desugar$0 is nil
-    %6 ? bb1 : bb2;
+    %3 = x;
+    %4 = ConstantLoad 2
+    %5 = %3 is nil
+    %5 ? bb1 : bb2;
   }
   bb1 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %6 = ConstantLoad <nil>
     GOTO bb3;
   }
   bb2 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$0);
-    %2 = ConstantLoad 2
-    %3 = %2;
-    %0 = * %1 %3;
-    (1, $desugar$1) = %0;
-    PopScopeFrame
+    %6 = * %3 %4;
     GOTO bb3;
   }
   bb3 {
-    %7 = $desugar$1;
+    %7 = %6;
     %8 = println(%7) -> bb4;
   }
   bb4 {

--- a/corpus/bir/subset1/01-int/sub-nil-lift-v.txt
+++ b/corpus/bir/subset1/01-int/sub-nil-lift-v.txt
@@ -3,29 +3,21 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad <nil>
     x = %1;
-    $desugar$0 = x;
-    %4 = ConstantLoad <nil>
-    $desugar$1 = %4;
-    %6 = $desugar$0 is nil
-    %6 ? bb1 : bb2;
+    %3 = x;
+    %4 = ConstantLoad 1
+    %5 = %3 is nil
+    %5 ? bb1 : bb2;
   }
   bb1 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %6 = ConstantLoad <nil>
     GOTO bb3;
   }
   bb2 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$0);
-    %2 = ConstantLoad 1
-    %3 = %2;
-    %0 = - %1 %3;
-    (1, $desugar$1) = %0;
-    PopScopeFrame
+    %6 = - %3 %4;
     GOTO bb3;
   }
   bb3 {
-    %7 = $desugar$1;
+    %7 = %6;
     %8 = println(%7) -> bb4;
   }
   bb4 {

--- a/corpus/bir/subset10/10-conditional-expr/check-v.txt
+++ b/corpus/bir/subset10/10-conditional-expr/check-v.txt
@@ -264,7 +264,7 @@ main() -> nil{
   
   error-table {
     [bb13, bb20] -> bb21, %20
-    [bb22, bb25] -> bb30, %30
-    [bb31, bb34] -> bb39, %38
+    [bb22, bb29] -> bb30, %30
+    [bb31, bb38] -> bb39, %38
   }
 }

--- a/corpus/bir/subset10/10-conditional-expr/desugar-v.txt
+++ b/corpus/bir/subset10/10-conditional-expr/desugar-v.txt
@@ -15,167 +15,133 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad <nil>
     absent = %1;
-    $desugar$0 = absent;
-    %4 = ConstantLoad <nil>
-    $desugar$1 = %4;
-    %6 = $desugar$0 is nil
+    %4 = absent;
+    %5 = ConstantLoad 1
+    %6 = %4 is nil
     %6 ? bb1 : bb2;
   }
   bb1 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %7 = ConstantLoad <nil>
     GOTO bb3;
   }
   bb2 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$0);
-    %2 = ConstantLoad 1
-    %3 = %2;
-    %0 = + %1 %3;
-    (1, $desugar$1) = %0;
-    PopScopeFrame
+    %7 = + %4 %5;
     GOTO bb3;
   }
   bb3 {
-    %8 = $desugar$1 is nil
+    %8 = %7 is nil
     %8 ? bb4 : bb5;
   }
   bb4 {
     %9 = ConstantLoad 10
-    %7 = %9;
+    %3 = %9;
     GOTO bb6;
   }
   bb5 {
-    %7 = $desugar$1;
+    %3 = %7;
     GOTO bb6;
   }
   bb6 {
-    liftedLhs = %7;
-    %11 = ConstantLoad <nil>
-    $desugar$4 = %11;
-    %14 = $desugar$4 is nil
-    %14 ? bb7 : bb14;
+    liftedLhs = %3;
+    %12 = ConstantLoad <nil>
+    %13 = %12 is nil
+    %13 ? bb7 : bb8;
   }
   bb7 {
-    PushScopeFrame 7
-    $desugar$2 = (1, absent);
-    %1 = ConstantLoad <nil>
-    $desugar$3 = %1;
-    %3 = $desugar$2 is nil
-    %3 ? bb8 : bb9;
+    %15 = absent;
+    %16 = ConstantLoad 1
+    %17 = %15 is nil
+    %17 ? bb9 : bb10;
   }
   bb8 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb10;
-  }
-  bb9 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$2);
-    %2 = ConstantLoad 1
-    %3 = %2;
-    %0 = + %1 %3;
-    (1, $desugar$3) = %0;
-    PopScopeFrame
-    GOTO bb10;
-  }
-  bb10 {
-    %5 = $desugar$3 is nil
-    %5 ? bb11 : bb12;
-  }
-  bb11 {
-    %6 = ConstantLoad 20
-    %4 = %6;
-    GOTO bb13;
-  }
-  bb12 {
-    %4 = $desugar$3;
-    GOTO bb13;
-  }
-  bb13 {
-    (1, $desugar$5) = %4;
-    PopScopeFrame
+    %11 = %12;
     GOTO bb15;
   }
+  bb9 {
+    %18 = ConstantLoad <nil>
+    GOTO bb11;
+  }
+  bb10 {
+    %18 = + %15 %16;
+    GOTO bb11;
+  }
+  bb11 {
+    %19 = %18 is nil
+    %19 ? bb12 : bb13;
+  }
+  bb12 {
+    %20 = ConstantLoad 20
+    %14 = %20;
+    GOTO bb14;
+  }
+  bb13 {
+    %14 = %18;
+    GOTO bb14;
+  }
   bb14 {
-    PushScopeFrame 0
-    (1, $desugar$5) = (1, $desugar$4);
-    PopScopeFrame
+    %11 = %14;
     GOTO bb15;
   }
   bb15 {
-    liftedRhs = $desugar$5;
-    %16 = ConstantLoad 30
-    present = %16;
-    $desugar$8 = present;
-    %20 = $desugar$8 is nil
-    %20 ? bb16 : bb24;
+    liftedRhs = %11;
+    %22 = ConstantLoad 30
+    present = %22;
+    %25 = present is nil
+    %25 ? bb16 : bb17;
   }
   bb16 {
-    PushScopeFrame 8
-    %0 = nullable() -> bb17;
+    %27 = nullable() -> bb18;
   }
   bb17 {
-    $desugar$6 = %0;
-    %2 = ConstantLoad <nil>
-    $desugar$7 = %2;
-    %4 = $desugar$6 is nil
-    %4 ? bb18 : bb19;
-  }
-  bb18 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb20;
-  }
-  bb19 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$6);
-    %2 = ConstantLoad 1
-    %3 = %2;
-    %0 = + %1 %3;
-    (1, $desugar$7) = %0;
-    PopScopeFrame
-    GOTO bb20;
-  }
-  bb20 {
-    %6 = $desugar$7 is nil
-    %6 ? bb21 : bb22;
-  }
-  bb21 {
-    %7 = ConstantLoad 40
-    %5 = %7;
-    GOTO bb23;
-  }
-  bb22 {
-    %5 = $desugar$7;
-    GOTO bb23;
-  }
-  bb23 {
-    (1, $desugar$9) = %5;
-    PopScopeFrame
+    %24 = present;
     GOTO bb25;
   }
+  bb18 {
+    %28 = %27;
+    %29 = ConstantLoad 1
+    %30 = %28 is nil
+    %30 ? bb19 : bb20;
+  }
+  bb19 {
+    %31 = ConstantLoad <nil>
+    GOTO bb21;
+  }
+  bb20 {
+    %31 = + %28 %29;
+    GOTO bb21;
+  }
+  bb21 {
+    %32 = %31 is nil
+    %32 ? bb22 : bb23;
+  }
+  bb22 {
+    %33 = ConstantLoad 40
+    %26 = %33;
+    GOTO bb24;
+  }
+  bb23 {
+    %26 = %31;
+    GOTO bb24;
+  }
   bb24 {
-    PushScopeFrame 0
-    (1, $desugar$9) = (1, $desugar$8);
-    PopScopeFrame
+    %24 = %26;
     GOTO bb25;
   }
   bb25 {
-    lazyRhs = $desugar$9;
-    %22 = liftedLhs;
-    %23 = println(%22) -> bb26;
+    lazyRhs = %24;
+    %35 = liftedLhs;
+    %36 = println(%35) -> bb26;
   }
   bb26 {
-    %24 = liftedRhs;
-    %25 = println(%24) -> bb27;
+    %37 = liftedRhs;
+    %38 = println(%37) -> bb27;
   }
   bb27 {
-    %26 = lazyRhs;
-    %27 = println(%26) -> bb28;
+    %39 = lazyRhs;
+    %40 = println(%39) -> bb28;
   }
   bb28 {
-    %28 = println(calls) -> bb29;
+    %41 = println(calls) -> bb29;
   }
   bb29 {
     return;

--- a/corpus/bir/subset10/10-conditional-expr/nil-conditional-v.txt
+++ b/corpus/bir/subset10/10-conditional-expr/nil-conditional-v.txt
@@ -236,522 +236,539 @@ main() -> nil{
   }
   bb5 {
     nonNil = %1;
-    %8 = ConstantLoad 30
-    %9 = %8;
-    %10 = lhs(%9) -> bb6;
+    %9 = ConstantLoad 30
+    %10 = %9;
+    %11 = lhs(%10) -> bb6;
   }
   bb6 {
-    $desugar$2 = %10;
-    %13 = $desugar$2 is nil
-    %13 ? bb7 : bb12;
+    %12 = %11 is nil
+    %12 ? bb7 : bb8;
   }
   bb7 {
-    PushScopeFrame 7
-    %0 = ConstantLoad 40
-    %1 = %0;
-    %2 = lhs(%1) -> bb8;
+    %13 = ConstantLoad 40
+    %14 = %13;
+    %15 = lhs(%14) -> bb9;
   }
   bb8 {
-    $desugar$0 = %2;
-    %4 = ConstantLoad <nil>
-    $desugar$1 = %4;
-    %6 = $desugar$0 is nil
-    %6 ? bb9 : bb10;
-  }
-  bb9 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb11;
-  }
-  bb10 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$0);
-    %2 = ConstantLoad 1
-    %3 = %2;
-    %0 = + %1 %3;
-    (1, $desugar$1) = %0;
-    PopScopeFrame
-    GOTO bb11;
-  }
-  bb11 {
-    (1, $desugar$3) = $desugar$1;
-    PopScopeFrame
+    %8 = %11;
     GOTO bb13;
   }
+  bb9 {
+    %16 = %15;
+    %17 = ConstantLoad 1
+    %18 = %16 is nil
+    %18 ? bb10 : bb11;
+  }
+  bb10 {
+    %19 = ConstantLoad <nil>
+    GOTO bb12;
+  }
+  bb11 {
+    %19 = + %16 %17;
+    GOTO bb12;
+  }
   bb12 {
-    PushScopeFrame 0
-    (1, $desugar$3) = (1, $desugar$2);
-    PopScopeFrame
+    %8 = %19;
     GOTO bb13;
   }
   bb13 {
-    nonNilComposite = $desugar$3;
-    %16 = ConstantLoad <nil>
-    %17 = %16;
-    %18 = lhs(%17) -> bb14;
+    nonNilComposite = %8;
+    %22 = ConstantLoad <nil>
+    %23 = %22;
+    %24 = lhs(%23) -> bb14;
   }
   bb14 {
-    %19 = %18 is nil
-    %19 ? bb15 : bb16;
+    %25 = %24 is nil
+    %25 ? bb15 : bb16;
   }
   bb15 {
-    %20 = rhs() -> bb17;
+    %26 = rhs() -> bb17;
   }
   bb16 {
-    %15 = %18;
+    %21 = %24;
     GOTO bb18;
   }
   bb17 {
-    %15 = %20;
+    %21 = %26;
     GOTO bb18;
   }
   bb18 {
-    fallback = %15;
-    %23 = ConstantLoad value
-    %24 = %23 is nil
-    %24 ? bb19 : bb20;
+    fallback = %21;
+    %29 = ConstantLoad value
+    %30 = %29 is nil
+    %30 ? bb19 : bb20;
   }
   bb19 {
-    %25 = ConstantLoad 100
-    %22 = %25;
+    %31 = ConstantLoad 100
+    %28 = %31;
     GOTO bb21;
   }
   bb20 {
-    %22 = %23;
+    %28 = %29;
     GOTO bb21;
   }
   bb21 {
-    staticallyNonNil = %22;
-    %27 = ConstantLoad <nil>
-    nilValue = %27;
-    %30 = nilValue is nil
-    %30 ? bb22 : bb23;
+    staticallyNonNil = %28;
+    %33 = ConstantLoad <nil>
+    nilValue = %33;
+    %36 = nilValue is nil
+    %36 ? bb22 : bb23;
   }
   bb22 {
-    %31 = ConstantLoad 50
-    %29 = %31;
+    %37 = ConstantLoad 50
+    %35 = %37;
     GOTO bb24;
   }
   bb23 {
-    %29 = nilValue;
+    %35 = nilValue;
     GOTO bb24;
   }
   bb24 {
-    staticallyNil = %29;
-    %35 = ConstantLoad <nil>
-    %36 = %35;
-    %37 = lhs(%36) -> bb25;
+    staticallyNil = %35;
+    %41 = ConstantLoad <nil>
+    %42 = %41;
+    %43 = lhs(%42) -> bb25;
   }
   bb25 {
-    %38 = %37 is nil
-    %38 ? bb26 : bb27;
+    %44 = %43 is nil
+    %44 ? bb26 : bb27;
   }
   bb26 {
-    %39 = ConstantLoad 20
-    %40 = %39;
-    %41 = lhs(%40) -> bb28;
+    %45 = ConstantLoad 20
+    %46 = %45;
+    %47 = lhs(%46) -> bb28;
   }
   bb27 {
-    %34 = %37;
+    %40 = %43;
     GOTO bb29;
   }
   bb28 {
-    %34 = %41;
+    %40 = %47;
     GOTO bb29;
   }
   bb29 {
-    %42 = %34 is nil
-    %42 ? bb30 : bb31;
+    %48 = %40 is nil
+    %48 ? bb30 : bb31;
   }
   bb30 {
-    %43 = rhs() -> bb32;
+    %49 = rhs() -> bb32;
   }
   bb31 {
-    %33 = %34;
+    %39 = %40;
     GOTO bb33;
   }
   bb32 {
-    %33 = %43;
+    %39 = %49;
     GOTO bb33;
   }
   bb33 {
-    nested = %33;
-    %46 = ConstantLoad false
-    %46 ? bb34 : bb35;
+    nested = %39;
+    %52 = ConstantLoad false
+    %52 ? bb34 : bb35;
   }
   bb34 {
-    %48 = ConstantLoad 30
-    %49 = %48;
-    %50 = lhs(%49) -> bb37;
+    %54 = ConstantLoad 30
+    %55 = %54;
+    %56 = lhs(%55) -> bb37;
   }
   bb35 {
-    %53 = ConstantLoad 60
-    %45 = %53;
+    %59 = ConstantLoad 60
+    %51 = %59;
     GOTO bb36;
   }
   bb36 {
-    lazyOuterBranch = %45;
-    %55 = ConstantLoad mixed
-    %56 = mixedResult(%55) -> bb42;
+    lazyOuterBranch = %51;
+    %61 = ConstantLoad mixed
+    %62 = mixedResult(%61) -> bb42;
   }
   bb37 {
-    %51 = %50 is nil
-    %51 ? bb38 : bb39;
+    %57 = %56 is nil
+    %57 ? bb38 : bb39;
   }
   bb38 {
-    %52 = rhs() -> bb40;
+    %58 = rhs() -> bb40;
   }
   bb39 {
-    %47 = %50;
+    %53 = %56;
     GOTO bb41;
   }
   bb40 {
-    %47 = %52;
+    %53 = %58;
     GOTO bb41;
   }
   bb41 {
-    %45 = %47;
+    %51 = %53;
     GOTO bb36;
   }
   bb42 {
-    mixedString = %56;
-    %58 = ConstantLoad <nil>
-    %59 = %58;
-    %60 = mixedResult(%59) -> bb43;
+    mixedString = %62;
+    %64 = ConstantLoad <nil>
+    %65 = %64;
+    %66 = mixedResult(%65) -> bb43;
   }
   bb43 {
-    mixedNil = %60;
-    %62 = ConstantLoad <nil>
-    %63 = %62;
-    %64 = nilSubtype(%63) -> bb44;
+    mixedNil = %66;
+    %68 = ConstantLoad <nil>
+    %69 = %68;
+    %70 = nilSubtype(%69) -> bb44;
   }
   bb44 {
-    nilSubtypeResult = %64;
-    %66 = ConstantLoad <nil>
-    %67 = %66;
-    %68 = optionalNever(%67) -> bb45;
+    nilSubtypeResult = %70;
+    %72 = ConstantLoad <nil>
+    %73 = %72;
+    %74 = optionalNever(%73) -> bb45;
   }
   bb45 {
-    optionalNeverResult = %68;
-    %70 = ConstantLoad 120
-    %71 = %70;
-    %72 = ConstantLoad false
-    %73 = %72;
-    %74 = checkedRhs(%71,%73) -> bb46;
-  }
-  bb46 {
-    lazyCheck = %74;
-    %76 = ConstantLoad <nil>
+    optionalNeverResult = %74;
+    %76 = ConstantLoad 120
     %77 = %76;
     %78 = ConstantLoad false
     %79 = %78;
-    %80 = checkedRhs(%77,%79) -> bb47;
+    %80 = checkedRhs(%77,%79) -> bb46;
   }
-  bb47 {
-    failedCheck = %80;
+  bb46 {
+    lazyCheck = %80;
     %82 = ConstantLoad <nil>
     %83 = %82;
-    %84 = checkedOuter(%83) -> bb48;
+    %84 = ConstantLoad false
+    %85 = %84;
+    %86 = checkedRhs(%83,%85) -> bb47;
+  }
+  bb47 {
+    failedCheck = %86;
+    %88 = ConstantLoad <nil>
+    %89 = %88;
+    %90 = checkedOuter(%89) -> bb48;
   }
   bb48 {
-    outerNil = %84;
-    %86 = ConstantLoad outer
-    %87 = newError error(%86)
-    %88 = checkedOuter(%87) -> bb49;
+    outerNil = %90;
+    %92 = ConstantLoad outer
+    %93 = newError error(%92)
+    %94 = checkedOuter(%93) -> bb49;
   }
   bb49 {
-    outerError = %88;
+    outerError = %94;
     GOTO bb50;
   }
   bb50 {
-    %92 = ConstantLoad 130
-    %93 = %92 is nil
-    %93 ? bb51 : bb52;
+    %98 = ConstantLoad 130
+    %99 = %98 is nil
+    %99 ? bb51 : bb52;
   }
   bb51 {
-    %96 = ConstantLoad false
-    %97 = %96;
-    %98 = nullableCheckedValue(%97) -> bb53;
+    %101 = ConstantLoad false
+    %102 = %101;
+    %103 = nullableCheckedValue(%102) -> bb53;
   }
   bb52 {
-    %91 = %92;
-    GOTO bb57;
+    %97 = %98;
+    GOTO bb60;
   }
   bb53 {
-    %99 = %98 is error
-    %99 ? bb54 : bb55;
+    %104 = %103 is error
+    %104 ? bb54 : bb55;
   }
   bb54 {
-    panic %98;
+    panic %103;
   }
   bb55 {
-    %95 = %98;
+    %100 = %103;
     GOTO bb56;
   }
   bb56 {
-    %100 = %95;
-    %101 = ConstantLoad 1
-    %102 = %101;
-    %94 = + %100 %102;
-    %91 = %94;
-    GOTO bb57;
+    %105 = %100;
+    %106 = ConstantLoad 1
+    %107 = %105 is nil
+    %107 ? bb57 : bb58;
   }
   bb57 {
-    %90 = %91;
-    GOTO bb58;
+    %108 = ConstantLoad <nil>
+    GOTO bb59;
   }
   bb58 {
-    lazyCheckpanic = %90;
+    %108 = + %105 %106;
     GOTO bb59;
   }
   bb59 {
-    %106 = ConstantLoad <nil>
-    %107 = %106 is nil
-    %107 ? bb60 : bb61;
+    %97 = %108;
+    GOTO bb60;
   }
   bb60 {
-    %110 = ConstantLoad false
-    %111 = %110;
-    %112 = nullableCheckedValue(%111) -> bb62;
+    %96 = %97;
+    GOTO bb61;
   }
   bb61 {
-    %105 = %106;
-    GOTO bb66;
+    lazyCheckpanic = %96;
+    GOTO bb62;
   }
   bb62 {
-    %113 = %112 is error
+    %112 = ConstantLoad <nil>
+    %113 = %112 is nil
     %113 ? bb63 : bb64;
   }
   bb63 {
-    panic %112;
+    %115 = ConstantLoad false
+    %116 = %115;
+    %117 = nullableCheckedValue(%116) -> bb65;
   }
   bb64 {
-    %109 = %112;
-    GOTO bb65;
+    %111 = %112;
+    GOTO bb72;
   }
   bb65 {
-    %114 = %109;
-    %115 = ConstantLoad 1
-    %116 = %115;
-    %108 = + %114 %116;
-    %105 = %108;
-    GOTO bb66;
+    %118 = %117 is error
+    %118 ? bb66 : bb67;
   }
   bb66 {
-    %104 = %105;
-    GOTO bb67;
+    panic %117;
   }
   bb67 {
-    trappedCheckpanic = %104;
+    %114 = %117;
     GOTO bb68;
   }
   bb68 {
-    %121 = ConstantLoad false
-    %122 = %121;
-    %123 = nullableCheckedValue(%122) -> bb69;
+    %119 = %114;
+    %120 = ConstantLoad 1
+    %121 = %119 is nil
+    %121 ? bb69 : bb70;
   }
   bb69 {
-    %124 = %123 is error
-    %124 ? bb70 : bb71;
+    %122 = ConstantLoad <nil>
+    GOTO bb71;
   }
   bb70 {
-    panic %123;
+    %122 = + %119 %120;
+    GOTO bb71;
   }
   bb71 {
-    %120 = %123;
+    %111 = %122;
     GOTO bb72;
   }
   bb72 {
-    %125 = %120 is nil
-    %125 ? bb73 : bb74;
+    %110 = %111;
+    GOTO bb73;
   }
   bb73 {
-    %126 = ConstantLoad 140
-    %119 = %126;
-    GOTO bb75;
+    trappedCheckpanic = %110;
+    GOTO bb74;
   }
   bb74 {
-    %119 = %120;
-    GOTO bb75;
+    %127 = ConstantLoad false
+    %128 = %127;
+    %129 = nullableCheckedValue(%128) -> bb75;
   }
   bb75 {
-    %118 = %119;
-    GOTO bb76;
+    %130 = %129 is error
+    %130 ? bb76 : bb77;
   }
   bb76 {
-    lhsCheckpanic = %118;
-    GOTO bb77;
+    panic %129;
   }
   bb77 {
-    %132 = ConstantLoad false
-    %133 = %132;
-    %134 = nullableCheckedValue(%133) -> bb78;
+    %126 = %129;
+    GOTO bb78;
   }
   bb78 {
-    %135 = %134 is error
-    %135 ? bb79 : bb80;
+    %131 = %126 is nil
+    %131 ? bb79 : bb80;
   }
   bb79 {
-    panic %134;
+    %132 = ConstantLoad 140
+    %125 = %132;
+    GOTO bb81;
   }
   bb80 {
-    %131 = %134;
+    %125 = %126;
     GOTO bb81;
   }
   bb81 {
-    %136 = %131;
-    %137 = ConstantLoad 1
-    %138 = %137;
-    %130 = + %136 %138;
-    %139 = %130 is nil
-    %139 ? bb82 : bb83;
+    %124 = %125;
+    GOTO bb82;
   }
   bb82 {
-    %140 = ConstantLoad 150
-    %129 = %140;
-    GOTO bb84;
+    lhsCheckpanic = %124;
+    GOTO bb83;
   }
   bb83 {
-    %129 = %130;
-    GOTO bb84;
+    %137 = ConstantLoad false
+    %138 = %137;
+    %139 = nullableCheckedValue(%138) -> bb84;
   }
   bb84 {
-    %128 = %129;
-    GOTO bb85;
+    %140 = %139 is error
+    %140 ? bb85 : bb86;
   }
   bb85 {
-    wrappedLhsCheckpanic = %128;
-    GOTO bb86;
+    panic %139;
   }
   bb86 {
-    %145 = ConstantLoad <nil>
-    %146 = %145 is nil
-    %146 ? bb87 : bb88;
+    %136 = %139;
+    GOTO bb87;
   }
   bb87 {
-    %147 = ConstantLoad false
-    %148 = %147;
-    %149 = checkedValue(%148) -> bb89;
+    %141 = %136;
+    %142 = ConstantLoad 1
+    %143 = %141 is nil
+    %143 ? bb88 : bb89;
   }
   bb88 {
-    %144 = %145;
+    %144 = ConstantLoad <nil>
     GOTO bb90;
   }
   bb89 {
-    %144 = %149;
+    %144 = + %141 %142;
     GOTO bb90;
   }
   bb90 {
-    %150 = %144 is error
-    %150 ? bb91 : bb92;
+    %145 = %144 is nil
+    %145 ? bb91 : bb92;
   }
   bb91 {
-    panic %144;
+    %146 = ConstantLoad 150
+    %135 = %146;
+    GOTO bb93;
   }
   bb92 {
-    %143 = %144;
+    %135 = %144;
     GOTO bb93;
   }
   bb93 {
-    %142 = %143;
+    %134 = %135;
     GOTO bb94;
   }
   bb94 {
-    outerCheckpanic = %142;
-    %152 = nonNil;
-    %153 = println(%152) -> bb95;
+    wrappedLhsCheckpanic = %134;
+    GOTO bb95;
   }
   bb95 {
-    %154 = nonNilComposite;
-    %155 = println(%154) -> bb96;
+    %151 = ConstantLoad <nil>
+    %152 = %151 is nil
+    %152 ? bb96 : bb97;
   }
   bb96 {
-    %156 = fallback;
-    %157 = println(%156) -> bb97;
+    %153 = ConstantLoad false
+    %154 = %153;
+    %155 = checkedValue(%154) -> bb98;
   }
   bb97 {
-    %158 = println(staticallyNonNil) -> bb98;
+    %150 = %151;
+    GOTO bb99;
   }
   bb98 {
-    %159 = staticallyNil;
-    %160 = println(%159) -> bb99;
+    %150 = %155;
+    GOTO bb99;
   }
   bb99 {
-    %161 = nested;
-    %162 = println(%161) -> bb100;
+    %156 = %150 is error
+    %156 ? bb100 : bb101;
   }
   bb100 {
-    %163 = lazyOuterBranch;
-    %164 = println(%163) -> bb101;
+    panic %150;
   }
   bb101 {
-    %165 = println(mixedString) -> bb102;
+    %149 = %150;
+    GOTO bb102;
   }
   bb102 {
-    %166 = println(mixedNil) -> bb103;
+    %148 = %149;
+    GOTO bb103;
   }
   bb103 {
-    %167 = nilSubtypeResult;
-    %168 = println(%167) -> bb104;
+    outerCheckpanic = %148;
+    %158 = nonNil;
+    %159 = println(%158) -> bb104;
   }
   bb104 {
-    %169 = optionalNeverResult;
-    %170 = println(%169) -> bb105;
+    %160 = nonNilComposite;
+    %161 = println(%160) -> bb105;
   }
   bb105 {
-    %171 = println(lazyCheck) -> bb106;
+    %162 = fallback;
+    %163 = println(%162) -> bb106;
   }
   bb106 {
-    %172 = failedCheck is error
-    %173 = %172;
-    %174 = println(%173) -> bb107;
+    %164 = println(staticallyNonNil) -> bb107;
   }
   bb107 {
-    %175 = println(outerNil) -> bb108;
+    %165 = staticallyNil;
+    %166 = println(%165) -> bb108;
   }
   bb108 {
-    %176 = outerError is error
-    %177 = %176;
-    %178 = println(%177) -> bb109;
+    %167 = nested;
+    %168 = println(%167) -> bb109;
   }
   bb109 {
-    %179 = println(lazyCheckpanic) -> bb110;
+    %169 = lazyOuterBranch;
+    %170 = println(%169) -> bb110;
   }
   bb110 {
-    %180 = trappedCheckpanic is error
-    %181 = %180;
-    %182 = println(%181) -> bb111;
+    %171 = println(mixedString) -> bb111;
   }
   bb111 {
-    %183 = lhsCheckpanic is error
-    %184 = %183;
-    %185 = println(%184) -> bb112;
+    %172 = println(mixedNil) -> bb112;
   }
   bb112 {
-    %186 = wrappedLhsCheckpanic is error
-    %187 = %186;
-    %188 = println(%187) -> bb113;
+    %173 = nilSubtypeResult;
+    %174 = println(%173) -> bb113;
   }
   bb113 {
-    %189 = outerCheckpanic is error
-    %190 = %189;
-    %191 = println(%190) -> bb114;
+    %175 = optionalNeverResult;
+    %176 = println(%175) -> bb114;
   }
   bb114 {
-    %192 = println(lhsCalls) -> bb115;
+    %177 = println(lazyCheck) -> bb115;
   }
   bb115 {
-    %193 = println(rhsCalls) -> bb116;
+    %178 = failedCheck is error
+    %179 = %178;
+    %180 = println(%179) -> bb116;
   }
   bb116 {
+    %181 = println(outerNil) -> bb117;
+  }
+  bb117 {
+    %182 = outerError is error
+    %183 = %182;
+    %184 = println(%183) -> bb118;
+  }
+  bb118 {
+    %185 = println(lazyCheckpanic) -> bb119;
+  }
+  bb119 {
+    %186 = trappedCheckpanic is error
+    %187 = %186;
+    %188 = println(%187) -> bb120;
+  }
+  bb120 {
+    %189 = lhsCheckpanic is error
+    %190 = %189;
+    %191 = println(%190) -> bb121;
+  }
+  bb121 {
+    %192 = wrappedLhsCheckpanic is error
+    %193 = %192;
+    %194 = println(%193) -> bb122;
+  }
+  bb122 {
+    %195 = outerCheckpanic is error
+    %196 = %195;
+    %197 = println(%196) -> bb123;
+  }
+  bb123 {
+    %198 = println(lhsCalls) -> bb124;
+  }
+  bb124 {
+    %199 = println(rhsCalls) -> bb125;
+  }
+  bb125 {
     return;
   }
   
   error-table {
-    [bb50, bb57] -> bb58, %90
-    [bb59, bb66] -> bb67, %104
-    [bb68, bb75] -> bb76, %118
-    [bb77, bb84] -> bb85, %128
-    [bb86, bb93] -> bb94, %142
+    [bb50, bb60] -> bb61, %96
+    [bb62, bb72] -> bb73, %110
+    [bb74, bb81] -> bb82, %124
+    [bb83, bb93] -> bb94, %134
+    [bb95, bb102] -> bb103, %148
   }
 }

--- a/corpus/bir/subset10/10-conditional-expr/trap-v.txt
+++ b/corpus/bir/subset10/10-conditional-expr/trap-v.txt
@@ -120,7 +120,7 @@ main() -> nil{
   }
   
   error-table {
-    [bb1, bb4] -> bb6, %1
+    [bb1, bb5] -> bb6, %1
     [bb14, bb15] -> bb16, %14
     [bb20, bb21] -> bb22, %21
   }

--- a/corpus/bir/subset2/02-bitwise/and-nil-lift-v.txt
+++ b/corpus/bir/subset2/02-bitwise/and-nil-lift-v.txt
@@ -3,29 +3,21 @@ main() -> nil{
   bb0 {
     %1 = ConstantLoad <nil>
     x = %1;
-    $desugar$0 = x;
-    %4 = ConstantLoad <nil>
-    $desugar$1 = %4;
-    %6 = $desugar$0 is nil
-    %6 ? bb1 : bb2;
+    %3 = x;
+    %4 = ConstantLoad 1
+    %5 = %3 is nil
+    %5 ? bb1 : bb2;
   }
   bb1 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %6 = ConstantLoad <nil>
     GOTO bb3;
   }
   bb2 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$0);
-    %2 = ConstantLoad 1
-    %3 = %2;
-    %0 = unknown %1 %3;
-    (1, $desugar$1) = %0;
-    PopScopeFrame
+    %6 = unknown %3 %4;
     GOTO bb3;
   }
   bb3 {
-    %7 = $desugar$1;
+    %7 = %6;
     %8 = println(%7) -> bb4;
   }
   bb4 {

--- a/corpus/bir/subset8/08-nillifting/1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/1-v.txt
@@ -7,716 +7,407 @@ main() -> nil{
     b = %3;
     %5 = ConstantLoad 1
     c = %5;
-    $desugar$0 = a;
-    $desugar$1 = b;
-    %9 = ConstantLoad <nil>
-    $desugar$2 = %9;
-    %12 = $desugar$0 is nil
-    %11 = %12;
-    %12 ? bb2 : bb1;
+    %7 = a;
+    %8 = %7 is nil
+    %9 = b is nil
+    %10 = || %8 %9;
+    %10 ? bb1 : bb2;
   }
   bb1 {
-    %13 = $desugar$1 is nil
-    %11 = %13;
-    GOTO bb2;
+    %11 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %11 ? bb3 : bb4;
+    %11 = + %7 b;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    v1 = %11;
+    %13 = v1;
+    %14 = println(%13) -> bb4;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = + %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %15 = a;
+    %16 = %15 is nil
+    %17 = b is nil
+    %18 = || %16 %17;
+    %18 ? bb5 : bb6;
   }
   bb5 {
-    v1 = $desugar$2;
-    %15 = v1;
-    %16 = println(%15) -> bb6;
+    %19 = ConstantLoad <nil>
+    GOTO bb7;
   }
   bb6 {
-    $desugar$3 = a;
-    $desugar$4 = b;
-    %19 = ConstantLoad <nil>
-    $desugar$5 = %19;
-    %22 = $desugar$3 is nil
-    %21 = %22;
-    %22 ? bb8 : bb7;
+    %19 = + %15 b;
+    GOTO bb7;
   }
   bb7 {
-    %23 = $desugar$4 is nil
-    %21 = %23;
-    GOTO bb8;
+    %20 = %19;
+    %21 = println(%20) -> bb8;
   }
   bb8 {
-    %21 ? bb9 : bb10;
+    %22 = a;
+    %23 = %22 is nil
+    %24 = b is nil
+    %25 = || %23 %24;
+    %25 ? bb9 : bb10;
   }
   bb9 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %26 = ConstantLoad <nil>
     GOTO bb11;
   }
   bb10 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = + %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
+    %26 = + %22 b;
     GOTO bb11;
   }
   bb11 {
-    %24 = $desugar$5;
-    %25 = println(%24) -> bb12;
+    %27 = %26;
+    %28 = %27 is nil
+    %29 = c is nil
+    %30 = || %28 %29;
+    %30 ? bb12 : bb13;
   }
   bb12 {
-    $desugar$6 = a;
-    $desugar$7 = b;
-    %28 = ConstantLoad <nil>
-    $desugar$8 = %28;
-    %31 = $desugar$6 is nil
-    %30 = %31;
-    %31 ? bb14 : bb13;
+    %31 = ConstantLoad <nil>
+    GOTO bb14;
   }
   bb13 {
-    %32 = $desugar$7 is nil
-    %30 = %32;
+    %31 = + %27 c;
     GOTO bb14;
   }
   bb14 {
-    %30 ? bb15 : bb16;
+    v2 = %31;
+    %33 = v2;
+    %34 = println(%33) -> bb15;
   }
   bb15 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb17;
+    %35 = a;
+    %36 = %35 is nil
+    %37 = b is nil
+    %38 = || %36 %37;
+    %38 ? bb16 : bb17;
   }
   bb16 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = + %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
-    GOTO bb17;
+    %39 = ConstantLoad <nil>
+    GOTO bb18;
   }
   bb17 {
-    $desugar$9 = $desugar$8;
-    $desugar$10 = c;
-    %35 = ConstantLoad <nil>
-    $desugar$11 = %35;
-    %38 = $desugar$9 is nil
-    %37 = %38;
-    %38 ? bb19 : bb18;
+    %39 = + %35 b;
+    GOTO bb18;
   }
   bb18 {
-    %39 = $desugar$10 is nil
-    %37 = %39;
-    GOTO bb19;
+    %40 = %39;
+    %41 = %40 is nil
+    %42 = c is nil
+    %43 = || %41 %42;
+    %43 ? bb19 : bb20;
   }
   bb19 {
-    %37 ? bb20 : bb21;
+    %44 = ConstantLoad <nil>
+    GOTO bb21;
   }
   bb20 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb22;
+    %44 = + %40 c;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = + %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb22;
+    %45 = %44;
+    %46 = println(%45) -> bb22;
   }
   bb22 {
-    v2 = $desugar$11;
-    %41 = v2;
-    %42 = println(%41) -> bb23;
+    %47 = a;
+    %48 = %47 is nil
+    %49 = b is nil
+    %50 = || %48 %49;
+    %50 ? bb23 : bb24;
   }
   bb23 {
-    $desugar$12 = a;
-    $desugar$13 = b;
-    %45 = ConstantLoad <nil>
-    $desugar$14 = %45;
-    %48 = $desugar$12 is nil
-    %47 = %48;
-    %48 ? bb25 : bb24;
+    %51 = ConstantLoad <nil>
+    GOTO bb25;
   }
   bb24 {
-    %49 = $desugar$13 is nil
-    %47 = %49;
+    %51 = - %47 b;
     GOTO bb25;
   }
   bb25 {
-    %47 ? bb26 : bb27;
+    v3 = %51;
+    %53 = v3;
+    %54 = println(%53) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb28;
+    %55 = a;
+    %56 = %55 is nil
+    %57 = b is nil
+    %58 = || %56 %57;
+    %58 ? bb27 : bb28;
   }
   bb27 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$12);
-    %2 = (1, $desugar$13);
-    %0 = + %1 %2;
-    (1, $desugar$14) = %0;
-    PopScopeFrame
-    GOTO bb28;
+    %59 = ConstantLoad <nil>
+    GOTO bb29;
   }
   bb28 {
-    $desugar$15 = $desugar$14;
-    $desugar$16 = c;
-    %52 = ConstantLoad <nil>
-    $desugar$17 = %52;
-    %55 = $desugar$15 is nil
-    %54 = %55;
-    %55 ? bb30 : bb29;
+    %59 = + %55 b;
+    GOTO bb29;
   }
   bb29 {
-    %56 = $desugar$16 is nil
-    %54 = %56;
-    GOTO bb30;
+    %60 = %59;
+    %61 = %60 is nil
+    %62 = c is nil
+    %63 = || %61 %62;
+    %63 ? bb30 : bb31;
   }
   bb30 {
-    %54 ? bb31 : bb32;
+    %64 = ConstantLoad <nil>
+    GOTO bb32;
   }
   bb31 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb33;
+    %64 = - %60 c;
+    GOTO bb32;
   }
   bb32 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$15);
-    %2 = (1, $desugar$16);
-    %0 = + %1 %2;
-    (1, $desugar$17) = %0;
-    PopScopeFrame
-    GOTO bb33;
+    v4 = %64;
+    %66 = v4;
+    %67 = println(%66) -> bb33;
   }
   bb33 {
-    %57 = $desugar$17;
-    %58 = println(%57) -> bb34;
+    %68 = b;
+    %69 = %68 is nil
+    %70 = c is nil
+    %71 = || %69 %70;
+    %71 ? bb34 : bb35;
   }
   bb34 {
-    $desugar$18 = a;
-    $desugar$19 = b;
-    %61 = ConstantLoad <nil>
-    $desugar$20 = %61;
-    %64 = $desugar$18 is nil
-    %63 = %64;
-    %64 ? bb36 : bb35;
+    %72 = ConstantLoad <nil>
+    GOTO bb36;
   }
   bb35 {
-    %65 = $desugar$19 is nil
-    %63 = %65;
+    %72 = / %68 c;
     GOTO bb36;
   }
   bb36 {
-    %63 ? bb37 : bb38;
+    %73 = %72;
+    %74 = println(%73) -> bb37;
   }
   bb37 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb39;
+    %75 = b;
+    %76 = ConstantLoad 3
+    %77 = %75 is nil
+    %77 ? bb38 : bb39;
   }
   bb38 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$18);
-    %2 = (1, $desugar$19);
-    %0 = - %1 %2;
-    (1, $desugar$20) = %0;
-    PopScopeFrame
-    GOTO bb39;
+    %78 = ConstantLoad <nil>
+    GOTO bb40;
   }
   bb39 {
-    v3 = $desugar$20;
-    %67 = v3;
-    %68 = println(%67) -> bb40;
+    %78 = / %75 %76;
+    GOTO bb40;
   }
   bb40 {
-    $desugar$21 = a;
-    $desugar$22 = b;
-    %71 = ConstantLoad <nil>
-    $desugar$23 = %71;
-    %74 = $desugar$21 is nil
-    %73 = %74;
-    %74 ? bb42 : bb41;
+    v5 = %78;
+    %80 = v5;
+    %81 = println(%80) -> bb41;
   }
   bb41 {
-    %75 = $desugar$22 is nil
-    %73 = %75;
-    GOTO bb42;
+    %82 = a is nil
+    %82 ? bb42 : bb43;
   }
   bb42 {
-    %73 ? bb43 : bb44;
+    %83 = ConstantLoad <nil>
+    GOTO bb44;
   }
   bb43 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb45;
+    %83 = unknown a;
+    GOTO bb44;
   }
   bb44 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$21);
-    %2 = (1, $desugar$22);
-    %0 = + %1 %2;
-    (1, $desugar$23) = %0;
-    PopScopeFrame
-    GOTO bb45;
+    v6 = %83;
+    %85 = v6;
+    %86 = println(%85) -> bb45;
   }
   bb45 {
-    $desugar$24 = $desugar$23;
-    $desugar$25 = c;
-    %78 = ConstantLoad <nil>
-    $desugar$26 = %78;
-    %81 = $desugar$24 is nil
-    %80 = %81;
-    %81 ? bb47 : bb46;
+    %87 = c is nil
+    %87 ? bb46 : bb47;
   }
   bb46 {
-    %82 = $desugar$25 is nil
-    %80 = %82;
-    GOTO bb47;
+    %88 = ConstantLoad <nil>
+    GOTO bb48;
   }
   bb47 {
-    %80 ? bb48 : bb49;
+    %88 = unknown c;
+    GOTO bb48;
   }
   bb48 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb50;
+    %89 = %88;
+    %90 = println(%89) -> bb49;
   }
   bb49 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$24);
-    %2 = (1, $desugar$25);
-    %0 = - %1 %2;
-    (1, $desugar$26) = %0;
-    PopScopeFrame
-    GOTO bb50;
+    %91 = ConstantLoad 13
+    d = %91;
+    %93 = a;
+    %94 = %93 is nil
+    %94 ? bb50 : bb51;
   }
   bb50 {
-    v4 = $desugar$26;
-    %84 = v4;
-    %85 = println(%84) -> bb51;
+    %95 = ConstantLoad <nil>
+    GOTO bb52;
   }
   bb51 {
-    $desugar$27 = b;
-    $desugar$28 = c;
-    %88 = ConstantLoad <nil>
-    $desugar$29 = %88;
-    %91 = $desugar$27 is nil
-    %90 = %91;
-    %91 ? bb53 : bb52;
+    %95 = + %93 d;
+    GOTO bb52;
   }
   bb52 {
-    %92 = $desugar$28 is nil
-    %90 = %92;
-    GOTO bb53;
+    v7 = %95;
+    %97 = v7;
+    %98 = println(%97) -> bb53;
   }
   bb53 {
-    %90 ? bb54 : bb55;
+    %99 = a;
+    %100 = %99 is nil
+    %101 = b is nil
+    %102 = || %100 %101;
+    %102 ? bb54 : bb55;
   }
   bb54 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %103 = ConstantLoad <nil>
     GOTO bb56;
   }
   bb55 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$27);
-    %2 = (1, $desugar$28);
-    %0 = / %1 %2;
-    (1, $desugar$29) = %0;
-    PopScopeFrame
+    %103 = + %99 b;
     GOTO bb56;
   }
   bb56 {
-    %93 = $desugar$29;
-    %94 = println(%93) -> bb57;
+    %104 = %103;
+    %105 = %104 is nil
+    %106 = c is nil
+    %107 = || %105 %106;
+    %107 ? bb57 : bb58;
   }
   bb57 {
-    $desugar$30 = b;
-    %96 = ConstantLoad <nil>
-    $desugar$31 = %96;
-    %98 = $desugar$30 is nil
-    %98 ? bb58 : bb59;
+    %108 = ConstantLoad <nil>
+    GOTO bb59;
   }
   bb58 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb60;
+    %108 = + %104 c;
+    GOTO bb59;
   }
   bb59 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$30);
-    %2 = ConstantLoad 3
-    %3 = %2;
-    %0 = / %1 %3;
-    (1, $desugar$31) = %0;
-    PopScopeFrame
-    GOTO bb60;
+    %109 = %108;
+    %110 = %109 is nil
+    %110 ? bb60 : bb61;
   }
   bb60 {
-    v5 = $desugar$31;
-    %100 = v5;
-    %101 = println(%100) -> bb61;
+    %111 = ConstantLoad <nil>
+    GOTO bb62;
   }
   bb61 {
-    $desugar$32 = a;
-    %103 = ConstantLoad <nil>
-    $desugar$33 = %103;
-    %105 = $desugar$32 is nil
-    %105 ? bb62 : bb63;
+    %111 = + %109 d;
+    GOTO bb62;
   }
   bb62 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb64;
+    %112 = %111;
+    %113 = println(%112) -> bb63;
   }
   bb63 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$32);
-    (1, $desugar$33) = %0;
-    PopScopeFrame
-    GOTO bb64;
+    %114 = ConstantLoad <nil>
+    e = %114;
+    %116 = a;
+    %117 = %116 is nil
+    %118 = e is nil
+    %119 = || %117 %118;
+    %119 ? bb64 : bb65;
   }
   bb64 {
-    v6 = $desugar$33;
-    %107 = v6;
-    %108 = println(%107) -> bb65;
+    %120 = ConstantLoad <nil>
+    GOTO bb66;
   }
   bb65 {
-    $desugar$34 = c;
-    %110 = ConstantLoad <nil>
-    $desugar$35 = %110;
-    %112 = $desugar$34 is nil
-    %112 ? bb66 : bb67;
+    %120 = + %116 e;
+    GOTO bb66;
   }
   bb66 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb68;
+    v8 = %120;
+    %122 = v8;
+    %123 = println(%122) -> bb67;
   }
   bb67 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$34);
-    (1, $desugar$35) = %0;
-    PopScopeFrame
-    GOTO bb68;
+    %124 = a;
+    %125 = %124 is nil
+    %126 = b is nil
+    %127 = || %125 %126;
+    %127 ? bb68 : bb69;
   }
   bb68 {
-    %113 = $desugar$35;
-    %114 = println(%113) -> bb69;
+    %128 = ConstantLoad <nil>
+    GOTO bb70;
   }
   bb69 {
-    %115 = ConstantLoad 13
-    d = %115;
-    $desugar$36 = a;
-    %118 = ConstantLoad <nil>
-    $desugar$37 = %118;
-    %120 = $desugar$36 is nil
-    %120 ? bb70 : bb71;
+    %128 = + %124 b;
+    GOTO bb70;
   }
   bb70 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb72;
+    %129 = %128;
+    %130 = %129 is nil
+    %131 = c is nil
+    %132 = || %130 %131;
+    %132 ? bb71 : bb72;
   }
   bb71 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$36);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$37) = %0;
-    PopScopeFrame
-    GOTO bb72;
+    %133 = ConstantLoad <nil>
+    GOTO bb73;
   }
   bb72 {
-    v7 = $desugar$37;
-    %122 = v7;
-    %123 = println(%122) -> bb73;
+    %133 = + %129 c;
+    GOTO bb73;
   }
   bb73 {
-    $desugar$38 = a;
-    $desugar$39 = b;
-    %126 = ConstantLoad <nil>
-    $desugar$40 = %126;
-    %129 = $desugar$38 is nil
-    %128 = %129;
-    %129 ? bb75 : bb74;
+    %134 = %133;
+    %135 = %134 is nil
+    %135 ? bb74 : bb75;
   }
   bb74 {
-    %130 = $desugar$39 is nil
-    %128 = %130;
-    GOTO bb75;
+    %136 = ConstantLoad <nil>
+    GOTO bb76;
   }
   bb75 {
-    %128 ? bb76 : bb77;
+    %136 = + %134 d;
+    GOTO bb76;
   }
   bb76 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb78;
+    %137 = %136;
+    %138 = %137 is nil
+    %139 = e is nil
+    %140 = || %138 %139;
+    %140 ? bb77 : bb78;
   }
   bb77 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$38);
-    %2 = (1, $desugar$39);
-    %0 = + %1 %2;
-    (1, $desugar$40) = %0;
-    PopScopeFrame
-    GOTO bb78;
+    %141 = ConstantLoad <nil>
+    GOTO bb79;
   }
   bb78 {
-    $desugar$41 = $desugar$40;
-    $desugar$42 = c;
-    %133 = ConstantLoad <nil>
-    $desugar$43 = %133;
-    %136 = $desugar$41 is nil
-    %135 = %136;
-    %136 ? bb80 : bb79;
+    %141 = + %137 e;
+    GOTO bb79;
   }
   bb79 {
-    %137 = $desugar$42 is nil
-    %135 = %137;
-    GOTO bb80;
+    %142 = %141;
+    %143 = println(%142) -> bb80;
   }
   bb80 {
-    %135 ? bb81 : bb82;
+    %144 = a is nil
+    %144 ? bb81 : bb82;
   }
   bb81 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %145 = ConstantLoad <nil>
     GOTO bb83;
   }
   bb82 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$41);
-    %2 = (1, $desugar$42);
-    %0 = + %1 %2;
-    (1, $desugar$43) = %0;
-    PopScopeFrame
+    %145 = unknown a;
     GOTO bb83;
   }
   bb83 {
-    $desugar$44 = $desugar$43;
-    %139 = ConstantLoad <nil>
-    $desugar$45 = %139;
-    %141 = $desugar$44 is nil
-    %141 ? bb84 : bb85;
+    %146 = %145;
+    %147 = println(%146) -> bb84;
   }
   bb84 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb86;
-  }
-  bb85 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$44);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$45) = %0;
-    PopScopeFrame
-    GOTO bb86;
-  }
-  bb86 {
-    %142 = $desugar$45;
-    %143 = println(%142) -> bb87;
-  }
-  bb87 {
-    %144 = ConstantLoad <nil>
-    e = %144;
-    $desugar$46 = a;
-    $desugar$47 = e;
-    %148 = ConstantLoad <nil>
-    $desugar$48 = %148;
-    %151 = $desugar$46 is nil
-    %150 = %151;
-    %151 ? bb89 : bb88;
-  }
-  bb88 {
-    %152 = $desugar$47 is nil
-    %150 = %152;
-    GOTO bb89;
-  }
-  bb89 {
-    %150 ? bb90 : bb91;
-  }
-  bb90 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb92;
-  }
-  bb91 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$46);
-    %2 = (1, $desugar$47);
-    %0 = + %1 %2;
-    (1, $desugar$48) = %0;
-    PopScopeFrame
-    GOTO bb92;
-  }
-  bb92 {
-    v8 = $desugar$48;
-    %154 = v8;
-    %155 = println(%154) -> bb93;
-  }
-  bb93 {
-    $desugar$49 = a;
-    $desugar$50 = b;
-    %158 = ConstantLoad <nil>
-    $desugar$51 = %158;
-    %161 = $desugar$49 is nil
-    %160 = %161;
-    %161 ? bb95 : bb94;
-  }
-  bb94 {
-    %162 = $desugar$50 is nil
-    %160 = %162;
-    GOTO bb95;
-  }
-  bb95 {
-    %160 ? bb96 : bb97;
-  }
-  bb96 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb98;
-  }
-  bb97 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$49);
-    %2 = (1, $desugar$50);
-    %0 = + %1 %2;
-    (1, $desugar$51) = %0;
-    PopScopeFrame
-    GOTO bb98;
-  }
-  bb98 {
-    $desugar$52 = $desugar$51;
-    $desugar$53 = c;
-    %165 = ConstantLoad <nil>
-    $desugar$54 = %165;
-    %168 = $desugar$52 is nil
-    %167 = %168;
-    %168 ? bb100 : bb99;
-  }
-  bb99 {
-    %169 = $desugar$53 is nil
-    %167 = %169;
-    GOTO bb100;
-  }
-  bb100 {
-    %167 ? bb101 : bb102;
-  }
-  bb101 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb103;
-  }
-  bb102 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$52);
-    %2 = (1, $desugar$53);
-    %0 = + %1 %2;
-    (1, $desugar$54) = %0;
-    PopScopeFrame
-    GOTO bb103;
-  }
-  bb103 {
-    $desugar$55 = $desugar$54;
-    %171 = ConstantLoad <nil>
-    $desugar$56 = %171;
-    %173 = $desugar$55 is nil
-    %173 ? bb104 : bb105;
-  }
-  bb104 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb106;
-  }
-  bb105 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$55);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$56) = %0;
-    PopScopeFrame
-    GOTO bb106;
-  }
-  bb106 {
-    $desugar$57 = $desugar$56;
-    $desugar$58 = e;
-    %176 = ConstantLoad <nil>
-    $desugar$59 = %176;
-    %179 = $desugar$57 is nil
-    %178 = %179;
-    %179 ? bb108 : bb107;
-  }
-  bb107 {
-    %180 = $desugar$58 is nil
-    %178 = %180;
-    GOTO bb108;
-  }
-  bb108 {
-    %178 ? bb109 : bb110;
-  }
-  bb109 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb111;
-  }
-  bb110 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$57);
-    %2 = (1, $desugar$58);
-    %0 = + %1 %2;
-    (1, $desugar$59) = %0;
-    PopScopeFrame
-    GOTO bb111;
-  }
-  bb111 {
-    %181 = $desugar$59;
-    %182 = println(%181) -> bb112;
-  }
-  bb112 {
-    $desugar$60 = a;
-    %184 = ConstantLoad <nil>
-    $desugar$61 = %184;
-    %186 = $desugar$60 is nil
-    %186 ? bb113 : bb114;
-  }
-  bb113 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb115;
-  }
-  bb114 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$60);
-    (1, $desugar$61) = %0;
-    PopScopeFrame
-    GOTO bb115;
-  }
-  bb115 {
-    %187 = $desugar$61;
-    %188 = println(%187) -> bb116;
-  }
-  bb116 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/2-v.txt
+++ b/corpus/bir/subset8/08-nillifting/2-v.txt
@@ -7,716 +7,407 @@ main() -> nil{
     b = %3;
     %5 = ConstantLoad 1
     c = %5;
-    $desugar$0 = a;
-    $desugar$1 = b;
-    %9 = ConstantLoad <nil>
-    $desugar$2 = %9;
-    %12 = $desugar$0 is nil
-    %11 = %12;
-    %12 ? bb2 : bb1;
+    %7 = a;
+    %8 = %7 is nil
+    %9 = b is nil
+    %10 = || %8 %9;
+    %10 ? bb1 : bb2;
   }
   bb1 {
-    %13 = $desugar$1 is nil
-    %11 = %13;
-    GOTO bb2;
+    %11 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %11 ? bb3 : bb4;
+    %11 = + %7 b;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    v1 = %11;
+    %13 = v1;
+    %14 = println(%13) -> bb4;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = + %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %15 = a;
+    %16 = %15 is nil
+    %17 = b is nil
+    %18 = || %16 %17;
+    %18 ? bb5 : bb6;
   }
   bb5 {
-    v1 = $desugar$2;
-    %15 = v1;
-    %16 = println(%15) -> bb6;
+    %19 = ConstantLoad <nil>
+    GOTO bb7;
   }
   bb6 {
-    $desugar$3 = a;
-    $desugar$4 = b;
-    %19 = ConstantLoad <nil>
-    $desugar$5 = %19;
-    %22 = $desugar$3 is nil
-    %21 = %22;
-    %22 ? bb8 : bb7;
+    %19 = + %15 b;
+    GOTO bb7;
   }
   bb7 {
-    %23 = $desugar$4 is nil
-    %21 = %23;
-    GOTO bb8;
+    %20 = %19;
+    %21 = println(%20) -> bb8;
   }
   bb8 {
-    %21 ? bb9 : bb10;
+    %22 = a;
+    %23 = %22 is nil
+    %24 = b is nil
+    %25 = || %23 %24;
+    %25 ? bb9 : bb10;
   }
   bb9 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %26 = ConstantLoad <nil>
     GOTO bb11;
   }
   bb10 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = + %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
+    %26 = + %22 b;
     GOTO bb11;
   }
   bb11 {
-    %24 = $desugar$5;
-    %25 = println(%24) -> bb12;
+    %27 = %26;
+    %28 = %27 is nil
+    %29 = c is nil
+    %30 = || %28 %29;
+    %30 ? bb12 : bb13;
   }
   bb12 {
-    $desugar$6 = a;
-    $desugar$7 = b;
-    %28 = ConstantLoad <nil>
-    $desugar$8 = %28;
-    %31 = $desugar$6 is nil
-    %30 = %31;
-    %31 ? bb14 : bb13;
+    %31 = ConstantLoad <nil>
+    GOTO bb14;
   }
   bb13 {
-    %32 = $desugar$7 is nil
-    %30 = %32;
+    %31 = + %27 c;
     GOTO bb14;
   }
   bb14 {
-    %30 ? bb15 : bb16;
+    v2 = %31;
+    %33 = v2;
+    %34 = println(%33) -> bb15;
   }
   bb15 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb17;
+    %35 = a;
+    %36 = %35 is nil
+    %37 = b is nil
+    %38 = || %36 %37;
+    %38 ? bb16 : bb17;
   }
   bb16 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = + %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
-    GOTO bb17;
+    %39 = ConstantLoad <nil>
+    GOTO bb18;
   }
   bb17 {
-    $desugar$9 = $desugar$8;
-    $desugar$10 = c;
-    %35 = ConstantLoad <nil>
-    $desugar$11 = %35;
-    %38 = $desugar$9 is nil
-    %37 = %38;
-    %38 ? bb19 : bb18;
+    %39 = + %35 b;
+    GOTO bb18;
   }
   bb18 {
-    %39 = $desugar$10 is nil
-    %37 = %39;
-    GOTO bb19;
+    %40 = %39;
+    %41 = %40 is nil
+    %42 = c is nil
+    %43 = || %41 %42;
+    %43 ? bb19 : bb20;
   }
   bb19 {
-    %37 ? bb20 : bb21;
+    %44 = ConstantLoad <nil>
+    GOTO bb21;
   }
   bb20 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb22;
+    %44 = + %40 c;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = + %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb22;
+    %45 = %44;
+    %46 = println(%45) -> bb22;
   }
   bb22 {
-    v2 = $desugar$11;
-    %41 = v2;
-    %42 = println(%41) -> bb23;
+    %47 = a;
+    %48 = %47 is nil
+    %49 = b is nil
+    %50 = || %48 %49;
+    %50 ? bb23 : bb24;
   }
   bb23 {
-    $desugar$12 = a;
-    $desugar$13 = b;
-    %45 = ConstantLoad <nil>
-    $desugar$14 = %45;
-    %48 = $desugar$12 is nil
-    %47 = %48;
-    %48 ? bb25 : bb24;
+    %51 = ConstantLoad <nil>
+    GOTO bb25;
   }
   bb24 {
-    %49 = $desugar$13 is nil
-    %47 = %49;
+    %51 = - %47 b;
     GOTO bb25;
   }
   bb25 {
-    %47 ? bb26 : bb27;
+    v3 = %51;
+    %53 = v3;
+    %54 = println(%53) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb28;
+    %55 = a;
+    %56 = %55 is nil
+    %57 = b is nil
+    %58 = || %56 %57;
+    %58 ? bb27 : bb28;
   }
   bb27 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$12);
-    %2 = (1, $desugar$13);
-    %0 = + %1 %2;
-    (1, $desugar$14) = %0;
-    PopScopeFrame
-    GOTO bb28;
+    %59 = ConstantLoad <nil>
+    GOTO bb29;
   }
   bb28 {
-    $desugar$15 = $desugar$14;
-    $desugar$16 = c;
-    %52 = ConstantLoad <nil>
-    $desugar$17 = %52;
-    %55 = $desugar$15 is nil
-    %54 = %55;
-    %55 ? bb30 : bb29;
+    %59 = + %55 b;
+    GOTO bb29;
   }
   bb29 {
-    %56 = $desugar$16 is nil
-    %54 = %56;
-    GOTO bb30;
+    %60 = %59;
+    %61 = %60 is nil
+    %62 = c is nil
+    %63 = || %61 %62;
+    %63 ? bb30 : bb31;
   }
   bb30 {
-    %54 ? bb31 : bb32;
+    %64 = ConstantLoad <nil>
+    GOTO bb32;
   }
   bb31 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb33;
+    %64 = - %60 c;
+    GOTO bb32;
   }
   bb32 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$15);
-    %2 = (1, $desugar$16);
-    %0 = + %1 %2;
-    (1, $desugar$17) = %0;
-    PopScopeFrame
-    GOTO bb33;
+    v4 = %64;
+    %66 = v4;
+    %67 = println(%66) -> bb33;
   }
   bb33 {
-    %57 = $desugar$17;
-    %58 = println(%57) -> bb34;
+    %68 = b;
+    %69 = %68 is nil
+    %70 = c is nil
+    %71 = || %69 %70;
+    %71 ? bb34 : bb35;
   }
   bb34 {
-    $desugar$18 = a;
-    $desugar$19 = b;
-    %61 = ConstantLoad <nil>
-    $desugar$20 = %61;
-    %64 = $desugar$18 is nil
-    %63 = %64;
-    %64 ? bb36 : bb35;
+    %72 = ConstantLoad <nil>
+    GOTO bb36;
   }
   bb35 {
-    %65 = $desugar$19 is nil
-    %63 = %65;
+    %72 = / %68 c;
     GOTO bb36;
   }
   bb36 {
-    %63 ? bb37 : bb38;
+    %73 = %72;
+    %74 = println(%73) -> bb37;
   }
   bb37 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb39;
+    %75 = b;
+    %76 = ConstantLoad 3
+    %77 = %75 is nil
+    %77 ? bb38 : bb39;
   }
   bb38 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$18);
-    %2 = (1, $desugar$19);
-    %0 = - %1 %2;
-    (1, $desugar$20) = %0;
-    PopScopeFrame
-    GOTO bb39;
+    %78 = ConstantLoad <nil>
+    GOTO bb40;
   }
   bb39 {
-    v3 = $desugar$20;
-    %67 = v3;
-    %68 = println(%67) -> bb40;
+    %78 = / %75 %76;
+    GOTO bb40;
   }
   bb40 {
-    $desugar$21 = a;
-    $desugar$22 = b;
-    %71 = ConstantLoad <nil>
-    $desugar$23 = %71;
-    %74 = $desugar$21 is nil
-    %73 = %74;
-    %74 ? bb42 : bb41;
+    v5 = %78;
+    %80 = v5;
+    %81 = println(%80) -> bb41;
   }
   bb41 {
-    %75 = $desugar$22 is nil
-    %73 = %75;
-    GOTO bb42;
+    %82 = a is nil
+    %82 ? bb42 : bb43;
   }
   bb42 {
-    %73 ? bb43 : bb44;
+    %83 = ConstantLoad <nil>
+    GOTO bb44;
   }
   bb43 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb45;
+    %83 = unknown a;
+    GOTO bb44;
   }
   bb44 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$21);
-    %2 = (1, $desugar$22);
-    %0 = + %1 %2;
-    (1, $desugar$23) = %0;
-    PopScopeFrame
-    GOTO bb45;
+    v6 = %83;
+    %85 = v6;
+    %86 = println(%85) -> bb45;
   }
   bb45 {
-    $desugar$24 = $desugar$23;
-    $desugar$25 = c;
-    %78 = ConstantLoad <nil>
-    $desugar$26 = %78;
-    %81 = $desugar$24 is nil
-    %80 = %81;
-    %81 ? bb47 : bb46;
+    %87 = c is nil
+    %87 ? bb46 : bb47;
   }
   bb46 {
-    %82 = $desugar$25 is nil
-    %80 = %82;
-    GOTO bb47;
+    %88 = ConstantLoad <nil>
+    GOTO bb48;
   }
   bb47 {
-    %80 ? bb48 : bb49;
+    %88 = unknown c;
+    GOTO bb48;
   }
   bb48 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb50;
+    %89 = %88;
+    %90 = println(%89) -> bb49;
   }
   bb49 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$24);
-    %2 = (1, $desugar$25);
-    %0 = - %1 %2;
-    (1, $desugar$26) = %0;
-    PopScopeFrame
-    GOTO bb50;
+    %91 = ConstantLoad 13
+    d = %91;
+    %93 = a;
+    %94 = %93 is nil
+    %94 ? bb50 : bb51;
   }
   bb50 {
-    v4 = $desugar$26;
-    %84 = v4;
-    %85 = println(%84) -> bb51;
+    %95 = ConstantLoad <nil>
+    GOTO bb52;
   }
   bb51 {
-    $desugar$27 = b;
-    $desugar$28 = c;
-    %88 = ConstantLoad <nil>
-    $desugar$29 = %88;
-    %91 = $desugar$27 is nil
-    %90 = %91;
-    %91 ? bb53 : bb52;
+    %95 = + %93 d;
+    GOTO bb52;
   }
   bb52 {
-    %92 = $desugar$28 is nil
-    %90 = %92;
-    GOTO bb53;
+    v7 = %95;
+    %97 = v7;
+    %98 = println(%97) -> bb53;
   }
   bb53 {
-    %90 ? bb54 : bb55;
+    %99 = a;
+    %100 = %99 is nil
+    %101 = b is nil
+    %102 = || %100 %101;
+    %102 ? bb54 : bb55;
   }
   bb54 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %103 = ConstantLoad <nil>
     GOTO bb56;
   }
   bb55 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$27);
-    %2 = (1, $desugar$28);
-    %0 = / %1 %2;
-    (1, $desugar$29) = %0;
-    PopScopeFrame
+    %103 = + %99 b;
     GOTO bb56;
   }
   bb56 {
-    %93 = $desugar$29;
-    %94 = println(%93) -> bb57;
+    %104 = %103;
+    %105 = %104 is nil
+    %106 = c is nil
+    %107 = || %105 %106;
+    %107 ? bb57 : bb58;
   }
   bb57 {
-    $desugar$30 = b;
-    %96 = ConstantLoad <nil>
-    $desugar$31 = %96;
-    %98 = $desugar$30 is nil
-    %98 ? bb58 : bb59;
+    %108 = ConstantLoad <nil>
+    GOTO bb59;
   }
   bb58 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb60;
+    %108 = + %104 c;
+    GOTO bb59;
   }
   bb59 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$30);
-    %2 = ConstantLoad 3
-    %3 = %2;
-    %0 = / %1 %3;
-    (1, $desugar$31) = %0;
-    PopScopeFrame
-    GOTO bb60;
+    %109 = %108;
+    %110 = %109 is nil
+    %110 ? bb60 : bb61;
   }
   bb60 {
-    v5 = $desugar$31;
-    %100 = v5;
-    %101 = println(%100) -> bb61;
+    %111 = ConstantLoad <nil>
+    GOTO bb62;
   }
   bb61 {
-    $desugar$32 = a;
-    %103 = ConstantLoad <nil>
-    $desugar$33 = %103;
-    %105 = $desugar$32 is nil
-    %105 ? bb62 : bb63;
+    %111 = + %109 d;
+    GOTO bb62;
   }
   bb62 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb64;
+    %112 = %111;
+    %113 = println(%112) -> bb63;
   }
   bb63 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$32);
-    (1, $desugar$33) = %0;
-    PopScopeFrame
-    GOTO bb64;
+    %114 = ConstantLoad <nil>
+    e = %114;
+    %116 = a;
+    %117 = %116 is nil
+    %118 = e is nil
+    %119 = || %117 %118;
+    %119 ? bb64 : bb65;
   }
   bb64 {
-    v6 = $desugar$33;
-    %107 = v6;
-    %108 = println(%107) -> bb65;
+    %120 = ConstantLoad <nil>
+    GOTO bb66;
   }
   bb65 {
-    $desugar$34 = c;
-    %110 = ConstantLoad <nil>
-    $desugar$35 = %110;
-    %112 = $desugar$34 is nil
-    %112 ? bb66 : bb67;
+    %120 = + %116 e;
+    GOTO bb66;
   }
   bb66 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb68;
+    v8 = %120;
+    %122 = v8;
+    %123 = println(%122) -> bb67;
   }
   bb67 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$34);
-    (1, $desugar$35) = %0;
-    PopScopeFrame
-    GOTO bb68;
+    %124 = a;
+    %125 = %124 is nil
+    %126 = b is nil
+    %127 = || %125 %126;
+    %127 ? bb68 : bb69;
   }
   bb68 {
-    %113 = $desugar$35;
-    %114 = println(%113) -> bb69;
+    %128 = ConstantLoad <nil>
+    GOTO bb70;
   }
   bb69 {
-    %115 = ConstantLoad 13
-    d = %115;
-    $desugar$36 = a;
-    %118 = ConstantLoad <nil>
-    $desugar$37 = %118;
-    %120 = $desugar$36 is nil
-    %120 ? bb70 : bb71;
+    %128 = + %124 b;
+    GOTO bb70;
   }
   bb70 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb72;
+    %129 = %128;
+    %130 = %129 is nil
+    %131 = c is nil
+    %132 = || %130 %131;
+    %132 ? bb71 : bb72;
   }
   bb71 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$36);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$37) = %0;
-    PopScopeFrame
-    GOTO bb72;
+    %133 = ConstantLoad <nil>
+    GOTO bb73;
   }
   bb72 {
-    v7 = $desugar$37;
-    %122 = v7;
-    %123 = println(%122) -> bb73;
+    %133 = + %129 c;
+    GOTO bb73;
   }
   bb73 {
-    $desugar$38 = a;
-    $desugar$39 = b;
-    %126 = ConstantLoad <nil>
-    $desugar$40 = %126;
-    %129 = $desugar$38 is nil
-    %128 = %129;
-    %129 ? bb75 : bb74;
+    %134 = %133;
+    %135 = %134 is nil
+    %135 ? bb74 : bb75;
   }
   bb74 {
-    %130 = $desugar$39 is nil
-    %128 = %130;
-    GOTO bb75;
+    %136 = ConstantLoad <nil>
+    GOTO bb76;
   }
   bb75 {
-    %128 ? bb76 : bb77;
+    %136 = + %134 d;
+    GOTO bb76;
   }
   bb76 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb78;
+    %137 = %136;
+    %138 = %137 is nil
+    %139 = e is nil
+    %140 = || %138 %139;
+    %140 ? bb77 : bb78;
   }
   bb77 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$38);
-    %2 = (1, $desugar$39);
-    %0 = + %1 %2;
-    (1, $desugar$40) = %0;
-    PopScopeFrame
-    GOTO bb78;
+    %141 = ConstantLoad <nil>
+    GOTO bb79;
   }
   bb78 {
-    $desugar$41 = $desugar$40;
-    $desugar$42 = c;
-    %133 = ConstantLoad <nil>
-    $desugar$43 = %133;
-    %136 = $desugar$41 is nil
-    %135 = %136;
-    %136 ? bb80 : bb79;
+    %141 = + %137 e;
+    GOTO bb79;
   }
   bb79 {
-    %137 = $desugar$42 is nil
-    %135 = %137;
-    GOTO bb80;
+    %142 = %141;
+    %143 = println(%142) -> bb80;
   }
   bb80 {
-    %135 ? bb81 : bb82;
+    %144 = a is nil
+    %144 ? bb81 : bb82;
   }
   bb81 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %145 = ConstantLoad <nil>
     GOTO bb83;
   }
   bb82 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$41);
-    %2 = (1, $desugar$42);
-    %0 = + %1 %2;
-    (1, $desugar$43) = %0;
-    PopScopeFrame
+    %145 = unknown a;
     GOTO bb83;
   }
   bb83 {
-    $desugar$44 = $desugar$43;
-    %139 = ConstantLoad <nil>
-    $desugar$45 = %139;
-    %141 = $desugar$44 is nil
-    %141 ? bb84 : bb85;
+    %146 = %145;
+    %147 = println(%146) -> bb84;
   }
   bb84 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb86;
-  }
-  bb85 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$44);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$45) = %0;
-    PopScopeFrame
-    GOTO bb86;
-  }
-  bb86 {
-    %142 = $desugar$45;
-    %143 = println(%142) -> bb87;
-  }
-  bb87 {
-    %144 = ConstantLoad <nil>
-    e = %144;
-    $desugar$46 = a;
-    $desugar$47 = e;
-    %148 = ConstantLoad <nil>
-    $desugar$48 = %148;
-    %151 = $desugar$46 is nil
-    %150 = %151;
-    %151 ? bb89 : bb88;
-  }
-  bb88 {
-    %152 = $desugar$47 is nil
-    %150 = %152;
-    GOTO bb89;
-  }
-  bb89 {
-    %150 ? bb90 : bb91;
-  }
-  bb90 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb92;
-  }
-  bb91 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$46);
-    %2 = (1, $desugar$47);
-    %0 = + %1 %2;
-    (1, $desugar$48) = %0;
-    PopScopeFrame
-    GOTO bb92;
-  }
-  bb92 {
-    v8 = $desugar$48;
-    %154 = v8;
-    %155 = println(%154) -> bb93;
-  }
-  bb93 {
-    $desugar$49 = a;
-    $desugar$50 = b;
-    %158 = ConstantLoad <nil>
-    $desugar$51 = %158;
-    %161 = $desugar$49 is nil
-    %160 = %161;
-    %161 ? bb95 : bb94;
-  }
-  bb94 {
-    %162 = $desugar$50 is nil
-    %160 = %162;
-    GOTO bb95;
-  }
-  bb95 {
-    %160 ? bb96 : bb97;
-  }
-  bb96 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb98;
-  }
-  bb97 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$49);
-    %2 = (1, $desugar$50);
-    %0 = + %1 %2;
-    (1, $desugar$51) = %0;
-    PopScopeFrame
-    GOTO bb98;
-  }
-  bb98 {
-    $desugar$52 = $desugar$51;
-    $desugar$53 = c;
-    %165 = ConstantLoad <nil>
-    $desugar$54 = %165;
-    %168 = $desugar$52 is nil
-    %167 = %168;
-    %168 ? bb100 : bb99;
-  }
-  bb99 {
-    %169 = $desugar$53 is nil
-    %167 = %169;
-    GOTO bb100;
-  }
-  bb100 {
-    %167 ? bb101 : bb102;
-  }
-  bb101 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb103;
-  }
-  bb102 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$52);
-    %2 = (1, $desugar$53);
-    %0 = + %1 %2;
-    (1, $desugar$54) = %0;
-    PopScopeFrame
-    GOTO bb103;
-  }
-  bb103 {
-    $desugar$55 = $desugar$54;
-    %171 = ConstantLoad <nil>
-    $desugar$56 = %171;
-    %173 = $desugar$55 is nil
-    %173 ? bb104 : bb105;
-  }
-  bb104 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb106;
-  }
-  bb105 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$55);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$56) = %0;
-    PopScopeFrame
-    GOTO bb106;
-  }
-  bb106 {
-    $desugar$57 = $desugar$56;
-    $desugar$58 = e;
-    %176 = ConstantLoad <nil>
-    $desugar$59 = %176;
-    %179 = $desugar$57 is nil
-    %178 = %179;
-    %179 ? bb108 : bb107;
-  }
-  bb107 {
-    %180 = $desugar$58 is nil
-    %178 = %180;
-    GOTO bb108;
-  }
-  bb108 {
-    %178 ? bb109 : bb110;
-  }
-  bb109 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb111;
-  }
-  bb110 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$57);
-    %2 = (1, $desugar$58);
-    %0 = + %1 %2;
-    (1, $desugar$59) = %0;
-    PopScopeFrame
-    GOTO bb111;
-  }
-  bb111 {
-    %181 = $desugar$59;
-    %182 = println(%181) -> bb112;
-  }
-  bb112 {
-    $desugar$60 = a;
-    %184 = ConstantLoad <nil>
-    $desugar$61 = %184;
-    %186 = $desugar$60 is nil
-    %186 ? bb113 : bb114;
-  }
-  bb113 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb115;
-  }
-  bb114 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$60);
-    (1, $desugar$61) = %0;
-    PopScopeFrame
-    GOTO bb115;
-  }
-  bb115 {
-    %187 = $desugar$61;
-    %188 = println(%187) -> bb116;
-  }
-  bb116 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/3-v.txt
+++ b/corpus/bir/subset8/08-nillifting/3-v.txt
@@ -7,279 +7,151 @@ main() -> nil{
     b = %3;
     %5 = ConstantLoad 1
     c = %5;
-    $desugar$0 = a;
-    $desugar$1 = b;
-    %9 = ConstantLoad <nil>
-    $desugar$2 = %9;
-    %12 = $desugar$0 is nil
-    %11 = %12;
-    %12 ? bb2 : bb1;
+    %7 = a;
+    %8 = %7 is nil
+    %9 = b is nil
+    %10 = || %8 %9;
+    %10 ? bb1 : bb2;
   }
   bb1 {
-    %13 = $desugar$1 is nil
-    %11 = %13;
-    GOTO bb2;
+    %11 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %11 ? bb3 : bb4;
+    %11 = unknown %7 b;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    v1 = %11;
+    %13 = v1;
+    %14 = println(%13) -> bb4;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = unknown %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %15 = a;
+    %16 = %15 is nil
+    %17 = b is nil
+    %18 = || %16 %17;
+    %18 ? bb5 : bb6;
   }
   bb5 {
-    v1 = $desugar$2;
-    %15 = v1;
-    %16 = println(%15) -> bb6;
+    %19 = ConstantLoad <nil>
+    GOTO bb7;
   }
   bb6 {
-    $desugar$3 = a;
-    $desugar$4 = b;
-    %19 = ConstantLoad <nil>
-    $desugar$5 = %19;
-    %22 = $desugar$3 is nil
-    %21 = %22;
-    %22 ? bb8 : bb7;
+    %19 = unknown %15 b;
+    GOTO bb7;
   }
   bb7 {
-    %23 = $desugar$4 is nil
-    %21 = %23;
-    GOTO bb8;
+    %20 = %19;
+    %21 = %20 is nil
+    %22 = c is nil
+    %23 = || %21 %22;
+    %23 ? bb8 : bb9;
   }
   bb8 {
-    %21 ? bb9 : bb10;
+    %24 = ConstantLoad <nil>
+    GOTO bb10;
   }
   bb9 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb11;
+    %24 = unknown %20 c;
+    GOTO bb10;
   }
   bb10 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = unknown %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
-    GOTO bb11;
+    %25 = %24;
+    %26 = println(%25) -> bb11;
   }
   bb11 {
-    $desugar$6 = $desugar$5;
-    $desugar$7 = c;
-    %26 = ConstantLoad <nil>
-    $desugar$8 = %26;
-    %29 = $desugar$6 is nil
-    %28 = %29;
-    %29 ? bb13 : bb12;
+    %27 = ConstantLoad <nil>
+    d = %27;
+    %29 = a;
+    %30 = %29 is nil
+    %31 = d is nil
+    %32 = || %30 %31;
+    %32 ? bb12 : bb13;
   }
   bb12 {
-    %30 = $desugar$7 is nil
-    %28 = %30;
-    GOTO bb13;
+    %33 = ConstantLoad <nil>
+    GOTO bb14;
   }
   bb13 {
-    %28 ? bb14 : bb15;
+    %33 = unknown %29 d;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb16;
+    v2 = %33;
+    %35 = v2;
+    %36 = println(%35) -> bb15;
   }
   bb15 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = unknown %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
-    GOTO bb16;
+    %37 = a;
+    %38 = %37 is nil
+    %39 = b is nil
+    %40 = || %38 %39;
+    %40 ? bb16 : bb17;
   }
   bb16 {
-    %31 = $desugar$8;
-    %32 = println(%31) -> bb17;
+    %41 = ConstantLoad <nil>
+    GOTO bb18;
   }
   bb17 {
-    %33 = ConstantLoad <nil>
-    d = %33;
-    $desugar$9 = a;
-    $desugar$10 = d;
-    %37 = ConstantLoad <nil>
-    $desugar$11 = %37;
-    %40 = $desugar$9 is nil
-    %39 = %40;
-    %40 ? bb19 : bb18;
+    %41 = unknown %37 b;
+    GOTO bb18;
   }
   bb18 {
-    %41 = $desugar$10 is nil
-    %39 = %41;
-    GOTO bb19;
+    %42 = %41;
+    %43 = %42 is nil
+    %44 = c is nil
+    %45 = || %43 %44;
+    %45 ? bb19 : bb20;
   }
   bb19 {
-    %39 ? bb20 : bb21;
+    %46 = ConstantLoad <nil>
+    GOTO bb21;
   }
   bb20 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb22;
+    %46 = unknown %42 c;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = unknown %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb22;
+    %47 = %46;
+    %48 = %47 is nil
+    %49 = d is nil
+    %50 = || %48 %49;
+    %50 ? bb22 : bb23;
   }
   bb22 {
-    v2 = $desugar$11;
-    %43 = v2;
-    %44 = println(%43) -> bb23;
+    %51 = ConstantLoad <nil>
+    GOTO bb24;
   }
   bb23 {
-    $desugar$12 = a;
-    $desugar$13 = b;
-    %47 = ConstantLoad <nil>
-    $desugar$14 = %47;
-    %50 = $desugar$12 is nil
-    %49 = %50;
-    %50 ? bb25 : bb24;
+    %51 = unknown %47 d;
+    GOTO bb24;
   }
   bb24 {
-    %51 = $desugar$13 is nil
-    %49 = %51;
-    GOTO bb25;
+    %52 = %51;
+    %53 = println(%52) -> bb25;
   }
   bb25 {
-    %49 ? bb26 : bb27;
+    %54 = c;
+    %55 = %54 is nil
+    %56 = b is nil
+    %57 = || %55 %56;
+    %57 ? bb26 : bb27;
   }
   bb26 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %58 = ConstantLoad <nil>
     GOTO bb28;
   }
   bb27 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$12);
-    %2 = (1, $desugar$13);
-    %0 = unknown %1 %2;
-    (1, $desugar$14) = %0;
-    PopScopeFrame
+    %58 = unknown %54 b;
     GOTO bb28;
   }
   bb28 {
-    $desugar$15 = $desugar$14;
-    $desugar$16 = c;
-    %54 = ConstantLoad <nil>
-    $desugar$17 = %54;
-    %57 = $desugar$15 is nil
-    %56 = %57;
-    %57 ? bb30 : bb29;
+    v3 = %58;
+    %60 = v3;
+    %61 = println(%60) -> bb29;
   }
   bb29 {
-    %58 = $desugar$16 is nil
-    %56 = %58;
-    GOTO bb30;
-  }
-  bb30 {
-    %56 ? bb31 : bb32;
-  }
-  bb31 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb33;
-  }
-  bb32 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$15);
-    %2 = (1, $desugar$16);
-    %0 = unknown %1 %2;
-    (1, $desugar$17) = %0;
-    PopScopeFrame
-    GOTO bb33;
-  }
-  bb33 {
-    $desugar$18 = $desugar$17;
-    $desugar$19 = d;
-    %61 = ConstantLoad <nil>
-    $desugar$20 = %61;
-    %64 = $desugar$18 is nil
-    %63 = %64;
-    %64 ? bb35 : bb34;
-  }
-  bb34 {
-    %65 = $desugar$19 is nil
-    %63 = %65;
-    GOTO bb35;
-  }
-  bb35 {
-    %63 ? bb36 : bb37;
-  }
-  bb36 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb38;
-  }
-  bb37 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$18);
-    %2 = (1, $desugar$19);
-    %0 = unknown %1 %2;
-    (1, $desugar$20) = %0;
-    PopScopeFrame
-    GOTO bb38;
-  }
-  bb38 {
-    %66 = $desugar$20;
-    %67 = println(%66) -> bb39;
-  }
-  bb39 {
-    $desugar$21 = c;
-    $desugar$22 = b;
-    %70 = ConstantLoad <nil>
-    $desugar$23 = %70;
-    %73 = $desugar$21 is nil
-    %72 = %73;
-    %73 ? bb41 : bb40;
-  }
-  bb40 {
-    %74 = $desugar$22 is nil
-    %72 = %74;
-    GOTO bb41;
-  }
-  bb41 {
-    %72 ? bb42 : bb43;
-  }
-  bb42 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb44;
-  }
-  bb43 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$21);
-    %2 = (1, $desugar$22);
-    %0 = unknown %1 %2;
-    (1, $desugar$23) = %0;
-    PopScopeFrame
-    GOTO bb44;
-  }
-  bb44 {
-    v3 = $desugar$23;
-    %76 = v3;
-    %77 = println(%76) -> bb45;
-  }
-  bb45 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/4-v.txt
+++ b/corpus/bir/subset8/08-nillifting/4-v.txt
@@ -5,140 +5,84 @@ main() -> nil{
     a = %1;
     %3 = ConstantLoad <nil>
     b = %3;
-    $desugar$0 = a;
-    $desugar$1 = b;
-    %7 = ConstantLoad <nil>
-    $desugar$2 = %7;
-    %10 = $desugar$0 is nil
-    %9 = %10;
-    %10 ? bb2 : bb1;
+    %5 = a;
+    %6 = %5 is nil
+    %7 = b is nil
+    %8 = || %6 %7;
+    %8 ? bb1 : bb2;
   }
   bb1 {
-    %11 = $desugar$1 is nil
-    %9 = %11;
-    GOTO bb2;
+    %9 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %9 ? bb3 : bb4;
+    %9 = + %5 b;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    %10 = %9;
+    %11 = c() -> bb4;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = + %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %12 = %10 is nil
+    %13 = %11 is nil
+    %14 = || %12 %13;
+    %14 ? bb5 : bb6;
   }
   bb5 {
-    $desugar$3 = $desugar$2;
-    %13 = c() -> bb6;
+    %15 = ConstantLoad <nil>
+    GOTO bb7;
   }
   bb6 {
-    $desugar$4 = %13;
-    %15 = ConstantLoad <nil>
-    $desugar$5 = %15;
-    %18 = $desugar$3 is nil
-    %17 = %18;
-    %18 ? bb8 : bb7;
+    %15 = + %10 %11;
+    GOTO bb7;
   }
   bb7 {
-    %19 = $desugar$4 is nil
-    %17 = %19;
-    GOTO bb8;
+    d = %15;
+    %17 = d;
+    %18 = println(%17) -> bb8;
   }
   bb8 {
-    %17 ? bb9 : bb10;
+    %19 = ConstantLoad 5.5
+    e = %19;
+    %21 = ConstantLoad <nil>
+    f = %21;
+    %23 = e;
+    %24 = f is nil
+    %24 ? bb9 : bb10;
   }
   bb9 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %25 = ConstantLoad <nil>
     GOTO bb11;
   }
   bb10 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = + %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
+    %25 = + %23 f;
     GOTO bb11;
   }
   bb11 {
-    d = $desugar$5;
-    %21 = d;
-    %22 = println(%21) -> bb12;
+    %26 = %25;
+    %27 = g() -> bb12;
   }
   bb12 {
-    %23 = ConstantLoad 5.5
-    e = %23;
-    %25 = ConstantLoad <nil>
-    f = %25;
-    $desugar$6 = f;
-    %28 = ConstantLoad <nil>
-    $desugar$7 = %28;
-    %30 = $desugar$6 is nil
+    %28 = %26 is nil
+    %29 = %27 is nil
+    %30 = || %28 %29;
     %30 ? bb13 : bb14;
   }
   bb13 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %31 = ConstantLoad <nil>
     GOTO bb15;
   }
   bb14 {
-    PushScopeFrame 3
-    %1 = (1, e);
-    %2 = (1, $desugar$6);
-    %0 = + %1 %2;
-    (1, $desugar$7) = %0;
-    PopScopeFrame
+    %31 = + %26 %27;
     GOTO bb15;
   }
   bb15 {
-    $desugar$8 = $desugar$7;
-    %32 = g() -> bb16;
+    h = %31;
+    %33 = h;
+    %34 = println(%33) -> bb16;
   }
   bb16 {
-    $desugar$9 = %32;
-    %34 = ConstantLoad <nil>
-    $desugar$10 = %34;
-    %37 = $desugar$8 is nil
-    %36 = %37;
-    %37 ? bb18 : bb17;
-  }
-  bb17 {
-    %38 = $desugar$9 is nil
-    %36 = %38;
-    GOTO bb18;
-  }
-  bb18 {
-    %36 ? bb19 : bb20;
-  }
-  bb19 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb21;
-  }
-  bb20 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$8);
-    %2 = (1, $desugar$9);
-    %0 = + %1 %2;
-    (1, $desugar$10) = %0;
-    PopScopeFrame
-    GOTO bb21;
-  }
-  bb21 {
-    h = $desugar$10;
-    %40 = h;
-    %41 = println(%40) -> bb22;
-  }
-  bb22 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/5-v.txt
+++ b/corpus/bir/subset8/08-nillifting/5-v.txt
@@ -5,73 +5,45 @@ main() -> nil{
     a = %1;
     %3 = ConstantLoad b
     b = %3;
-    $desugar$0 = a;
-    $desugar$1 = b;
-    %7 = ConstantLoad <nil>
-    $desugar$2 = %7;
-    %10 = $desugar$0 is nil
-    %9 = %10;
-    %10 ? bb2 : bb1;
+    %5 = a;
+    %6 = %5 is nil
+    %7 = b is nil
+    %8 = || %6 %7;
+    %8 ? bb1 : bb2;
   }
   bb1 {
-    %11 = $desugar$1 is nil
-    %9 = %11;
-    GOTO bb2;
+    %9 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %9 ? bb3 : bb4;
+    %9 = + %5 b;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    c = %9;
+    %11 = println(c) -> bb4;
   }
   bb4 {
-    PushScopeFrame 1
-    %0 = + (1, $desugar$0) (1, $desugar$1);
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %12 = ConstantLoad <nil>
+    d = %12;
+    %14 = c;
+    %15 = %14 is nil
+    %16 = d is nil
+    %17 = || %15 %16;
+    %17 ? bb5 : bb6;
   }
   bb5 {
-    c = $desugar$2;
-    %13 = println(c) -> bb6;
+    %18 = ConstantLoad <nil>
+    GOTO bb7;
   }
   bb6 {
-    %14 = ConstantLoad <nil>
-    d = %14;
-    $desugar$3 = c;
-    $desugar$4 = d;
-    %18 = ConstantLoad <nil>
-    $desugar$5 = %18;
-    %21 = $desugar$3 is nil
-    %20 = %21;
-    %21 ? bb8 : bb7;
+    %18 = + %14 d;
+    GOTO bb7;
   }
   bb7 {
-    %22 = $desugar$4 is nil
-    %20 = %22;
-    GOTO bb8;
+    %19 = println(%18) -> bb8;
   }
   bb8 {
-    %20 ? bb9 : bb10;
-  }
-  bb9 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb11;
-  }
-  bb10 {
-    PushScopeFrame 1
-    %0 = + (1, $desugar$3) (1, $desugar$4);
-    (1, $desugar$5) = %0;
-    PopScopeFrame
-    GOTO bb11;
-  }
-  bb11 {
-    %23 = println($desugar$5) -> bb12;
-  }
-  bb12 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/8-v.txt
+++ b/corpus/bir/subset8/08-nillifting/8-v.txt
@@ -14,657 +14,396 @@ main() -> nil{
     m[%8] = %7;
     %10 = ConstantLoad a
     %9 = m[%10];
-    $desugar$0 = %9;
+    %11 = %9;
     %13 = ConstantLoad b
     %12 = m[%13];
-    $desugar$1 = %12;
-    %15 = ConstantLoad <nil>
-    $desugar$2 = %15;
-    %18 = $desugar$0 is nil
-    %17 = %18;
-    %18 ? bb2 : bb1;
+    %14 = %11 is nil
+    %15 = %12 is nil
+    %16 = || %14 %15;
+    %16 ? bb1 : bb2;
   }
   bb1 {
-    %19 = $desugar$1 is nil
-    %17 = %19;
-    GOTO bb2;
+    %17 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %17 ? bb3 : bb4;
+    %17 = + %11 %12;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    %18 = %17;
+    %19 = println(%18) -> bb4;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = + %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %21 = ConstantLoad a
+    %20 = m[%21];
+    %22 = %20;
+    %24 = ConstantLoad b
+    %23 = m[%24];
+    %25 = %22 is nil
+    %26 = %23 is nil
+    %27 = || %25 %26;
+    %27 ? bb5 : bb6;
   }
   bb5 {
-    %20 = $desugar$2;
-    %21 = println(%20) -> bb6;
+    %28 = ConstantLoad <nil>
+    GOTO bb7;
   }
   bb6 {
-    %23 = ConstantLoad a
-    %22 = m[%23];
-    $desugar$3 = %22;
-    %26 = ConstantLoad b
-    %25 = m[%26];
-    $desugar$4 = %25;
-    %28 = ConstantLoad <nil>
-    $desugar$5 = %28;
-    %31 = $desugar$3 is nil
-    %30 = %31;
-    %31 ? bb8 : bb7;
+    %28 = + %22 %23;
+    GOTO bb7;
   }
   bb7 {
-    %32 = $desugar$4 is nil
-    %30 = %32;
-    GOTO bb8;
+    %29 = %28;
+    %31 = ConstantLoad c
+    %30 = m[%31];
+    %32 = %29 is nil
+    %33 = %30 is nil
+    %34 = || %32 %33;
+    %34 ? bb8 : bb9;
   }
   bb8 {
-    %30 ? bb9 : bb10;
+    %35 = ConstantLoad <nil>
+    GOTO bb10;
   }
   bb9 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb11;
+    %35 = + %29 %30;
+    GOTO bb10;
   }
   bb10 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = + %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
-    GOTO bb11;
+    %36 = %35;
+    %37 = println(%36) -> bb11;
   }
   bb11 {
-    $desugar$6 = $desugar$5;
-    %35 = ConstantLoad c
-    %34 = m[%35];
-    $desugar$7 = %34;
-    %37 = ConstantLoad <nil>
-    $desugar$8 = %37;
-    %40 = $desugar$6 is nil
-    %39 = %40;
-    %40 ? bb13 : bb12;
+    %39 = ConstantLoad a
+    %38 = m[%39];
+    %40 = %38;
+    %42 = ConstantLoad b
+    %41 = m[%42];
+    %43 = %40 is nil
+    %44 = %41 is nil
+    %45 = || %43 %44;
+    %45 ? bb12 : bb13;
   }
   bb12 {
-    %41 = $desugar$7 is nil
-    %39 = %41;
-    GOTO bb13;
+    %46 = ConstantLoad <nil>
+    GOTO bb14;
   }
   bb13 {
-    %39 ? bb14 : bb15;
+    %46 = - %40 %41;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb16;
+    %47 = %46;
+    %48 = println(%47) -> bb15;
   }
   bb15 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = + %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
-    GOTO bb16;
+    %50 = ConstantLoad a
+    %49 = m[%50];
+    %51 = %49;
+    %53 = ConstantLoad b
+    %52 = m[%53];
+    %54 = %51 is nil
+    %55 = %52 is nil
+    %56 = || %54 %55;
+    %56 ? bb16 : bb17;
   }
   bb16 {
-    %42 = $desugar$8;
-    %43 = println(%42) -> bb17;
+    %57 = ConstantLoad <nil>
+    GOTO bb18;
   }
   bb17 {
-    %45 = ConstantLoad a
-    %44 = m[%45];
-    $desugar$9 = %44;
-    %48 = ConstantLoad b
-    %47 = m[%48];
-    $desugar$10 = %47;
-    %50 = ConstantLoad <nil>
-    $desugar$11 = %50;
-    %53 = $desugar$9 is nil
-    %52 = %53;
-    %53 ? bb19 : bb18;
+    %57 = + %51 %52;
+    GOTO bb18;
   }
   bb18 {
-    %54 = $desugar$10 is nil
-    %52 = %54;
-    GOTO bb19;
+    %58 = %57;
+    %60 = ConstantLoad c
+    %59 = m[%60];
+    %61 = %58 is nil
+    %62 = %59 is nil
+    %63 = || %61 %62;
+    %63 ? bb19 : bb20;
   }
   bb19 {
-    %52 ? bb20 : bb21;
+    %64 = ConstantLoad <nil>
+    GOTO bb21;
   }
   bb20 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb22;
+    %64 = - %58 %59;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = - %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb22;
+    %65 = %64;
+    %66 = println(%65) -> bb22;
   }
   bb22 {
-    %55 = $desugar$11;
-    %56 = println(%55) -> bb23;
+    %68 = ConstantLoad b
+    %67 = m[%68];
+    %69 = %67;
+    %71 = ConstantLoad c
+    %70 = m[%71];
+    %72 = %69 is nil
+    %73 = %70 is nil
+    %74 = || %72 %73;
+    %74 ? bb23 : bb24;
   }
   bb23 {
-    %58 = ConstantLoad a
-    %57 = m[%58];
-    $desugar$12 = %57;
-    %61 = ConstantLoad b
-    %60 = m[%61];
-    $desugar$13 = %60;
-    %63 = ConstantLoad <nil>
-    $desugar$14 = %63;
-    %66 = $desugar$12 is nil
-    %65 = %66;
-    %66 ? bb25 : bb24;
+    %75 = ConstantLoad <nil>
+    GOTO bb25;
   }
   bb24 {
-    %67 = $desugar$13 is nil
-    %65 = %67;
+    %75 = / %69 %70;
     GOTO bb25;
   }
   bb25 {
-    %65 ? bb26 : bb27;
+    %76 = %75;
+    %77 = println(%76) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb28;
+    %79 = ConstantLoad b
+    %78 = m[%79];
+    %80 = %78;
+    %81 = ConstantLoad 3
+    %82 = %80 is nil
+    %82 ? bb27 : bb28;
   }
   bb27 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$12);
-    %2 = (1, $desugar$13);
-    %0 = + %1 %2;
-    (1, $desugar$14) = %0;
-    PopScopeFrame
-    GOTO bb28;
+    %83 = ConstantLoad <nil>
+    GOTO bb29;
   }
   bb28 {
-    $desugar$15 = $desugar$14;
-    %70 = ConstantLoad c
-    %69 = m[%70];
-    $desugar$16 = %69;
-    %72 = ConstantLoad <nil>
-    $desugar$17 = %72;
-    %75 = $desugar$15 is nil
-    %74 = %75;
-    %75 ? bb30 : bb29;
+    %83 = / %80 %81;
+    GOTO bb29;
   }
   bb29 {
-    %76 = $desugar$16 is nil
-    %74 = %76;
-    GOTO bb30;
+    v5 = %83;
+    %85 = v5;
+    %86 = println(%85) -> bb30;
   }
   bb30 {
-    %74 ? bb31 : bb32;
+    %88 = ConstantLoad a
+    %87 = m[%88];
+    %89 = %87 is nil
+    %89 ? bb31 : bb32;
   }
   bb31 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %90 = ConstantLoad <nil>
     GOTO bb33;
   }
   bb32 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$15);
-    %2 = (1, $desugar$16);
-    %0 = - %1 %2;
-    (1, $desugar$17) = %0;
-    PopScopeFrame
+    %90 = unknown %87;
     GOTO bb33;
   }
   bb33 {
-    %77 = $desugar$17;
-    %78 = println(%77) -> bb34;
+    v6 = %90;
+    %92 = v6;
+    %93 = println(%92) -> bb34;
   }
   bb34 {
-    %80 = ConstantLoad b
-    %79 = m[%80];
-    $desugar$18 = %79;
-    %83 = ConstantLoad c
-    %82 = m[%83];
-    $desugar$19 = %82;
-    %85 = ConstantLoad <nil>
-    $desugar$20 = %85;
-    %88 = $desugar$18 is nil
-    %87 = %88;
-    %88 ? bb36 : bb35;
+    %95 = ConstantLoad c
+    %94 = m[%95];
+    %96 = %94 is nil
+    %96 ? bb35 : bb36;
   }
   bb35 {
-    %89 = $desugar$19 is nil
-    %87 = %89;
-    GOTO bb36;
+    %97 = ConstantLoad <nil>
+    GOTO bb37;
   }
   bb36 {
-    %87 ? bb37 : bb38;
+    %97 = unknown %94;
+    GOTO bb37;
   }
   bb37 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb39;
+    %98 = %97;
+    %99 = println(%98) -> bb38;
   }
   bb38 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$18);
-    %2 = (1, $desugar$19);
-    %0 = / %1 %2;
-    (1, $desugar$20) = %0;
-    PopScopeFrame
-    GOTO bb39;
+    %100 = ConstantLoad 13
+    d = %100;
+    %103 = ConstantLoad a
+    %102 = m[%103];
+    %104 = %102;
+    %105 = %104 is nil
+    %105 ? bb39 : bb40;
   }
   bb39 {
-    %90 = $desugar$20;
-    %91 = println(%90) -> bb40;
+    %106 = ConstantLoad <nil>
+    GOTO bb41;
   }
   bb40 {
-    %93 = ConstantLoad b
-    %92 = m[%93];
-    $desugar$21 = %92;
-    %95 = ConstantLoad <nil>
-    $desugar$22 = %95;
-    %97 = $desugar$21 is nil
-    %97 ? bb41 : bb42;
+    %106 = + %104 d;
+    GOTO bb41;
   }
   bb41 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb43;
+    v7 = %106;
+    %108 = v7;
+    %109 = println(%108) -> bb42;
   }
   bb42 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$21);
-    %2 = ConstantLoad 3
-    %3 = %2;
-    %0 = / %1 %3;
-    (1, $desugar$22) = %0;
-    PopScopeFrame
-    GOTO bb43;
+    %111 = ConstantLoad a
+    %110 = m[%111];
+    %112 = %110;
+    %114 = ConstantLoad b
+    %113 = m[%114];
+    %115 = %112 is nil
+    %116 = %113 is nil
+    %117 = || %115 %116;
+    %117 ? bb43 : bb44;
   }
   bb43 {
-    v5 = $desugar$22;
-    %99 = v5;
-    %100 = println(%99) -> bb44;
+    %118 = ConstantLoad <nil>
+    GOTO bb45;
   }
   bb44 {
-    %102 = ConstantLoad a
-    %101 = m[%102];
-    $desugar$23 = %101;
-    %104 = ConstantLoad <nil>
-    $desugar$24 = %104;
-    %106 = $desugar$23 is nil
-    %106 ? bb45 : bb46;
+    %118 = + %112 %113;
+    GOTO bb45;
   }
   bb45 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb47;
+    %119 = %118;
+    %121 = ConstantLoad c
+    %120 = m[%121];
+    %122 = %119 is nil
+    %123 = %120 is nil
+    %124 = || %122 %123;
+    %124 ? bb46 : bb47;
   }
   bb46 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$23);
-    (1, $desugar$24) = %0;
-    PopScopeFrame
-    GOTO bb47;
+    %125 = ConstantLoad <nil>
+    GOTO bb48;
   }
   bb47 {
-    v6 = $desugar$24;
-    %108 = v6;
-    %109 = println(%108) -> bb48;
+    %125 = + %119 %120;
+    GOTO bb48;
   }
   bb48 {
-    %111 = ConstantLoad c
-    %110 = m[%111];
-    $desugar$25 = %110;
-    %113 = ConstantLoad <nil>
-    $desugar$26 = %113;
-    %115 = $desugar$25 is nil
-    %115 ? bb49 : bb50;
+    %126 = %125;
+    %127 = %126 is nil
+    %127 ? bb49 : bb50;
   }
   bb49 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %128 = ConstantLoad <nil>
     GOTO bb51;
   }
   bb50 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$25);
-    (1, $desugar$26) = %0;
-    PopScopeFrame
+    %128 = + %126 d;
     GOTO bb51;
   }
   bb51 {
-    %116 = $desugar$26;
-    %117 = println(%116) -> bb52;
+    %129 = %128;
+    %130 = println(%129) -> bb52;
   }
   bb52 {
-    %118 = ConstantLoad 13
-    d = %118;
-    %121 = ConstantLoad a
-    %120 = m[%121];
-    $desugar$27 = %120;
-    %123 = ConstantLoad <nil>
-    $desugar$28 = %123;
-    %125 = $desugar$27 is nil
-    %125 ? bb53 : bb54;
+    %131 = ConstantLoad <nil>
+    e = %131;
+    %134 = ConstantLoad a
+    %133 = m[%134];
+    %135 = %133;
+    %136 = %135 is nil
+    %137 = e is nil
+    %138 = || %136 %137;
+    %138 ? bb53 : bb54;
   }
   bb53 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %139 = ConstantLoad <nil>
     GOTO bb55;
   }
   bb54 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$27);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$28) = %0;
-    PopScopeFrame
+    %139 = + %135 e;
     GOTO bb55;
   }
   bb55 {
-    v7 = $desugar$28;
-    %127 = v7;
-    %128 = println(%127) -> bb56;
+    v8 = %139;
+    %141 = v8;
+    %142 = println(%141) -> bb56;
   }
   bb56 {
-    %130 = ConstantLoad a
-    %129 = m[%130];
-    $desugar$29 = %129;
-    %133 = ConstantLoad b
-    %132 = m[%133];
-    $desugar$30 = %132;
-    %135 = ConstantLoad <nil>
-    $desugar$31 = %135;
-    %138 = $desugar$29 is nil
-    %137 = %138;
-    %138 ? bb58 : bb57;
+    %144 = ConstantLoad a
+    %143 = m[%144];
+    %145 = %143;
+    %147 = ConstantLoad b
+    %146 = m[%147];
+    %148 = %145 is nil
+    %149 = %146 is nil
+    %150 = || %148 %149;
+    %150 ? bb57 : bb58;
   }
   bb57 {
-    %139 = $desugar$30 is nil
-    %137 = %139;
-    GOTO bb58;
+    %151 = ConstantLoad <nil>
+    GOTO bb59;
   }
   bb58 {
-    %137 ? bb59 : bb60;
+    %151 = + %145 %146;
+    GOTO bb59;
   }
   bb59 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb61;
+    %152 = %151;
+    %154 = ConstantLoad c
+    %153 = m[%154];
+    %155 = %152 is nil
+    %156 = %153 is nil
+    %157 = || %155 %156;
+    %157 ? bb60 : bb61;
   }
   bb60 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$29);
-    %2 = (1, $desugar$30);
-    %0 = + %1 %2;
-    (1, $desugar$31) = %0;
-    PopScopeFrame
-    GOTO bb61;
+    %158 = ConstantLoad <nil>
+    GOTO bb62;
   }
   bb61 {
-    $desugar$32 = $desugar$31;
-    %142 = ConstantLoad c
-    %141 = m[%142];
-    $desugar$33 = %141;
-    %144 = ConstantLoad <nil>
-    $desugar$34 = %144;
-    %147 = $desugar$32 is nil
-    %146 = %147;
-    %147 ? bb63 : bb62;
+    %158 = + %152 %153;
+    GOTO bb62;
   }
   bb62 {
-    %148 = $desugar$33 is nil
-    %146 = %148;
-    GOTO bb63;
+    %159 = %158;
+    %160 = %159 is nil
+    %160 ? bb63 : bb64;
   }
   bb63 {
-    %146 ? bb64 : bb65;
+    %161 = ConstantLoad <nil>
+    GOTO bb65;
   }
   bb64 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb66;
+    %161 = + %159 d;
+    GOTO bb65;
   }
   bb65 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$32);
-    %2 = (1, $desugar$33);
-    %0 = + %1 %2;
-    (1, $desugar$34) = %0;
-    PopScopeFrame
-    GOTO bb66;
+    %162 = %161;
+    %163 = %162 is nil
+    %164 = e is nil
+    %165 = || %163 %164;
+    %165 ? bb66 : bb67;
   }
   bb66 {
-    $desugar$35 = $desugar$34;
-    %150 = ConstantLoad <nil>
-    $desugar$36 = %150;
-    %152 = $desugar$35 is nil
-    %152 ? bb67 : bb68;
+    %166 = ConstantLoad <nil>
+    GOTO bb68;
   }
   bb67 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb69;
+    %166 = + %162 e;
+    GOTO bb68;
   }
   bb68 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$35);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$36) = %0;
-    PopScopeFrame
-    GOTO bb69;
+    %167 = %166;
+    %168 = println(%167) -> bb69;
   }
   bb69 {
-    %153 = $desugar$36;
-    %154 = println(%153) -> bb70;
+    %170 = ConstantLoad a
+    %169 = m[%170];
+    %171 = %169 is nil
+    %171 ? bb70 : bb71;
   }
   bb70 {
-    %155 = ConstantLoad <nil>
-    e = %155;
-    %158 = ConstantLoad a
-    %157 = m[%158];
-    $desugar$37 = %157;
-    $desugar$38 = e;
-    %161 = ConstantLoad <nil>
-    $desugar$39 = %161;
-    %164 = $desugar$37 is nil
-    %163 = %164;
-    %164 ? bb72 : bb71;
+    %172 = ConstantLoad <nil>
+    GOTO bb72;
   }
   bb71 {
-    %165 = $desugar$38 is nil
-    %163 = %165;
+    %172 = unknown %169;
     GOTO bb72;
   }
   bb72 {
-    %163 ? bb73 : bb74;
+    %173 = %172;
+    %174 = println(%173) -> bb73;
   }
   bb73 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb75;
-  }
-  bb74 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$37);
-    %2 = (1, $desugar$38);
-    %0 = + %1 %2;
-    (1, $desugar$39) = %0;
-    PopScopeFrame
-    GOTO bb75;
-  }
-  bb75 {
-    v8 = $desugar$39;
-    %167 = v8;
-    %168 = println(%167) -> bb76;
-  }
-  bb76 {
-    %170 = ConstantLoad a
-    %169 = m[%170];
-    $desugar$40 = %169;
-    %173 = ConstantLoad b
-    %172 = m[%173];
-    $desugar$41 = %172;
-    %175 = ConstantLoad <nil>
-    $desugar$42 = %175;
-    %178 = $desugar$40 is nil
-    %177 = %178;
-    %178 ? bb78 : bb77;
-  }
-  bb77 {
-    %179 = $desugar$41 is nil
-    %177 = %179;
-    GOTO bb78;
-  }
-  bb78 {
-    %177 ? bb79 : bb80;
-  }
-  bb79 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb81;
-  }
-  bb80 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$40);
-    %2 = (1, $desugar$41);
-    %0 = + %1 %2;
-    (1, $desugar$42) = %0;
-    PopScopeFrame
-    GOTO bb81;
-  }
-  bb81 {
-    $desugar$43 = $desugar$42;
-    %182 = ConstantLoad c
-    %181 = m[%182];
-    $desugar$44 = %181;
-    %184 = ConstantLoad <nil>
-    $desugar$45 = %184;
-    %187 = $desugar$43 is nil
-    %186 = %187;
-    %187 ? bb83 : bb82;
-  }
-  bb82 {
-    %188 = $desugar$44 is nil
-    %186 = %188;
-    GOTO bb83;
-  }
-  bb83 {
-    %186 ? bb84 : bb85;
-  }
-  bb84 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb86;
-  }
-  bb85 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$43);
-    %2 = (1, $desugar$44);
-    %0 = + %1 %2;
-    (1, $desugar$45) = %0;
-    PopScopeFrame
-    GOTO bb86;
-  }
-  bb86 {
-    $desugar$46 = $desugar$45;
-    %190 = ConstantLoad <nil>
-    $desugar$47 = %190;
-    %192 = $desugar$46 is nil
-    %192 ? bb87 : bb88;
-  }
-  bb87 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb89;
-  }
-  bb88 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$46);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$47) = %0;
-    PopScopeFrame
-    GOTO bb89;
-  }
-  bb89 {
-    $desugar$48 = $desugar$47;
-    $desugar$49 = e;
-    %195 = ConstantLoad <nil>
-    $desugar$50 = %195;
-    %198 = $desugar$48 is nil
-    %197 = %198;
-    %198 ? bb91 : bb90;
-  }
-  bb90 {
-    %199 = $desugar$49 is nil
-    %197 = %199;
-    GOTO bb91;
-  }
-  bb91 {
-    %197 ? bb92 : bb93;
-  }
-  bb92 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb94;
-  }
-  bb93 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$48);
-    %2 = (1, $desugar$49);
-    %0 = + %1 %2;
-    (1, $desugar$50) = %0;
-    PopScopeFrame
-    GOTO bb94;
-  }
-  bb94 {
-    %200 = $desugar$50;
-    %201 = println(%200) -> bb95;
-  }
-  bb95 {
-    %203 = ConstantLoad a
-    %202 = m[%203];
-    $desugar$51 = %202;
-    %205 = ConstantLoad <nil>
-    $desugar$52 = %205;
-    %207 = $desugar$51 is nil
-    %207 ? bb96 : bb97;
-  }
-  bb96 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb98;
-  }
-  bb97 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$51);
-    (1, $desugar$52) = %0;
-    PopScopeFrame
-    GOTO bb98;
-  }
-  bb98 {
-    %208 = $desugar$52;
-    %209 = println(%208) -> bb99;
-  }
-  bb99 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/9-v.txt
+++ b/corpus/bir/subset8/08-nillifting/9-v.txt
@@ -14,657 +14,396 @@ main() -> nil{
     m[%8] = %7;
     %10 = ConstantLoad a
     %9 = m[%10];
-    $desugar$0 = %9;
+    %11 = %9;
     %13 = ConstantLoad b
     %12 = m[%13];
-    $desugar$1 = %12;
-    %15 = ConstantLoad <nil>
-    $desugar$2 = %15;
-    %18 = $desugar$0 is nil
-    %17 = %18;
-    %18 ? bb2 : bb1;
+    %14 = %11 is nil
+    %15 = %12 is nil
+    %16 = || %14 %15;
+    %16 ? bb1 : bb2;
   }
   bb1 {
-    %19 = $desugar$1 is nil
-    %17 = %19;
-    GOTO bb2;
+    %17 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %17 ? bb3 : bb4;
+    %17 = + %11 %12;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    %18 = %17;
+    %19 = println(%18) -> bb4;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = + %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %21 = ConstantLoad a
+    %20 = m[%21];
+    %22 = %20;
+    %24 = ConstantLoad b
+    %23 = m[%24];
+    %25 = %22 is nil
+    %26 = %23 is nil
+    %27 = || %25 %26;
+    %27 ? bb5 : bb6;
   }
   bb5 {
-    %20 = $desugar$2;
-    %21 = println(%20) -> bb6;
+    %28 = ConstantLoad <nil>
+    GOTO bb7;
   }
   bb6 {
-    %23 = ConstantLoad a
-    %22 = m[%23];
-    $desugar$3 = %22;
-    %26 = ConstantLoad b
-    %25 = m[%26];
-    $desugar$4 = %25;
-    %28 = ConstantLoad <nil>
-    $desugar$5 = %28;
-    %31 = $desugar$3 is nil
-    %30 = %31;
-    %31 ? bb8 : bb7;
+    %28 = + %22 %23;
+    GOTO bb7;
   }
   bb7 {
-    %32 = $desugar$4 is nil
-    %30 = %32;
-    GOTO bb8;
+    %29 = %28;
+    %31 = ConstantLoad c
+    %30 = m[%31];
+    %32 = %29 is nil
+    %33 = %30 is nil
+    %34 = || %32 %33;
+    %34 ? bb8 : bb9;
   }
   bb8 {
-    %30 ? bb9 : bb10;
+    %35 = ConstantLoad <nil>
+    GOTO bb10;
   }
   bb9 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb11;
+    %35 = + %29 %30;
+    GOTO bb10;
   }
   bb10 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = + %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
-    GOTO bb11;
+    %36 = %35;
+    %37 = println(%36) -> bb11;
   }
   bb11 {
-    $desugar$6 = $desugar$5;
-    %35 = ConstantLoad c
-    %34 = m[%35];
-    $desugar$7 = %34;
-    %37 = ConstantLoad <nil>
-    $desugar$8 = %37;
-    %40 = $desugar$6 is nil
-    %39 = %40;
-    %40 ? bb13 : bb12;
+    %39 = ConstantLoad a
+    %38 = m[%39];
+    %40 = %38;
+    %42 = ConstantLoad b
+    %41 = m[%42];
+    %43 = %40 is nil
+    %44 = %41 is nil
+    %45 = || %43 %44;
+    %45 ? bb12 : bb13;
   }
   bb12 {
-    %41 = $desugar$7 is nil
-    %39 = %41;
-    GOTO bb13;
+    %46 = ConstantLoad <nil>
+    GOTO bb14;
   }
   bb13 {
-    %39 ? bb14 : bb15;
+    %46 = - %40 %41;
+    GOTO bb14;
   }
   bb14 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb16;
+    %47 = %46;
+    %48 = println(%47) -> bb15;
   }
   bb15 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = + %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
-    GOTO bb16;
+    %50 = ConstantLoad a
+    %49 = m[%50];
+    %51 = %49;
+    %53 = ConstantLoad b
+    %52 = m[%53];
+    %54 = %51 is nil
+    %55 = %52 is nil
+    %56 = || %54 %55;
+    %56 ? bb16 : bb17;
   }
   bb16 {
-    %42 = $desugar$8;
-    %43 = println(%42) -> bb17;
+    %57 = ConstantLoad <nil>
+    GOTO bb18;
   }
   bb17 {
-    %45 = ConstantLoad a
-    %44 = m[%45];
-    $desugar$9 = %44;
-    %48 = ConstantLoad b
-    %47 = m[%48];
-    $desugar$10 = %47;
-    %50 = ConstantLoad <nil>
-    $desugar$11 = %50;
-    %53 = $desugar$9 is nil
-    %52 = %53;
-    %53 ? bb19 : bb18;
+    %57 = + %51 %52;
+    GOTO bb18;
   }
   bb18 {
-    %54 = $desugar$10 is nil
-    %52 = %54;
-    GOTO bb19;
+    %58 = %57;
+    %60 = ConstantLoad c
+    %59 = m[%60];
+    %61 = %58 is nil
+    %62 = %59 is nil
+    %63 = || %61 %62;
+    %63 ? bb19 : bb20;
   }
   bb19 {
-    %52 ? bb20 : bb21;
+    %64 = ConstantLoad <nil>
+    GOTO bb21;
   }
   bb20 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb22;
+    %64 = - %58 %59;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = - %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb22;
+    %65 = %64;
+    %66 = println(%65) -> bb22;
   }
   bb22 {
-    %55 = $desugar$11;
-    %56 = println(%55) -> bb23;
+    %68 = ConstantLoad b
+    %67 = m[%68];
+    %69 = %67;
+    %71 = ConstantLoad c
+    %70 = m[%71];
+    %72 = %69 is nil
+    %73 = %70 is nil
+    %74 = || %72 %73;
+    %74 ? bb23 : bb24;
   }
   bb23 {
-    %58 = ConstantLoad a
-    %57 = m[%58];
-    $desugar$12 = %57;
-    %61 = ConstantLoad b
-    %60 = m[%61];
-    $desugar$13 = %60;
-    %63 = ConstantLoad <nil>
-    $desugar$14 = %63;
-    %66 = $desugar$12 is nil
-    %65 = %66;
-    %66 ? bb25 : bb24;
+    %75 = ConstantLoad <nil>
+    GOTO bb25;
   }
   bb24 {
-    %67 = $desugar$13 is nil
-    %65 = %67;
+    %75 = / %69 %70;
     GOTO bb25;
   }
   bb25 {
-    %65 ? bb26 : bb27;
+    %76 = %75;
+    %77 = println(%76) -> bb26;
   }
   bb26 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb28;
+    %79 = ConstantLoad b
+    %78 = m[%79];
+    %80 = %78;
+    %81 = ConstantLoad 3
+    %82 = %80 is nil
+    %82 ? bb27 : bb28;
   }
   bb27 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$12);
-    %2 = (1, $desugar$13);
-    %0 = + %1 %2;
-    (1, $desugar$14) = %0;
-    PopScopeFrame
-    GOTO bb28;
+    %83 = ConstantLoad <nil>
+    GOTO bb29;
   }
   bb28 {
-    $desugar$15 = $desugar$14;
-    %70 = ConstantLoad c
-    %69 = m[%70];
-    $desugar$16 = %69;
-    %72 = ConstantLoad <nil>
-    $desugar$17 = %72;
-    %75 = $desugar$15 is nil
-    %74 = %75;
-    %75 ? bb30 : bb29;
+    %83 = / %80 %81;
+    GOTO bb29;
   }
   bb29 {
-    %76 = $desugar$16 is nil
-    %74 = %76;
-    GOTO bb30;
+    v5 = %83;
+    %85 = v5;
+    %86 = println(%85) -> bb30;
   }
   bb30 {
-    %74 ? bb31 : bb32;
+    %88 = ConstantLoad a
+    %87 = m[%88];
+    %89 = %87 is nil
+    %89 ? bb31 : bb32;
   }
   bb31 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %90 = ConstantLoad <nil>
     GOTO bb33;
   }
   bb32 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$15);
-    %2 = (1, $desugar$16);
-    %0 = - %1 %2;
-    (1, $desugar$17) = %0;
-    PopScopeFrame
+    %90 = unknown %87;
     GOTO bb33;
   }
   bb33 {
-    %77 = $desugar$17;
-    %78 = println(%77) -> bb34;
+    v6 = %90;
+    %92 = v6;
+    %93 = println(%92) -> bb34;
   }
   bb34 {
-    %80 = ConstantLoad b
-    %79 = m[%80];
-    $desugar$18 = %79;
-    %83 = ConstantLoad c
-    %82 = m[%83];
-    $desugar$19 = %82;
-    %85 = ConstantLoad <nil>
-    $desugar$20 = %85;
-    %88 = $desugar$18 is nil
-    %87 = %88;
-    %88 ? bb36 : bb35;
+    %95 = ConstantLoad c
+    %94 = m[%95];
+    %96 = %94 is nil
+    %96 ? bb35 : bb36;
   }
   bb35 {
-    %89 = $desugar$19 is nil
-    %87 = %89;
-    GOTO bb36;
+    %97 = ConstantLoad <nil>
+    GOTO bb37;
   }
   bb36 {
-    %87 ? bb37 : bb38;
+    %97 = unknown %94;
+    GOTO bb37;
   }
   bb37 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb39;
+    %98 = %97;
+    %99 = println(%98) -> bb38;
   }
   bb38 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$18);
-    %2 = (1, $desugar$19);
-    %0 = / %1 %2;
-    (1, $desugar$20) = %0;
-    PopScopeFrame
-    GOTO bb39;
+    %100 = ConstantLoad 13
+    d = %100;
+    %103 = ConstantLoad a
+    %102 = m[%103];
+    %104 = %102;
+    %105 = %104 is nil
+    %105 ? bb39 : bb40;
   }
   bb39 {
-    %90 = $desugar$20;
-    %91 = println(%90) -> bb40;
+    %106 = ConstantLoad <nil>
+    GOTO bb41;
   }
   bb40 {
-    %93 = ConstantLoad b
-    %92 = m[%93];
-    $desugar$21 = %92;
-    %95 = ConstantLoad <nil>
-    $desugar$22 = %95;
-    %97 = $desugar$21 is nil
-    %97 ? bb41 : bb42;
+    %106 = + %104 d;
+    GOTO bb41;
   }
   bb41 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb43;
+    v7 = %106;
+    %108 = v7;
+    %109 = println(%108) -> bb42;
   }
   bb42 {
-    PushScopeFrame 4
-    %1 = (1, $desugar$21);
-    %2 = ConstantLoad 3
-    %3 = %2;
-    %0 = / %1 %3;
-    (1, $desugar$22) = %0;
-    PopScopeFrame
-    GOTO bb43;
+    %111 = ConstantLoad a
+    %110 = m[%111];
+    %112 = %110;
+    %114 = ConstantLoad b
+    %113 = m[%114];
+    %115 = %112 is nil
+    %116 = %113 is nil
+    %117 = || %115 %116;
+    %117 ? bb43 : bb44;
   }
   bb43 {
-    v5 = $desugar$22;
-    %99 = v5;
-    %100 = println(%99) -> bb44;
+    %118 = ConstantLoad <nil>
+    GOTO bb45;
   }
   bb44 {
-    %102 = ConstantLoad a
-    %101 = m[%102];
-    $desugar$23 = %101;
-    %104 = ConstantLoad <nil>
-    $desugar$24 = %104;
-    %106 = $desugar$23 is nil
-    %106 ? bb45 : bb46;
+    %118 = + %112 %113;
+    GOTO bb45;
   }
   bb45 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb47;
+    %119 = %118;
+    %121 = ConstantLoad c
+    %120 = m[%121];
+    %122 = %119 is nil
+    %123 = %120 is nil
+    %124 = || %122 %123;
+    %124 ? bb46 : bb47;
   }
   bb46 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$23);
-    (1, $desugar$24) = %0;
-    PopScopeFrame
-    GOTO bb47;
+    %125 = ConstantLoad <nil>
+    GOTO bb48;
   }
   bb47 {
-    v6 = $desugar$24;
-    %108 = v6;
-    %109 = println(%108) -> bb48;
+    %125 = + %119 %120;
+    GOTO bb48;
   }
   bb48 {
-    %111 = ConstantLoad c
-    %110 = m[%111];
-    $desugar$25 = %110;
-    %113 = ConstantLoad <nil>
-    $desugar$26 = %113;
-    %115 = $desugar$25 is nil
-    %115 ? bb49 : bb50;
+    %126 = %125;
+    %127 = %126 is nil
+    %127 ? bb49 : bb50;
   }
   bb49 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %128 = ConstantLoad <nil>
     GOTO bb51;
   }
   bb50 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$25);
-    (1, $desugar$26) = %0;
-    PopScopeFrame
+    %128 = + %126 d;
     GOTO bb51;
   }
   bb51 {
-    %116 = $desugar$26;
-    %117 = println(%116) -> bb52;
+    %129 = %128;
+    %130 = println(%129) -> bb52;
   }
   bb52 {
-    %118 = ConstantLoad 13
-    d = %118;
-    %121 = ConstantLoad a
-    %120 = m[%121];
-    $desugar$27 = %120;
-    %123 = ConstantLoad <nil>
-    $desugar$28 = %123;
-    %125 = $desugar$27 is nil
-    %125 ? bb53 : bb54;
+    %131 = ConstantLoad <nil>
+    e = %131;
+    %134 = ConstantLoad a
+    %133 = m[%134];
+    %135 = %133;
+    %136 = %135 is nil
+    %137 = e is nil
+    %138 = || %136 %137;
+    %138 ? bb53 : bb54;
   }
   bb53 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %139 = ConstantLoad <nil>
     GOTO bb55;
   }
   bb54 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$27);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$28) = %0;
-    PopScopeFrame
+    %139 = + %135 e;
     GOTO bb55;
   }
   bb55 {
-    v7 = $desugar$28;
-    %127 = v7;
-    %128 = println(%127) -> bb56;
+    v8 = %139;
+    %141 = v8;
+    %142 = println(%141) -> bb56;
   }
   bb56 {
-    %130 = ConstantLoad a
-    %129 = m[%130];
-    $desugar$29 = %129;
-    %133 = ConstantLoad b
-    %132 = m[%133];
-    $desugar$30 = %132;
-    %135 = ConstantLoad <nil>
-    $desugar$31 = %135;
-    %138 = $desugar$29 is nil
-    %137 = %138;
-    %138 ? bb58 : bb57;
+    %144 = ConstantLoad a
+    %143 = m[%144];
+    %145 = %143;
+    %147 = ConstantLoad b
+    %146 = m[%147];
+    %148 = %145 is nil
+    %149 = %146 is nil
+    %150 = || %148 %149;
+    %150 ? bb57 : bb58;
   }
   bb57 {
-    %139 = $desugar$30 is nil
-    %137 = %139;
-    GOTO bb58;
+    %151 = ConstantLoad <nil>
+    GOTO bb59;
   }
   bb58 {
-    %137 ? bb59 : bb60;
+    %151 = + %145 %146;
+    GOTO bb59;
   }
   bb59 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb61;
+    %152 = %151;
+    %154 = ConstantLoad c
+    %153 = m[%154];
+    %155 = %152 is nil
+    %156 = %153 is nil
+    %157 = || %155 %156;
+    %157 ? bb60 : bb61;
   }
   bb60 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$29);
-    %2 = (1, $desugar$30);
-    %0 = + %1 %2;
-    (1, $desugar$31) = %0;
-    PopScopeFrame
-    GOTO bb61;
+    %158 = ConstantLoad <nil>
+    GOTO bb62;
   }
   bb61 {
-    $desugar$32 = $desugar$31;
-    %142 = ConstantLoad c
-    %141 = m[%142];
-    $desugar$33 = %141;
-    %144 = ConstantLoad <nil>
-    $desugar$34 = %144;
-    %147 = $desugar$32 is nil
-    %146 = %147;
-    %147 ? bb63 : bb62;
+    %158 = + %152 %153;
+    GOTO bb62;
   }
   bb62 {
-    %148 = $desugar$33 is nil
-    %146 = %148;
-    GOTO bb63;
+    %159 = %158;
+    %160 = %159 is nil
+    %160 ? bb63 : bb64;
   }
   bb63 {
-    %146 ? bb64 : bb65;
+    %161 = ConstantLoad <nil>
+    GOTO bb65;
   }
   bb64 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb66;
+    %161 = + %159 d;
+    GOTO bb65;
   }
   bb65 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$32);
-    %2 = (1, $desugar$33);
-    %0 = + %1 %2;
-    (1, $desugar$34) = %0;
-    PopScopeFrame
-    GOTO bb66;
+    %162 = %161;
+    %163 = %162 is nil
+    %164 = e is nil
+    %165 = || %163 %164;
+    %165 ? bb66 : bb67;
   }
   bb66 {
-    $desugar$35 = $desugar$34;
-    %150 = ConstantLoad <nil>
-    $desugar$36 = %150;
-    %152 = $desugar$35 is nil
-    %152 ? bb67 : bb68;
+    %166 = ConstantLoad <nil>
+    GOTO bb68;
   }
   bb67 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb69;
+    %166 = + %162 e;
+    GOTO bb68;
   }
   bb68 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$35);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$36) = %0;
-    PopScopeFrame
-    GOTO bb69;
+    %167 = %166;
+    %168 = println(%167) -> bb69;
   }
   bb69 {
-    %153 = $desugar$36;
-    %154 = println(%153) -> bb70;
+    %170 = ConstantLoad a
+    %169 = m[%170];
+    %171 = %169 is nil
+    %171 ? bb70 : bb71;
   }
   bb70 {
-    %155 = ConstantLoad <nil>
-    e = %155;
-    %158 = ConstantLoad a
-    %157 = m[%158];
-    $desugar$37 = %157;
-    $desugar$38 = e;
-    %161 = ConstantLoad <nil>
-    $desugar$39 = %161;
-    %164 = $desugar$37 is nil
-    %163 = %164;
-    %164 ? bb72 : bb71;
+    %172 = ConstantLoad <nil>
+    GOTO bb72;
   }
   bb71 {
-    %165 = $desugar$38 is nil
-    %163 = %165;
+    %172 = unknown %169;
     GOTO bb72;
   }
   bb72 {
-    %163 ? bb73 : bb74;
+    %173 = %172;
+    %174 = println(%173) -> bb73;
   }
   bb73 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb75;
-  }
-  bb74 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$37);
-    %2 = (1, $desugar$38);
-    %0 = + %1 %2;
-    (1, $desugar$39) = %0;
-    PopScopeFrame
-    GOTO bb75;
-  }
-  bb75 {
-    v8 = $desugar$39;
-    %167 = v8;
-    %168 = println(%167) -> bb76;
-  }
-  bb76 {
-    %170 = ConstantLoad a
-    %169 = m[%170];
-    $desugar$40 = %169;
-    %173 = ConstantLoad b
-    %172 = m[%173];
-    $desugar$41 = %172;
-    %175 = ConstantLoad <nil>
-    $desugar$42 = %175;
-    %178 = $desugar$40 is nil
-    %177 = %178;
-    %178 ? bb78 : bb77;
-  }
-  bb77 {
-    %179 = $desugar$41 is nil
-    %177 = %179;
-    GOTO bb78;
-  }
-  bb78 {
-    %177 ? bb79 : bb80;
-  }
-  bb79 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb81;
-  }
-  bb80 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$40);
-    %2 = (1, $desugar$41);
-    %0 = + %1 %2;
-    (1, $desugar$42) = %0;
-    PopScopeFrame
-    GOTO bb81;
-  }
-  bb81 {
-    $desugar$43 = $desugar$42;
-    %182 = ConstantLoad c
-    %181 = m[%182];
-    $desugar$44 = %181;
-    %184 = ConstantLoad <nil>
-    $desugar$45 = %184;
-    %187 = $desugar$43 is nil
-    %186 = %187;
-    %187 ? bb83 : bb82;
-  }
-  bb82 {
-    %188 = $desugar$44 is nil
-    %186 = %188;
-    GOTO bb83;
-  }
-  bb83 {
-    %186 ? bb84 : bb85;
-  }
-  bb84 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb86;
-  }
-  bb85 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$43);
-    %2 = (1, $desugar$44);
-    %0 = + %1 %2;
-    (1, $desugar$45) = %0;
-    PopScopeFrame
-    GOTO bb86;
-  }
-  bb86 {
-    $desugar$46 = $desugar$45;
-    %190 = ConstantLoad <nil>
-    $desugar$47 = %190;
-    %192 = $desugar$46 is nil
-    %192 ? bb87 : bb88;
-  }
-  bb87 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb89;
-  }
-  bb88 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$46);
-    %2 = (1, d);
-    %0 = + %1 %2;
-    (1, $desugar$47) = %0;
-    PopScopeFrame
-    GOTO bb89;
-  }
-  bb89 {
-    $desugar$48 = $desugar$47;
-    $desugar$49 = e;
-    %195 = ConstantLoad <nil>
-    $desugar$50 = %195;
-    %198 = $desugar$48 is nil
-    %197 = %198;
-    %198 ? bb91 : bb90;
-  }
-  bb90 {
-    %199 = $desugar$49 is nil
-    %197 = %199;
-    GOTO bb91;
-  }
-  bb91 {
-    %197 ? bb92 : bb93;
-  }
-  bb92 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb94;
-  }
-  bb93 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$48);
-    %2 = (1, $desugar$49);
-    %0 = + %1 %2;
-    (1, $desugar$50) = %0;
-    PopScopeFrame
-    GOTO bb94;
-  }
-  bb94 {
-    %200 = $desugar$50;
-    %201 = println(%200) -> bb95;
-  }
-  bb95 {
-    %203 = ConstantLoad a
-    %202 = m[%203];
-    $desugar$51 = %202;
-    %205 = ConstantLoad <nil>
-    $desugar$52 = %205;
-    %207 = $desugar$51 is nil
-    %207 ? bb96 : bb97;
-  }
-  bb96 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb98;
-  }
-  bb97 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$51);
-    (1, $desugar$52) = %0;
-    PopScopeFrame
-    GOTO bb98;
-  }
-  bb98 {
-    %208 = $desugar$52;
-    %209 = println(%208) -> bb99;
-  }
-  bb99 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/additive-1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/additive-1-v.txt
@@ -5,154 +5,90 @@ main() -> nil{
     x = %1;
     %3 = ConstantLoad <nil>
     y = %3;
-    $desugar$0 = x;
-    $desugar$1 = y;
-    %7 = ConstantLoad <nil>
-    $desugar$2 = %7;
-    %10 = $desugar$0 is nil
-    %9 = %10;
-    %10 ? bb2 : bb1;
+    %5 = x;
+    %6 = %5 is nil
+    %7 = y is nil
+    %8 = || %6 %7;
+    %8 ? bb1 : bb2;
   }
   bb1 {
-    %11 = $desugar$1 is nil
-    %9 = %11;
-    GOTO bb2;
+    %9 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %9 ? bb3 : bb4;
+    %9 = + %5 y;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    a = %9;
+    %11 = x;
+    %12 = %11 is nil
+    %13 = y is nil
+    %14 = || %12 %13;
+    %14 ? bb4 : bb5;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = + %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %15 = ConstantLoad <nil>
+    GOTO bb6;
   }
   bb5 {
-    a = $desugar$2;
-    $desugar$3 = x;
-    $desugar$4 = y;
-    %15 = ConstantLoad <nil>
-    $desugar$5 = %15;
-    %18 = $desugar$3 is nil
-    %17 = %18;
-    %18 ? bb7 : bb6;
+    %15 = - %11 y;
+    GOTO bb6;
   }
   bb6 {
-    %19 = $desugar$4 is nil
-    %17 = %19;
-    GOTO bb7;
+    b = %15;
+    %17 = a;
+    %18 = println(%17) -> bb7;
   }
   bb7 {
-    %17 ? bb8 : bb9;
+    %19 = b;
+    %20 = println(%19) -> bb8;
   }
   bb8 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb10;
+    %21 = ConstantLoad <nil>
+    i = %21;
+    %23 = ConstantLoad 10
+    j = %23;
+    %25 = i;
+    %26 = %25 is nil
+    %27 = j is nil
+    %28 = || %26 %27;
+    %28 ? bb9 : bb10;
   }
   bb9 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = - %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
-    GOTO bb10;
+    %29 = ConstantLoad <nil>
+    GOTO bb11;
   }
   bb10 {
-    b = $desugar$5;
-    %21 = a;
-    %22 = println(%21) -> bb11;
+    %29 = + %25 j;
+    GOTO bb11;
   }
   bb11 {
-    %23 = b;
-    %24 = println(%23) -> bb12;
+    a1 = %29;
+    %31 = i;
+    %32 = %31 is nil
+    %33 = y is nil
+    %34 = || %32 %33;
+    %34 ? bb12 : bb13;
   }
   bb12 {
-    %25 = ConstantLoad <nil>
-    i = %25;
-    %27 = ConstantLoad 10
-    j = %27;
-    $desugar$6 = i;
-    $desugar$7 = j;
-    %31 = ConstantLoad <nil>
-    $desugar$8 = %31;
-    %34 = $desugar$6 is nil
-    %33 = %34;
-    %34 ? bb14 : bb13;
+    %35 = ConstantLoad <nil>
+    GOTO bb14;
   }
   bb13 {
-    %35 = $desugar$7 is nil
-    %33 = %35;
+    %35 = - %31 y;
     GOTO bb14;
   }
   bb14 {
-    %33 ? bb15 : bb16;
+    b1 = %35;
+    %37 = a1;
+    %38 = println(%37) -> bb15;
   }
   bb15 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb17;
+    %39 = b1;
+    %40 = println(%39) -> bb16;
   }
   bb16 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = + %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
-    GOTO bb17;
-  }
-  bb17 {
-    a1 = $desugar$8;
-    $desugar$9 = i;
-    $desugar$10 = y;
-    %39 = ConstantLoad <nil>
-    $desugar$11 = %39;
-    %42 = $desugar$9 is nil
-    %41 = %42;
-    %42 ? bb19 : bb18;
-  }
-  bb18 {
-    %43 = $desugar$10 is nil
-    %41 = %43;
-    GOTO bb19;
-  }
-  bb19 {
-    %41 ? bb20 : bb21;
-  }
-  bb20 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb22;
-  }
-  bb21 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = - %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb22;
-  }
-  bb22 {
-    b1 = $desugar$11;
-    %45 = a1;
-    %46 = println(%45) -> bb23;
-  }
-  bb23 {
-    %47 = b1;
-    %48 = println(%47) -> bb24;
-  }
-  bb24 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/binary-bitwise-1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/binary-bitwise-1-v.txt
@@ -5,226 +5,130 @@ main() -> nil{
     x = %1;
     %3 = ConstantLoad <nil>
     y = %3;
-    $desugar$0 = x;
-    $desugar$1 = y;
-    %7 = ConstantLoad <nil>
-    $desugar$2 = %7;
-    %10 = $desugar$0 is nil
-    %9 = %10;
-    %10 ? bb2 : bb1;
+    %5 = x;
+    %6 = %5 is nil
+    %7 = y is nil
+    %8 = || %6 %7;
+    %8 ? bb1 : bb2;
   }
   bb1 {
-    %11 = $desugar$1 is nil
-    %9 = %11;
-    GOTO bb2;
+    %9 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %9 ? bb3 : bb4;
+    %9 = unknown %5 y;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    a = %9;
+    %11 = x;
+    %12 = %11 is nil
+    %13 = y is nil
+    %14 = || %12 %13;
+    %14 ? bb4 : bb5;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = unknown %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %15 = ConstantLoad <nil>
+    GOTO bb6;
   }
   bb5 {
-    a = $desugar$2;
-    $desugar$3 = x;
-    $desugar$4 = y;
-    %15 = ConstantLoad <nil>
-    $desugar$5 = %15;
-    %18 = $desugar$3 is nil
-    %17 = %18;
-    %18 ? bb7 : bb6;
+    %15 = unknown %11 y;
+    GOTO bb6;
   }
   bb6 {
-    %19 = $desugar$4 is nil
-    %17 = %19;
-    GOTO bb7;
+    b = %15;
+    %17 = x;
+    %18 = %17 is nil
+    %19 = y is nil
+    %20 = || %18 %19;
+    %20 ? bb7 : bb8;
   }
   bb7 {
-    %17 ? bb8 : bb9;
+    %21 = ConstantLoad <nil>
+    GOTO bb9;
   }
   bb8 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb10;
+    %21 = unknown %17 y;
+    GOTO bb9;
   }
   bb9 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = unknown %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
-    GOTO bb10;
+    c = %21;
+    %23 = a;
+    %24 = println(%23) -> bb10;
   }
   bb10 {
-    b = $desugar$5;
-    $desugar$6 = x;
-    $desugar$7 = y;
-    %23 = ConstantLoad <nil>
-    $desugar$8 = %23;
-    %26 = $desugar$6 is nil
-    %25 = %26;
-    %26 ? bb12 : bb11;
+    %25 = b;
+    %26 = println(%25) -> bb11;
   }
   bb11 {
-    %27 = $desugar$7 is nil
-    %25 = %27;
-    GOTO bb12;
+    %27 = c;
+    %28 = println(%27) -> bb12;
   }
   bb12 {
-    %25 ? bb13 : bb14;
+    %29 = ConstantLoad <nil>
+    i = %29;
+    %31 = ConstantLoad 10
+    j = %31;
+    %33 = i;
+    %34 = %33 is nil
+    %35 = j is nil
+    %36 = || %34 %35;
+    %36 ? bb13 : bb14;
   }
   bb13 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %37 = ConstantLoad <nil>
     GOTO bb15;
   }
   bb14 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = unknown %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
+    %37 = unknown %33 j;
     GOTO bb15;
   }
   bb15 {
-    c = $desugar$8;
-    %29 = a;
-    %30 = println(%29) -> bb16;
+    a1 = %37;
+    %39 = i;
+    %40 = %39 is nil
+    %41 = y is nil
+    %42 = || %40 %41;
+    %42 ? bb16 : bb17;
   }
   bb16 {
-    %31 = b;
-    %32 = println(%31) -> bb17;
+    %43 = ConstantLoad <nil>
+    GOTO bb18;
   }
   bb17 {
-    %33 = c;
-    %34 = println(%33) -> bb18;
+    %43 = unknown %39 y;
+    GOTO bb18;
   }
   bb18 {
-    %35 = ConstantLoad <nil>
-    i = %35;
-    %37 = ConstantLoad 10
-    j = %37;
-    $desugar$9 = i;
-    $desugar$10 = j;
-    %41 = ConstantLoad <nil>
-    $desugar$11 = %41;
-    %44 = $desugar$9 is nil
-    %43 = %44;
-    %44 ? bb20 : bb19;
+    b1 = %43;
+    %45 = i;
+    %46 = %45 is nil
+    %47 = y is nil
+    %48 = || %46 %47;
+    %48 ? bb19 : bb20;
   }
   bb19 {
-    %45 = $desugar$10 is nil
-    %43 = %45;
-    GOTO bb20;
+    %49 = ConstantLoad <nil>
+    GOTO bb21;
   }
   bb20 {
-    %43 ? bb21 : bb22;
+    %49 = unknown %45 y;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb23;
+    c1 = %49;
+    %51 = a1;
+    %52 = println(%51) -> bb22;
   }
   bb22 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = unknown %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb23;
+    %53 = b1;
+    %54 = println(%53) -> bb23;
   }
   bb23 {
-    a1 = $desugar$11;
-    $desugar$12 = i;
-    $desugar$13 = y;
-    %49 = ConstantLoad <nil>
-    $desugar$14 = %49;
-    %52 = $desugar$12 is nil
-    %51 = %52;
-    %52 ? bb25 : bb24;
+    %55 = c1;
+    %56 = println(%55) -> bb24;
   }
   bb24 {
-    %53 = $desugar$13 is nil
-    %51 = %53;
-    GOTO bb25;
-  }
-  bb25 {
-    %51 ? bb26 : bb27;
-  }
-  bb26 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb28;
-  }
-  bb27 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$12);
-    %2 = (1, $desugar$13);
-    %0 = unknown %1 %2;
-    (1, $desugar$14) = %0;
-    PopScopeFrame
-    GOTO bb28;
-  }
-  bb28 {
-    b1 = $desugar$14;
-    $desugar$15 = i;
-    $desugar$16 = y;
-    %57 = ConstantLoad <nil>
-    $desugar$17 = %57;
-    %60 = $desugar$15 is nil
-    %59 = %60;
-    %60 ? bb30 : bb29;
-  }
-  bb29 {
-    %61 = $desugar$16 is nil
-    %59 = %61;
-    GOTO bb30;
-  }
-  bb30 {
-    %59 ? bb31 : bb32;
-  }
-  bb31 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb33;
-  }
-  bb32 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$15);
-    %2 = (1, $desugar$16);
-    %0 = unknown %1 %2;
-    (1, $desugar$17) = %0;
-    PopScopeFrame
-    GOTO bb33;
-  }
-  bb33 {
-    c1 = $desugar$17;
-    %63 = a1;
-    %64 = println(%63) -> bb34;
-  }
-  bb34 {
-    %65 = b1;
-    %66 = println(%65) -> bb35;
-  }
-  bb35 {
-    %67 = c1;
-    %68 = println(%67) -> bb36;
-  }
-  bb36 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/match-guard1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/match-guard1-v.txt
@@ -1,0 +1,71 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1
+    value = %1;
+    %3 = ConstantLoad 0
+    n = %3;
+    %5 = ConstantLoad 1
+    %6 = == value %5;
+    %6 ? bb2 : bb3;
+  }
+  bb1 {
+    return;
+  }
+  bb2 {
+    PushScopeFrame 2
+    %0 = ConstantLoad first
+    %1 = println(%0) -> bb4;
+  }
+  bb3 {
+    %7 = ConstantLoad true
+    %9 = guardValue() -> bb6;
+  }
+  bb4 {
+    PopScopeFrame
+    GOTO bb1;
+  }
+  bb5 {
+    PushScopeFrame 2
+    %0 = ConstantLoad guarded
+    %1 = println(%0) -> bb11;
+  }
+  bb6 {
+    %10 = %9;
+    %11 = n is nil
+    %11 ? bb7 : bb8;
+  }
+  bb7 {
+    %12 = ConstantLoad <nil>
+    GOTO bb9;
+  }
+  bb8 {
+    %12 = + %10 n;
+    GOTO bb9;
+  }
+  bb9 {
+    %13 = %12;
+    %14 = ConstantLoad 1
+    %15 = %14;
+    %8 = == %13 %15;
+    %16 = && %7 %8;
+    %16 ? bb5 : bb10;
+  }
+  bb10 {
+  }
+  bb11 {
+    PopScopeFrame
+    GOTO bb1;
+  }
+}
+guardValue() -> int{
+  bb0 {
+    %1 = ConstantLoad guard
+    %2 = println(%1) -> bb1;
+  }
+  bb1 {
+    %3 = ConstantLoad 1
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-nillifting/multiplicative-1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/multiplicative-1-v.txt
@@ -5,226 +5,130 @@ main() -> nil{
     x = %1;
     %3 = ConstantLoad <nil>
     y = %3;
-    $desugar$0 = x;
-    $desugar$1 = y;
-    %7 = ConstantLoad <nil>
-    $desugar$2 = %7;
-    %10 = $desugar$0 is nil
-    %9 = %10;
-    %10 ? bb2 : bb1;
+    %5 = x;
+    %6 = %5 is nil
+    %7 = y is nil
+    %8 = || %6 %7;
+    %8 ? bb1 : bb2;
   }
   bb1 {
-    %11 = $desugar$1 is nil
-    %9 = %11;
-    GOTO bb2;
+    %9 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %9 ? bb3 : bb4;
+    %9 = * %5 y;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    a = %9;
+    %11 = x;
+    %12 = %11 is nil
+    %13 = y is nil
+    %14 = || %12 %13;
+    %14 ? bb4 : bb5;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = * %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %15 = ConstantLoad <nil>
+    GOTO bb6;
   }
   bb5 {
-    a = $desugar$2;
-    $desugar$3 = x;
-    $desugar$4 = y;
-    %15 = ConstantLoad <nil>
-    $desugar$5 = %15;
-    %18 = $desugar$3 is nil
-    %17 = %18;
-    %18 ? bb7 : bb6;
+    %15 = / %11 y;
+    GOTO bb6;
   }
   bb6 {
-    %19 = $desugar$4 is nil
-    %17 = %19;
-    GOTO bb7;
+    b = %15;
+    %17 = x;
+    %18 = %17 is nil
+    %19 = y is nil
+    %20 = || %18 %19;
+    %20 ? bb7 : bb8;
   }
   bb7 {
-    %17 ? bb8 : bb9;
+    %21 = ConstantLoad <nil>
+    GOTO bb9;
   }
   bb8 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb10;
+    %21 = % %17 y;
+    GOTO bb9;
   }
   bb9 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = / %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
-    GOTO bb10;
+    c = %21;
+    %23 = a;
+    %24 = println(%23) -> bb10;
   }
   bb10 {
-    b = $desugar$5;
-    $desugar$6 = x;
-    $desugar$7 = y;
-    %23 = ConstantLoad <nil>
-    $desugar$8 = %23;
-    %26 = $desugar$6 is nil
-    %25 = %26;
-    %26 ? bb12 : bb11;
+    %25 = b;
+    %26 = println(%25) -> bb11;
   }
   bb11 {
-    %27 = $desugar$7 is nil
-    %25 = %27;
-    GOTO bb12;
+    %27 = c;
+    %28 = println(%27) -> bb12;
   }
   bb12 {
-    %25 ? bb13 : bb14;
+    %29 = ConstantLoad <nil>
+    i = %29;
+    %31 = ConstantLoad 10
+    j = %31;
+    %33 = i;
+    %34 = %33 is nil
+    %35 = j is nil
+    %36 = || %34 %35;
+    %36 ? bb13 : bb14;
   }
   bb13 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %37 = ConstantLoad <nil>
     GOTO bb15;
   }
   bb14 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = % %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
+    %37 = * %33 j;
     GOTO bb15;
   }
   bb15 {
-    c = $desugar$8;
-    %29 = a;
-    %30 = println(%29) -> bb16;
+    a1 = %37;
+    %39 = i;
+    %40 = %39 is nil
+    %41 = y is nil
+    %42 = || %40 %41;
+    %42 ? bb16 : bb17;
   }
   bb16 {
-    %31 = b;
-    %32 = println(%31) -> bb17;
+    %43 = ConstantLoad <nil>
+    GOTO bb18;
   }
   bb17 {
-    %33 = c;
-    %34 = println(%33) -> bb18;
+    %43 = / %39 y;
+    GOTO bb18;
   }
   bb18 {
-    %35 = ConstantLoad <nil>
-    i = %35;
-    %37 = ConstantLoad 10
-    j = %37;
-    $desugar$9 = i;
-    $desugar$10 = j;
-    %41 = ConstantLoad <nil>
-    $desugar$11 = %41;
-    %44 = $desugar$9 is nil
-    %43 = %44;
-    %44 ? bb20 : bb19;
+    b1 = %43;
+    %45 = i;
+    %46 = %45 is nil
+    %47 = y is nil
+    %48 = || %46 %47;
+    %48 ? bb19 : bb20;
   }
   bb19 {
-    %45 = $desugar$10 is nil
-    %43 = %45;
-    GOTO bb20;
+    %49 = ConstantLoad <nil>
+    GOTO bb21;
   }
   bb20 {
-    %43 ? bb21 : bb22;
+    %49 = % %45 y;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb23;
+    c1 = %49;
+    %51 = a1;
+    %52 = println(%51) -> bb22;
   }
   bb22 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = * %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb23;
+    %53 = b1;
+    %54 = println(%53) -> bb23;
   }
   bb23 {
-    a1 = $desugar$11;
-    $desugar$12 = i;
-    $desugar$13 = y;
-    %49 = ConstantLoad <nil>
-    $desugar$14 = %49;
-    %52 = $desugar$12 is nil
-    %51 = %52;
-    %52 ? bb25 : bb24;
+    %55 = c1;
+    %56 = println(%55) -> bb24;
   }
   bb24 {
-    %53 = $desugar$13 is nil
-    %51 = %53;
-    GOTO bb25;
-  }
-  bb25 {
-    %51 ? bb26 : bb27;
-  }
-  bb26 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb28;
-  }
-  bb27 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$12);
-    %2 = (1, $desugar$13);
-    %0 = / %1 %2;
-    (1, $desugar$14) = %0;
-    PopScopeFrame
-    GOTO bb28;
-  }
-  bb28 {
-    b1 = $desugar$14;
-    $desugar$15 = i;
-    $desugar$16 = y;
-    %57 = ConstantLoad <nil>
-    $desugar$17 = %57;
-    %60 = $desugar$15 is nil
-    %59 = %60;
-    %60 ? bb30 : bb29;
-  }
-  bb29 {
-    %61 = $desugar$16 is nil
-    %59 = %61;
-    GOTO bb30;
-  }
-  bb30 {
-    %59 ? bb31 : bb32;
-  }
-  bb31 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb33;
-  }
-  bb32 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$15);
-    %2 = (1, $desugar$16);
-    %0 = % %1 %2;
-    (1, $desugar$17) = %0;
-    PopScopeFrame
-    GOTO bb33;
-  }
-  bb33 {
-    c1 = $desugar$17;
-    %63 = a1;
-    %64 = println(%63) -> bb34;
-  }
-  bb34 {
-    %65 = b1;
-    %66 = println(%65) -> bb35;
-  }
-  bb35 {
-    %67 = c1;
-    %68 = println(%67) -> bb36;
-  }
-  bb36 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/mutate1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/mutate1-v.txt
@@ -1,0 +1,69 @@
+module $anon.. v 0.0.0;
+number  nil|int;
+text  nil|string;
+main() -> nil{
+  bb0 {
+    %1 = number;
+    %2 = mutateNumber() -> bb1;
+  }
+  bb1 {
+    %3 = %1 is nil
+    %4 = %2 is nil
+    %5 = || %3 %4;
+    %5 ? bb2 : bb3;
+  }
+  bb2 {
+    %6 = ConstantLoad <nil>
+    GOTO bb4;
+  }
+  bb3 {
+    %6 = + %1 %2;
+    GOTO bb4;
+  }
+  bb4 {
+    %7 = %6;
+    %8 = println(%7) -> bb5;
+  }
+  bb5 {
+    %9 = text;
+    %10 = mutateText() -> bb6;
+  }
+  bb6 {
+    %11 = %9 is nil
+    %12 = %10 is nil
+    %13 = || %11 %12;
+    %13 ? bb7 : bb8;
+  }
+  bb7 {
+    %14 = ConstantLoad <nil>
+    GOTO bb9;
+  }
+  bb8 {
+    %14 = + %9 %10;
+    GOTO bb9;
+  }
+  bb9 {
+    %15 = println(%14) -> bb10;
+  }
+  bb10 {
+    return;
+  }
+}
+mutateNumber() -> nil|int{
+  bb0 {
+    %1 = ConstantLoad 100
+    number = %1;
+    %2 = ConstantLoad 1
+    %0 = %2;
+    return;
+  }
+}
+mutateText() -> nil|string{
+  bb0 {
+    %1 = ConstantLoad mutated
+    text = %1;
+    %2 = ConstantLoad b
+    %0 = %2;
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-nillifting/operand-eval1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/operand-eval1-v.txt
@@ -1,0 +1,41 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad <nil>
+    nilValue = %1;
+    %3 = sideEffect() -> bb1;
+  }
+  bb1 {
+    %4 = %3;
+    %5 = nilValue is nil
+    %5 ? bb2 : bb3;
+  }
+  bb2 {
+    %6 = ConstantLoad <nil>
+    GOTO bb4;
+  }
+  bb3 {
+    %6 = + %4 nilValue;
+    GOTO bb4;
+  }
+  bb4 {
+    result = %6;
+    %8 = result is nil
+    %9 = %8;
+    %10 = println(%9) -> bb5;
+  }
+  bb5 {
+    return;
+  }
+}
+sideEffect() -> int{
+  bb0 {
+    %1 = ConstantLoad side-effect
+    %2 = println(%1) -> bb1;
+  }
+  bb1 {
+    %3 = ConstantLoad 1
+    %0 = %3;
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-nillifting/shift-1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/shift-1-v.txt
@@ -5,226 +5,130 @@ main() -> nil{
     x = %1;
     %3 = ConstantLoad <nil>
     y = %3;
-    $desugar$0 = x;
-    $desugar$1 = y;
-    %7 = ConstantLoad <nil>
-    $desugar$2 = %7;
-    %10 = $desugar$0 is nil
-    %9 = %10;
-    %10 ? bb2 : bb1;
+    %5 = x;
+    %6 = %5 is nil
+    %7 = y is nil
+    %8 = || %6 %7;
+    %8 ? bb1 : bb2;
   }
   bb1 {
-    %11 = $desugar$1 is nil
-    %9 = %11;
-    GOTO bb2;
+    %9 = ConstantLoad <nil>
+    GOTO bb3;
   }
   bb2 {
-    %9 ? bb3 : bb4;
+    %9 = unknown %5 y;
+    GOTO bb3;
   }
   bb3 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb5;
+    a = %9;
+    %11 = x;
+    %12 = %11 is nil
+    %13 = y is nil
+    %14 = || %12 %13;
+    %14 ? bb4 : bb5;
   }
   bb4 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$0);
-    %2 = (1, $desugar$1);
-    %0 = unknown %1 %2;
-    (1, $desugar$2) = %0;
-    PopScopeFrame
-    GOTO bb5;
+    %15 = ConstantLoad <nil>
+    GOTO bb6;
   }
   bb5 {
-    a = $desugar$2;
-    $desugar$3 = x;
-    $desugar$4 = y;
-    %15 = ConstantLoad <nil>
-    $desugar$5 = %15;
-    %18 = $desugar$3 is nil
-    %17 = %18;
-    %18 ? bb7 : bb6;
+    %15 = unknown %11 y;
+    GOTO bb6;
   }
   bb6 {
-    %19 = $desugar$4 is nil
-    %17 = %19;
-    GOTO bb7;
+    b = %15;
+    %17 = x;
+    %18 = %17 is nil
+    %19 = y is nil
+    %20 = || %18 %19;
+    %20 ? bb7 : bb8;
   }
   bb7 {
-    %17 ? bb8 : bb9;
+    %21 = ConstantLoad <nil>
+    GOTO bb9;
   }
   bb8 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb10;
+    %21 = unknown %17 y;
+    GOTO bb9;
   }
   bb9 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$3);
-    %2 = (1, $desugar$4);
-    %0 = unknown %1 %2;
-    (1, $desugar$5) = %0;
-    PopScopeFrame
-    GOTO bb10;
+    c = %21;
+    %23 = a;
+    %24 = println(%23) -> bb10;
   }
   bb10 {
-    b = $desugar$5;
-    $desugar$6 = x;
-    $desugar$7 = y;
-    %23 = ConstantLoad <nil>
-    $desugar$8 = %23;
-    %26 = $desugar$6 is nil
-    %25 = %26;
-    %26 ? bb12 : bb11;
+    %25 = b;
+    %26 = println(%25) -> bb11;
   }
   bb11 {
-    %27 = $desugar$7 is nil
-    %25 = %27;
-    GOTO bb12;
+    %27 = c;
+    %28 = println(%27) -> bb12;
   }
   bb12 {
-    %25 ? bb13 : bb14;
+    %29 = ConstantLoad <nil>
+    i = %29;
+    %31 = ConstantLoad 10
+    j = %31;
+    %33 = i;
+    %34 = %33 is nil
+    %35 = j is nil
+    %36 = || %34 %35;
+    %36 ? bb13 : bb14;
   }
   bb13 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %37 = ConstantLoad <nil>
     GOTO bb15;
   }
   bb14 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$6);
-    %2 = (1, $desugar$7);
-    %0 = unknown %1 %2;
-    (1, $desugar$8) = %0;
-    PopScopeFrame
+    %37 = unknown %33 j;
     GOTO bb15;
   }
   bb15 {
-    c = $desugar$8;
-    %29 = a;
-    %30 = println(%29) -> bb16;
+    a1 = %37;
+    %39 = i;
+    %40 = %39 is nil
+    %41 = y is nil
+    %42 = || %40 %41;
+    %42 ? bb16 : bb17;
   }
   bb16 {
-    %31 = b;
-    %32 = println(%31) -> bb17;
+    %43 = ConstantLoad <nil>
+    GOTO bb18;
   }
   bb17 {
-    %33 = c;
-    %34 = println(%33) -> bb18;
+    %43 = unknown %39 y;
+    GOTO bb18;
   }
   bb18 {
-    %35 = ConstantLoad <nil>
-    i = %35;
-    %37 = ConstantLoad 10
-    j = %37;
-    $desugar$9 = i;
-    $desugar$10 = j;
-    %41 = ConstantLoad <nil>
-    $desugar$11 = %41;
-    %44 = $desugar$9 is nil
-    %43 = %44;
-    %44 ? bb20 : bb19;
+    b1 = %43;
+    %45 = i;
+    %46 = %45 is nil
+    %47 = y is nil
+    %48 = || %46 %47;
+    %48 ? bb19 : bb20;
   }
   bb19 {
-    %45 = $desugar$10 is nil
-    %43 = %45;
-    GOTO bb20;
+    %49 = ConstantLoad <nil>
+    GOTO bb21;
   }
   bb20 {
-    %43 ? bb21 : bb22;
+    %49 = unknown %45 y;
+    GOTO bb21;
   }
   bb21 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb23;
+    c1 = %49;
+    %51 = a1;
+    %52 = println(%51) -> bb22;
   }
   bb22 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$9);
-    %2 = (1, $desugar$10);
-    %0 = unknown %1 %2;
-    (1, $desugar$11) = %0;
-    PopScopeFrame
-    GOTO bb23;
+    %53 = b1;
+    %54 = println(%53) -> bb23;
   }
   bb23 {
-    a1 = $desugar$11;
-    $desugar$12 = i;
-    $desugar$13 = y;
-    %49 = ConstantLoad <nil>
-    $desugar$14 = %49;
-    %52 = $desugar$12 is nil
-    %51 = %52;
-    %52 ? bb25 : bb24;
+    %55 = c1;
+    %56 = println(%55) -> bb24;
   }
   bb24 {
-    %53 = $desugar$13 is nil
-    %51 = %53;
-    GOTO bb25;
-  }
-  bb25 {
-    %51 ? bb26 : bb27;
-  }
-  bb26 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb28;
-  }
-  bb27 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$12);
-    %2 = (1, $desugar$13);
-    %0 = unknown %1 %2;
-    (1, $desugar$14) = %0;
-    PopScopeFrame
-    GOTO bb28;
-  }
-  bb28 {
-    b1 = $desugar$14;
-    $desugar$15 = i;
-    $desugar$16 = y;
-    %57 = ConstantLoad <nil>
-    $desugar$17 = %57;
-    %60 = $desugar$15 is nil
-    %59 = %60;
-    %60 ? bb30 : bb29;
-  }
-  bb29 {
-    %61 = $desugar$16 is nil
-    %59 = %61;
-    GOTO bb30;
-  }
-  bb30 {
-    %59 ? bb31 : bb32;
-  }
-  bb31 {
-    PushScopeFrame 0
-    PopScopeFrame
-    GOTO bb33;
-  }
-  bb32 {
-    PushScopeFrame 3
-    %1 = (1, $desugar$15);
-    %2 = (1, $desugar$16);
-    %0 = unknown %1 %2;
-    (1, $desugar$17) = %0;
-    PopScopeFrame
-    GOTO bb33;
-  }
-  bb33 {
-    c1 = $desugar$17;
-    %63 = a1;
-    %64 = println(%63) -> bb34;
-  }
-  bb34 {
-    %65 = b1;
-    %66 = println(%65) -> bb35;
-  }
-  bb35 {
-    %67 = c1;
-    %68 = println(%67) -> bb36;
-  }
-  bb36 {
     return;
   }
 }

--- a/corpus/bir/subset8/08-nillifting/trap1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/trap1-v.txt
@@ -1,0 +1,124 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 1
+    left = %1;
+    %3 = ConstantLoad 2
+    right = %3;
+    GOTO bb1;
+  }
+  bb1 {
+    %6 = left;
+    %7 = %6 is nil
+    %8 = right is nil
+    %9 = || %7 %8;
+    %9 ? bb2 : bb3;
+  }
+  bb2 {
+    %10 = ConstantLoad <nil>
+    GOTO bb4;
+  }
+  bb3 {
+    %10 = + %6 right;
+    GOTO bb4;
+  }
+  bb4 {
+    %5 = %10;
+    GOTO bb5;
+  }
+  bb5 {
+    sum = %5;
+    %12 = println(sum) -> bb6;
+  }
+  bb6 {
+    GOTO bb7;
+  }
+  bb7 {
+    %14 = left is nil
+    %14 ? bb8 : bb9;
+  }
+  bb8 {
+    %15 = ConstantLoad <nil>
+    GOTO bb10;
+  }
+  bb9 {
+    %15 = unknown left;
+    GOTO bb10;
+  }
+  bb10 {
+    %13 = %15;
+    GOTO bb11;
+  }
+  bb11 {
+    negated = %13;
+    %17 = println(negated) -> bb12;
+  }
+  bb12 {
+    %18 = ConstantLoad <nil>
+    nilValue = %18;
+    GOTO bb13;
+  }
+  bb13 {
+    %21 = left;
+    %22 = %21 is nil
+    %23 = nilValue is nil
+    %24 = || %22 %23;
+    %24 ? bb14 : bb15;
+  }
+  bb14 {
+    %25 = ConstantLoad <nil>
+    GOTO bb16;
+  }
+  bb15 {
+    %25 = + %21 nilValue;
+    GOTO bb16;
+  }
+  bb16 {
+    %20 = %25;
+    GOTO bb17;
+  }
+  bb17 {
+    nilSum = %20;
+    %27 = nilSum is nil
+    %28 = %27;
+    %29 = println(%28) -> bb18;
+  }
+  bb18 {
+    %30 = ConstantLoad 0
+    zero = %30;
+    GOTO bb19;
+  }
+  bb19 {
+    %33 = left;
+    %34 = %33 is nil
+    %35 = zero is nil
+    %36 = || %34 %35;
+    %36 ? bb20 : bb21;
+  }
+  bb20 {
+    %37 = ConstantLoad <nil>
+    GOTO bb22;
+  }
+  bb21 {
+    %37 = / %33 zero;
+    GOTO bb22;
+  }
+  bb22 {
+    %32 = %37;
+    GOTO bb23;
+  }
+  bb23 {
+    divided = %32;
+    %39 = println(divided) -> bb24;
+  }
+  bb24 {
+    return;
+  }
+  
+  error-table {
+    [bb1, bb4] -> bb5, %5
+    [bb7, bb10] -> bb11, %13
+    [bb13, bb16] -> bb17, %20
+    [bb19, bb22] -> bb23, %32
+  }
+}

--- a/corpus/bir/subset8/08-nillifting/trap2-v.txt
+++ b/corpus/bir/subset8/08-nillifting/trap2-v.txt
@@ -1,0 +1,50 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad true
+    b = %1;
+    %3 = ConstantLoad 0
+    zero = %3;
+    GOTO bb1;
+  }
+  bb1 {
+    %6 = b;
+    b ? bb2 : bb3;
+  }
+  bb2 {
+    %9 = value() -> bb4;
+  }
+  bb3 {
+    %5 = %6;
+    GOTO bb5;
+  }
+  bb4 {
+    %10 = %9;
+    %11 = zero;
+    %8 = / %10 %11;
+    %12 = %8;
+    %13 = ConstantLoad 0
+    %14 = %13;
+    %7 = > %12 %14;
+    %6 = %7;
+    GOTO bb3;
+  }
+  bb5 {
+    result = %5;
+    %16 = println(result) -> bb6;
+  }
+  bb6 {
+    return;
+  }
+  
+  error-table {
+    [bb1, bb4] -> bb5, %5
+  }
+}
+value() -> int{
+  bb0 {
+    %1 = ConstantLoad 1
+    %0 = %1;
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-nillifting/unary-1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/unary-1-v.txt
@@ -4,111 +4,83 @@ main() -> nil{
     %1 = ConstantLoad 5
     base = %1;
     a = base;
-    $desugar$0 = base;
-    %5 = ConstantLoad <nil>
-    $desugar$1 = %5;
-    %7 = $desugar$0 is nil
-    %7 ? bb1 : bb2;
+    %4 = base is nil
+    %4 ? bb1 : bb2;
   }
   bb1 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %5 = ConstantLoad <nil>
     GOTO bb3;
   }
   bb2 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$0);
-    (1, $desugar$1) = %0;
-    PopScopeFrame
+    %5 = unknown base;
     GOTO bb3;
   }
   bb3 {
-    c = $desugar$1;
-    $desugar$2 = base;
-    %10 = ConstantLoad <nil>
-    $desugar$3 = %10;
-    %12 = $desugar$2 is nil
-    %12 ? bb4 : bb5;
+    c = %5;
+    %7 = base is nil
+    %7 ? bb4 : bb5;
   }
   bb4 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %8 = ConstantLoad <nil>
     GOTO bb6;
   }
   bb5 {
-    PushScopeFrame 1
-    %0 = ~ (1, $desugar$2);
-    (1, $desugar$3) = %0;
-    PopScopeFrame
+    %8 = ~ base;
     GOTO bb6;
   }
   bb6 {
-    d = $desugar$3;
-    %14 = a;
-    %15 = println(%14) -> bb7;
+    d = %8;
+    %10 = a;
+    %11 = println(%10) -> bb7;
   }
   bb7 {
-    %16 = c;
-    %17 = println(%16) -> bb8;
+    %12 = c;
+    %13 = println(%12) -> bb8;
   }
   bb8 {
-    %18 = d;
-    %19 = println(%18) -> bb9;
+    %14 = d;
+    %15 = println(%14) -> bb9;
   }
   bb9 {
-    %20 = ConstantLoad <nil>
-    base = %20;
+    %16 = ConstantLoad <nil>
+    base = %16;
     x = base;
-    $desugar$4 = base;
-    %23 = ConstantLoad <nil>
-    $desugar$5 = %23;
-    %25 = $desugar$4 is nil
-    %25 ? bb10 : bb11;
+    %18 = base is nil
+    %18 ? bb10 : bb11;
   }
   bb10 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %19 = ConstantLoad <nil>
     GOTO bb12;
   }
   bb11 {
-    PushScopeFrame 1
-    %0 = unknown (1, $desugar$4);
-    (1, $desugar$5) = %0;
-    PopScopeFrame
+    %19 = unknown base;
     GOTO bb12;
   }
   bb12 {
-    y = $desugar$5;
-    $desugar$6 = base;
-    %28 = ConstantLoad <nil>
-    $desugar$7 = %28;
-    %30 = $desugar$6 is nil
-    %30 ? bb13 : bb14;
+    y = %19;
+    %21 = base is nil
+    %21 ? bb13 : bb14;
   }
   bb13 {
-    PushScopeFrame 0
-    PopScopeFrame
+    %22 = ConstantLoad <nil>
     GOTO bb15;
   }
   bb14 {
-    PushScopeFrame 1
-    %0 = ~ (1, $desugar$6);
-    (1, $desugar$7) = %0;
-    PopScopeFrame
+    %22 = ~ base;
     GOTO bb15;
   }
   bb15 {
-    z = $desugar$7;
-    %32 = x;
-    %33 = println(%32) -> bb16;
+    z = %22;
+    %24 = x;
+    %25 = println(%24) -> bb16;
   }
   bb16 {
-    %34 = y;
-    %35 = println(%34) -> bb17;
+    %26 = y;
+    %27 = println(%26) -> bb17;
   }
   bb17 {
-    %36 = z;
-    %37 = println(%36) -> bb18;
+    %28 = z;
+    %29 = println(%28) -> bb18;
   }
   bb18 {
     return;

--- a/corpus/bir/subset8/08-nillifting/while-cond1-v.txt
+++ b/corpus/bir/subset8/08-nillifting/while-cond1-v.txt
@@ -1,0 +1,56 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad 0
+    current = %1;
+    GOTO bb1;
+  }
+  bb1 {
+    %4 = current;
+    %5 = ConstantLoad 1
+    %6 = %4 is nil
+    %6 ? bb2 : bb3;
+  }
+  bb2 {
+    %7 = ConstantLoad <nil>
+    GOTO bb4;
+  }
+  bb3 {
+    %7 = + %4 %5;
+    GOTO bb4;
+  }
+  bb4 {
+    %8 = %7;
+    %9 = ConstantLoad 5
+    %10 = %9;
+    %3 = != %8 %10;
+    %3 ? bb5 : bb6;
+  }
+  bb5 {
+    PushScopeFrame 4
+    %0 = (1, current);
+    %1 = ConstantLoad 1
+    %2 = %0 is nil
+    %2 ? bb7 : bb8;
+  }
+  bb6 {
+    %11 = current;
+    %12 = println(%11) -> bb10;
+  }
+  bb7 {
+    %3 = ConstantLoad <nil>
+    GOTO bb9;
+  }
+  bb8 {
+    %3 = + %0 %1;
+    GOTO bb9;
+  }
+  bb9 {
+    (1, current) = %3;
+    PopScopeFrame
+    GOTO bb1;
+  }
+  bb10 {
+    return;
+  }
+}

--- a/corpus/cfg/subset8/08-nillifting/match-guard1-v.txt
+++ b/corpus/cfg/subset8/08-nillifting/match-guard1-v.txt
@@ -1,0 +1,35 @@
+(guardValue
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (literal guard))))
+    (return
+      (literal 1))
+  )
+)
+(main
+  (bb0 () (bb2 bb3)
+    (var-def
+      (variable value (type
+        (value-type int)) (expr
+        (literal 1))))
+    (var-def
+      (variable n (type
+        (union-type
+          (value-type int)
+          (value-type null))) (expr
+        (literal 0))))
+    (simple-var-ref value)
+  )
+  (bb1 (bb2 bb3) ())
+  (bb2 (bb0) (bb1)
+    (expression-stmt
+      (invocation io println (
+        (literal first))))
+  )
+  (bb3 (bb0) (bb1)
+    (expression-stmt
+      (invocation io println (
+        (literal guarded))))
+  )
+)

--- a/corpus/cfg/subset8/08-nillifting/mutate1-v.txt
+++ b/corpus/cfg/subset8/08-nillifting/mutate1-v.txt
@@ -1,0 +1,32 @@
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (binary-expr +
+          (simple-var-ref number)
+          (invocation mutateNumber ())))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr +
+          (simple-var-ref text)
+          (invocation mutateText ())))))
+  )
+)
+(mutateNumber
+  (bb0 () ()
+    (assignment
+      (simple-var-ref number)
+      (literal 100))
+    (return
+      (literal 1))
+  )
+)
+(mutateText
+  (bb0 () ()
+    (assignment
+      (simple-var-ref text)
+      (literal mutated))
+    (return
+      (literal b))
+  )
+)

--- a/corpus/cfg/subset8/08-nillifting/operand-eval1-v.txt
+++ b/corpus/cfg/subset8/08-nillifting/operand-eval1-v.txt
@@ -1,0 +1,32 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable nilValue (type
+        (union-type
+          (value-type int)
+          (value-type null))) (expr
+        (literal <nil>))))
+    (var-def
+      (variable result (type
+        (union-type
+          (value-type int)
+          (value-type null))) (expr
+        (binary-expr +
+          (invocation sideEffect ())
+          (simple-var-ref nilValue)))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref result)
+          (value-type null)))))
+  )
+)
+(sideEffect
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (literal side-effect))))
+    (return
+      (literal 1))
+  )
+)

--- a/corpus/cfg/subset8/08-nillifting/trap1-v.txt
+++ b/corpus/cfg/subset8/08-nillifting/trap1-v.txt
@@ -1,0 +1,65 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable left (type
+        (union-type
+          (value-type int)
+          (value-type null))) (expr
+        (literal 1))))
+    (var-def
+      (variable right (type
+        (union-type
+          (value-type int)
+          (value-type null))) (expr
+        (literal 2))))
+    (var-def
+      (variable sum (expr
+        (trap-expr
+          (binary-expr +
+            (simple-var-ref left)
+            (simple-var-ref right))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref sum))))
+    (var-def
+      (variable negated (expr
+        (trap-expr
+          (unary-expr -
+            (simple-var-ref left))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref negated))))
+    (var-def
+      (variable nilValue (type
+        (union-type
+          (value-type int)
+          (value-type null))) (expr
+        (literal <nil>))))
+    (var-def
+      (variable nilSum (expr
+        (trap-expr
+          (binary-expr +
+            (simple-var-ref left)
+            (simple-var-ref nilValue))))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref nilSum)
+          (value-type null)))))
+    (var-def
+      (variable zero (type
+        (union-type
+          (value-type int)
+          (value-type null))) (expr
+        (literal 0))))
+    (var-def
+      (variable divided (expr
+        (trap-expr
+          (binary-expr /
+            (simple-var-ref left)
+            (simple-var-ref zero))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref divided))))
+  )
+)

--- a/corpus/cfg/subset8/08-nillifting/trap2-v.txt
+++ b/corpus/cfg/subset8/08-nillifting/trap2-v.txt
@@ -1,0 +1,31 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable b (type
+        (value-type boolean)) (expr
+        (literal true))))
+    (var-def
+      (variable zero (type
+        (value-type int)) (expr
+        (literal 0))))
+    (var-def
+      (variable result (expr
+        (trap-expr
+          (binary-expr &&
+            (simple-var-ref b)
+            (binary-expr >
+              (binary-expr /
+                (invocation value ())
+                (simple-var-ref zero))
+              (literal 0)))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref result))))
+  )
+)
+(value
+  (bb0 () ()
+    (return
+      (literal 1))
+  )
+)

--- a/corpus/cfg/subset8/08-nillifting/while-cond1-v.txt
+++ b/corpus/cfg/subset8/08-nillifting/while-cond1-v.txt
@@ -1,0 +1,29 @@
+(main
+  (bb0 () (bb1)
+    (var-def
+      (variable current (type
+        (union-type
+          (value-type int)
+          (value-type null))) (expr
+        (literal 0))))
+  )
+  (bb1 (bb0 bb2) (bb2 bb3)
+    (binary-expr !=
+      (binary-expr +
+        (simple-var-ref current)
+        (literal 1))
+      (literal 5))
+  )
+  (bb2 (bb1) (bb1)
+    (assignment
+      (simple-var-ref current)
+      (binary-expr +
+        (simple-var-ref current)
+        (literal 1)))
+  )
+  (bb3 (bb1) ()
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref current))))
+  )
+)

--- a/corpus/desugared/subset1/01-int/mul-nil-lift-v.txt
+++ b/corpus/desugared/subset1/01-int/mul-nil-lift-v.txt
@@ -9,22 +9,8 @@
             (value-type int)
             (value-type null))) (expr
           (literal <nil>))))
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$1)
-            (binary-expr *
-              (simple-var-ref $desugar$0)
-              (literal 2))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1)))))))
+          (binary-expr *
+            (simple-var-ref x)
+            (literal 2))))))))

--- a/corpus/desugared/subset1/01-int/sub-nil-lift-v.txt
+++ b/corpus/desugared/subset1/01-int/sub-nil-lift-v.txt
@@ -9,22 +9,8 @@
             (value-type int)
             (value-type null))) (expr
           (literal <nil>))))
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$1)
-            (binary-expr -
-              (simple-var-ref $desugar$0)
-              (literal 1))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1)))))))
+          (binary-expr -
+            (simple-var-ref x)
+            (literal 1))))))))

--- a/corpus/desugared/subset10/10-conditional-expr/desugar-v.txt
+++ b/corpus/desugared/subset10/10-conditional-expr/desugar-v.txt
@@ -27,68 +27,26 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref absent))))
-      (var-def
-        (variable $desugar$1 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$1)
-            (binary-expr +
-              (simple-var-ref $desugar$0)
-              (literal 1))))))
-      (var-def
         (variable liftedLhs (type
           (value-type int)) (expr
           (nil-conditional-expr
             (group-expr
-              (simple-var-ref $desugar$1))
+              (binary-expr +
+                (simple-var-ref absent)
+                (literal 1)))
             (literal 10)))))
-      (var-def
-        (variable $desugar$4 (expr
-          (literal <nil>))))
-      (var-def
-        (variable $desugar$5))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt
-          (var-def
-            (variable $desugar$2 (expr
-              (simple-var-ref absent))))
-          (var-def
-            (variable $desugar$3 (expr
-              (literal <nil>))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$2))
-            (block-stmt) (
-            (block-stmt
-              (assignment
-                (simple-var-ref $desugar$3)
-                (binary-expr +
-                  (simple-var-ref $desugar$2)
-                  (literal 1))))))
-          (assignment
-            (simple-var-ref $desugar$5)
-            (group-expr
-              (nil-conditional-expr
-                (group-expr
-                  (simple-var-ref $desugar$3))
-                (literal 20))))) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (simple-var-ref $desugar$4)))))
       (var-def
         (variable liftedRhs (type
           (value-type int)) (expr
-          (simple-var-ref $desugar$5))))
+          (nil-conditional-expr
+            (literal <nil>)
+            (group-expr
+              (nil-conditional-expr
+                (group-expr
+                  (binary-expr +
+                    (simple-var-ref absent)
+                    (literal 1)))
+                (literal 20)))))))
       (var-def
         (variable present (type
           (union-type
@@ -96,45 +54,17 @@
             (value-type null))) (expr
           (literal 30))))
       (var-def
-        (variable $desugar$8 (expr
-          (simple-var-ref present))))
-      (var-def
-        (variable $desugar$9))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$8))
-        (block-stmt
-          (var-def
-            (variable $desugar$6 (expr
-              (invocation nullable ()))))
-          (var-def
-            (variable $desugar$7 (expr
-              (literal <nil>))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$6))
-            (block-stmt) (
-            (block-stmt
-              (assignment
-                (simple-var-ref $desugar$7)
-                (binary-expr +
-                  (simple-var-ref $desugar$6)
-                  (literal 1))))))
-          (assignment
-            (simple-var-ref $desugar$9)
+        (variable lazyRhs (type
+          (value-type int)) (expr
+          (nil-conditional-expr
+            (simple-var-ref present)
             (group-expr
               (nil-conditional-expr
                 (group-expr
-                  (simple-var-ref $desugar$7))
-                (literal 40))))) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$9)
-            (simple-var-ref $desugar$8)))))
-      (var-def
-        (variable lazyRhs (type
-          (value-type int)) (expr
-          (simple-var-ref $desugar$9))))
+                  (binary-expr +
+                    (invocation nullable ())
+                    (literal 1)))
+                (literal 40)))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref liftedLhs))))

--- a/corpus/desugared/subset10/10-conditional-expr/nil-conditional-v.txt
+++ b/corpus/desugared/subset10/10-conditional-expr/nil-conditional-v.txt
@@ -161,45 +161,17 @@
               (literal 10)))
             (invocation rhs ())))))
       (var-def
-        (variable $desugar$2 (expr
-          (invocation lhs (
-            (literal 30))))))
-      (var-def
-        (variable $desugar$3))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt
-          (var-def
-            (variable $desugar$0 (expr
-              (invocation lhs (
-                (literal 40))))))
-          (var-def
-            (variable $desugar$1 (expr
-              (literal <nil>))))
-          (if
-            (type-test-expr is
-              (simple-var-ref $desugar$0))
-            (block-stmt) (
-            (block-stmt
-              (assignment
-                (simple-var-ref $desugar$1)
-                (binary-expr +
-                  (simple-var-ref $desugar$0)
-                  (literal 1))))))
-          (assignment
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$1))) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$3)
-            (simple-var-ref $desugar$2)))))
-      (var-def
         (variable nonNilComposite (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$3))))
+          (nil-conditional-expr
+            (invocation lhs (
+              (literal 30)))
+            (binary-expr +
+              (invocation lhs (
+                (literal 40)))
+              (literal 1))))))
       (var-def
         (variable fallback (type
           (value-type int)) (expr

--- a/corpus/desugared/subset2/02-bitwise/and-nil-lift-v.txt
+++ b/corpus/desugared/subset2/02-bitwise/and-nil-lift-v.txt
@@ -9,22 +9,8 @@
             (value-type int)
             (value-type null))) (expr
           (literal <nil>))))
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$1)
-            (binary-expr &
-              (simple-var-ref $desugar$0)
-              (literal 1))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$1)))))))
+          (binary-expr &
+            (simple-var-ref x)
+            (literal 1))))))))

--- a/corpus/desugared/subset8/08-nillifting/1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/1-v.txt
@@ -22,429 +22,119 @@
             (value-type null))) (expr
           (literal 1))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr +
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
         (variable v1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$2))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref b)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v1))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr +
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr +
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
-      (var-def
-        (variable $desugar$9 (expr
-          (simple-var-ref $desugar$8))))
-      (var-def
-        (variable $desugar$10 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr +
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref b)))))
       (var-def
         (variable v2 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$11))))
+          (binary-expr +
+            (binary-expr +
+              (simple-var-ref a)
+              (simple-var-ref b))
+            (simple-var-ref c)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v2))))
-      (var-def
-        (variable $desugar$12 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$13 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$12))
-          (type-test-expr is
-            (simple-var-ref $desugar$13)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$14)
-            (binary-expr +
-              (simple-var-ref $desugar$12)
-              (simple-var-ref $desugar$13))))))
-      (var-def
-        (variable $desugar$15 (expr
-          (simple-var-ref $desugar$14))))
-      (var-def
-        (variable $desugar$16 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$17 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$15))
-          (type-test-expr is
-            (simple-var-ref $desugar$16)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$17)
-            (binary-expr +
-              (simple-var-ref $desugar$15)
-              (simple-var-ref $desugar$16))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$17))))
-      (var-def
-        (variable $desugar$18 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$19 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$20 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$18))
-          (type-test-expr is
-            (simple-var-ref $desugar$19)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$20)
-            (binary-expr -
-              (simple-var-ref $desugar$18)
-              (simple-var-ref $desugar$19))))))
+          (binary-expr +
+            (binary-expr +
+              (simple-var-ref a)
+              (simple-var-ref b))
+            (simple-var-ref c)))))
       (var-def
         (variable v3 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$20))))
+          (binary-expr -
+            (simple-var-ref a)
+            (simple-var-ref b)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v3))))
-      (var-def
-        (variable $desugar$21 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$22 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$23 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$21))
-          (type-test-expr is
-            (simple-var-ref $desugar$22)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$23)
-            (binary-expr +
-              (simple-var-ref $desugar$21)
-              (simple-var-ref $desugar$22))))))
-      (var-def
-        (variable $desugar$24 (expr
-          (simple-var-ref $desugar$23))))
-      (var-def
-        (variable $desugar$25 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$26 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$24))
-          (type-test-expr is
-            (simple-var-ref $desugar$25)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$26)
-            (binary-expr -
-              (simple-var-ref $desugar$24)
-              (simple-var-ref $desugar$25))))))
       (var-def
         (variable v4 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$26))))
+          (binary-expr -
+            (binary-expr +
+              (simple-var-ref a)
+              (simple-var-ref b))
+            (simple-var-ref c)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v4))))
-      (var-def
-        (variable $desugar$27 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$28 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$29 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$27))
-          (type-test-expr is
-            (simple-var-ref $desugar$28)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$29)
-            (binary-expr /
-              (simple-var-ref $desugar$27)
-              (simple-var-ref $desugar$28))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$29))))
-      (var-def
-        (variable $desugar$30 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$31 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$31)
-            (binary-expr /
-              (simple-var-ref $desugar$30)
-              (literal 3))))))
+          (binary-expr /
+            (simple-var-ref b)
+            (simple-var-ref c)))))
       (var-def
         (variable v5 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$31))))
+          (binary-expr /
+            (simple-var-ref b)
+            (literal 3)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v5))))
-      (var-def
-        (variable $desugar$32 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$33 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$32))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$33)
-            (unary-expr -
-              (simple-var-ref $desugar$32))))))
       (var-def
         (variable v6 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$33))))
+          (unary-expr -
+            (simple-var-ref a)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v6))))
-      (var-def
-        (variable $desugar$34 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$35 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$34))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$35)
-            (unary-expr -
-              (simple-var-ref $desugar$34))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$35))))
+          (unary-expr -
+            (simple-var-ref c)))))
       (var-def
         (variable d (type
           (value-type int)) (expr
           (literal 13))))
       (var-def
-        (variable $desugar$36 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$37 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$36))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$37)
-            (binary-expr +
-              (simple-var-ref $desugar$36)
-              (simple-var-ref d))))))
-      (var-def
         (variable v7 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$37))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref d)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v7))))
-      (var-def
-        (variable $desugar$38 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$39 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$40 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$38))
-          (type-test-expr is
-            (simple-var-ref $desugar$39)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$40)
-            (binary-expr +
-              (simple-var-ref $desugar$38)
-              (simple-var-ref $desugar$39))))))
-      (var-def
-        (variable $desugar$41 (expr
-          (simple-var-ref $desugar$40))))
-      (var-def
-        (variable $desugar$42 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$43 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$41))
-          (type-test-expr is
-            (simple-var-ref $desugar$42)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$43)
-            (binary-expr +
-              (simple-var-ref $desugar$41)
-              (simple-var-ref $desugar$42))))))
-      (var-def
-        (variable $desugar$44 (expr
-          (simple-var-ref $desugar$43))))
-      (var-def
-        (variable $desugar$45 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$44))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$45)
-            (binary-expr +
-              (simple-var-ref $desugar$44)
-              (simple-var-ref d))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$45))))
+          (binary-expr +
+            (binary-expr +
+              (binary-expr +
+                (simple-var-ref a)
+                (simple-var-ref b))
+              (simple-var-ref c))
+            (simple-var-ref d)))))
       (var-def
         (variable e (type
           (union-type
@@ -452,136 +142,28 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$46 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$47 (expr
-          (simple-var-ref e))))
-      (var-def
-        (variable $desugar$48 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$46))
-          (type-test-expr is
-            (simple-var-ref $desugar$47)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$48)
-            (binary-expr +
-              (simple-var-ref $desugar$46)
-              (simple-var-ref $desugar$47))))))
-      (var-def
         (variable v8 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$48))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref e)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v8))))
-      (var-def
-        (variable $desugar$49 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$50 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$51 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$49))
-          (type-test-expr is
-            (simple-var-ref $desugar$50)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$51)
-            (binary-expr +
-              (simple-var-ref $desugar$49)
-              (simple-var-ref $desugar$50))))))
-      (var-def
-        (variable $desugar$52 (expr
-          (simple-var-ref $desugar$51))))
-      (var-def
-        (variable $desugar$53 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$54 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$52))
-          (type-test-expr is
-            (simple-var-ref $desugar$53)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$54)
-            (binary-expr +
-              (simple-var-ref $desugar$52)
-              (simple-var-ref $desugar$53))))))
-      (var-def
-        (variable $desugar$55 (expr
-          (simple-var-ref $desugar$54))))
-      (var-def
-        (variable $desugar$56 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$55))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$56)
-            (binary-expr +
-              (simple-var-ref $desugar$55)
-              (simple-var-ref d))))))
-      (var-def
-        (variable $desugar$57 (expr
-          (simple-var-ref $desugar$56))))
-      (var-def
-        (variable $desugar$58 (expr
-          (simple-var-ref e))))
-      (var-def
-        (variable $desugar$59 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$57))
-          (type-test-expr is
-            (simple-var-ref $desugar$58)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$59)
-            (binary-expr +
-              (simple-var-ref $desugar$57)
-              (simple-var-ref $desugar$58))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$59))))
-      (var-def
-        (variable $desugar$60 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$61 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$60))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$61)
-            (unary-expr -
-              (simple-var-ref $desugar$60))))))
+          (binary-expr +
+            (binary-expr +
+              (binary-expr +
+                (binary-expr +
+                  (simple-var-ref a)
+                  (simple-var-ref b))
+                (simple-var-ref c))
+              (simple-var-ref d))
+            (simple-var-ref e)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$61)))))))
+          (unary-expr -
+            (simple-var-ref a))))))))

--- a/corpus/desugared/subset8/08-nillifting/2-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/2-v.txt
@@ -22,429 +22,119 @@
             (value-type null))) (expr
           (literal 1))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr +
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
         (variable v1 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$2))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref b)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v1))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr +
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr +
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
-      (var-def
-        (variable $desugar$9 (expr
-          (simple-var-ref $desugar$8))))
-      (var-def
-        (variable $desugar$10 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr +
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref b)))))
       (var-def
         (variable v2 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$11))))
+          (binary-expr +
+            (binary-expr +
+              (simple-var-ref a)
+              (simple-var-ref b))
+            (simple-var-ref c)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v2))))
-      (var-def
-        (variable $desugar$12 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$13 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$12))
-          (type-test-expr is
-            (simple-var-ref $desugar$13)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$14)
-            (binary-expr +
-              (simple-var-ref $desugar$12)
-              (simple-var-ref $desugar$13))))))
-      (var-def
-        (variable $desugar$15 (expr
-          (simple-var-ref $desugar$14))))
-      (var-def
-        (variable $desugar$16 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$17 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$15))
-          (type-test-expr is
-            (simple-var-ref $desugar$16)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$17)
-            (binary-expr +
-              (simple-var-ref $desugar$15)
-              (simple-var-ref $desugar$16))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$17))))
-      (var-def
-        (variable $desugar$18 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$19 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$20 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$18))
-          (type-test-expr is
-            (simple-var-ref $desugar$19)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$20)
-            (binary-expr -
-              (simple-var-ref $desugar$18)
-              (simple-var-ref $desugar$19))))))
+          (binary-expr +
+            (binary-expr +
+              (simple-var-ref a)
+              (simple-var-ref b))
+            (simple-var-ref c)))))
       (var-def
         (variable v3 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$20))))
+          (binary-expr -
+            (simple-var-ref a)
+            (simple-var-ref b)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v3))))
-      (var-def
-        (variable $desugar$21 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$22 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$23 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$21))
-          (type-test-expr is
-            (simple-var-ref $desugar$22)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$23)
-            (binary-expr +
-              (simple-var-ref $desugar$21)
-              (simple-var-ref $desugar$22))))))
-      (var-def
-        (variable $desugar$24 (expr
-          (simple-var-ref $desugar$23))))
-      (var-def
-        (variable $desugar$25 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$26 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$24))
-          (type-test-expr is
-            (simple-var-ref $desugar$25)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$26)
-            (binary-expr -
-              (simple-var-ref $desugar$24)
-              (simple-var-ref $desugar$25))))))
       (var-def
         (variable v4 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$26))))
+          (binary-expr -
+            (binary-expr +
+              (simple-var-ref a)
+              (simple-var-ref b))
+            (simple-var-ref c)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v4))))
-      (var-def
-        (variable $desugar$27 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$28 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$29 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$27))
-          (type-test-expr is
-            (simple-var-ref $desugar$28)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$29)
-            (binary-expr /
-              (simple-var-ref $desugar$27)
-              (simple-var-ref $desugar$28))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$29))))
-      (var-def
-        (variable $desugar$30 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$31 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$30))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$31)
-            (binary-expr /
-              (simple-var-ref $desugar$30)
-              (literal 3))))))
+          (binary-expr /
+            (simple-var-ref b)
+            (simple-var-ref c)))))
       (var-def
         (variable v5 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$31))))
+          (binary-expr /
+            (simple-var-ref b)
+            (literal 3)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v5))))
-      (var-def
-        (variable $desugar$32 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$33 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$32))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$33)
-            (unary-expr -
-              (simple-var-ref $desugar$32))))))
       (var-def
         (variable v6 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$33))))
+          (unary-expr -
+            (simple-var-ref a)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v6))))
-      (var-def
-        (variable $desugar$34 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$35 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$34))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$35)
-            (unary-expr -
-              (simple-var-ref $desugar$34))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$35))))
+          (unary-expr -
+            (simple-var-ref c)))))
       (var-def
         (variable d (type
           (value-type float)) (expr
           (literal 13))))
       (var-def
-        (variable $desugar$36 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$37 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$36))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$37)
-            (binary-expr +
-              (simple-var-ref $desugar$36)
-              (simple-var-ref d))))))
-      (var-def
         (variable v7 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$37))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref d)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v7))))
-      (var-def
-        (variable $desugar$38 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$39 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$40 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$38))
-          (type-test-expr is
-            (simple-var-ref $desugar$39)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$40)
-            (binary-expr +
-              (simple-var-ref $desugar$38)
-              (simple-var-ref $desugar$39))))))
-      (var-def
-        (variable $desugar$41 (expr
-          (simple-var-ref $desugar$40))))
-      (var-def
-        (variable $desugar$42 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$43 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$41))
-          (type-test-expr is
-            (simple-var-ref $desugar$42)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$43)
-            (binary-expr +
-              (simple-var-ref $desugar$41)
-              (simple-var-ref $desugar$42))))))
-      (var-def
-        (variable $desugar$44 (expr
-          (simple-var-ref $desugar$43))))
-      (var-def
-        (variable $desugar$45 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$44))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$45)
-            (binary-expr +
-              (simple-var-ref $desugar$44)
-              (simple-var-ref d))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$45))))
+          (binary-expr +
+            (binary-expr +
+              (binary-expr +
+                (simple-var-ref a)
+                (simple-var-ref b))
+              (simple-var-ref c))
+            (simple-var-ref d)))))
       (var-def
         (variable e (type
           (union-type
@@ -452,136 +142,28 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$46 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$47 (expr
-          (simple-var-ref e))))
-      (var-def
-        (variable $desugar$48 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$46))
-          (type-test-expr is
-            (simple-var-ref $desugar$47)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$48)
-            (binary-expr +
-              (simple-var-ref $desugar$46)
-              (simple-var-ref $desugar$47))))))
-      (var-def
         (variable v8 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$48))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref e)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v8))))
-      (var-def
-        (variable $desugar$49 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$50 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$51 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$49))
-          (type-test-expr is
-            (simple-var-ref $desugar$50)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$51)
-            (binary-expr +
-              (simple-var-ref $desugar$49)
-              (simple-var-ref $desugar$50))))))
-      (var-def
-        (variable $desugar$52 (expr
-          (simple-var-ref $desugar$51))))
-      (var-def
-        (variable $desugar$53 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$54 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$52))
-          (type-test-expr is
-            (simple-var-ref $desugar$53)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$54)
-            (binary-expr +
-              (simple-var-ref $desugar$52)
-              (simple-var-ref $desugar$53))))))
-      (var-def
-        (variable $desugar$55 (expr
-          (simple-var-ref $desugar$54))))
-      (var-def
-        (variable $desugar$56 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$55))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$56)
-            (binary-expr +
-              (simple-var-ref $desugar$55)
-              (simple-var-ref d))))))
-      (var-def
-        (variable $desugar$57 (expr
-          (simple-var-ref $desugar$56))))
-      (var-def
-        (variable $desugar$58 (expr
-          (simple-var-ref e))))
-      (var-def
-        (variable $desugar$59 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$57))
-          (type-test-expr is
-            (simple-var-ref $desugar$58)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$59)
-            (binary-expr +
-              (simple-var-ref $desugar$57)
-              (simple-var-ref $desugar$58))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$59))))
-      (var-def
-        (variable $desugar$60 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$61 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$60))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$61)
-            (unary-expr -
-              (simple-var-ref $desugar$60))))))
+          (binary-expr +
+            (binary-expr +
+              (binary-expr +
+                (binary-expr +
+                  (simple-var-ref a)
+                  (simple-var-ref b))
+                (simple-var-ref c))
+              (simple-var-ref d))
+            (simple-var-ref e)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$61)))))))
+          (unary-expr -
+            (simple-var-ref a))))))))

--- a/corpus/desugared/subset8/08-nillifting/3-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/3-v.txt
@@ -22,83 +22,23 @@
             (value-type null))) (expr
           (literal 1))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr |
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
         (variable v1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$2))))
+          (binary-expr |
+            (simple-var-ref a)
+            (simple-var-ref b)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v1))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr |
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr |
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$8))))
+          (binary-expr |
+            (binary-expr |
+              (simple-var-ref a)
+              (simple-var-ref b))
+            (simple-var-ref c)))))
       (var-def
         (variable d (type
           (union-type
@@ -106,133 +46,33 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$9 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$10 (expr
-          (simple-var-ref d))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr |
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
-      (var-def
         (variable v2 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$11))))
+          (binary-expr |
+            (simple-var-ref a)
+            (simple-var-ref d)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v2))))
-      (var-def
-        (variable $desugar$12 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$13 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$12))
-          (type-test-expr is
-            (simple-var-ref $desugar$13)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$14)
-            (binary-expr |
-              (simple-var-ref $desugar$12)
-              (simple-var-ref $desugar$13))))))
-      (var-def
-        (variable $desugar$15 (expr
-          (simple-var-ref $desugar$14))))
-      (var-def
-        (variable $desugar$16 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$17 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$15))
-          (type-test-expr is
-            (simple-var-ref $desugar$16)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$17)
-            (binary-expr |
-              (simple-var-ref $desugar$15)
-              (simple-var-ref $desugar$16))))))
-      (var-def
-        (variable $desugar$18 (expr
-          (simple-var-ref $desugar$17))))
-      (var-def
-        (variable $desugar$19 (expr
-          (simple-var-ref d))))
-      (var-def
-        (variable $desugar$20 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$18))
-          (type-test-expr is
-            (simple-var-ref $desugar$19)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$20)
-            (binary-expr |
-              (simple-var-ref $desugar$18)
-              (simple-var-ref $desugar$19))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$22 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$23 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$21))
-          (type-test-expr is
-            (simple-var-ref $desugar$22)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$23)
-            (binary-expr <<
-              (simple-var-ref $desugar$21)
-              (simple-var-ref $desugar$22))))))
+          (binary-expr |
+            (binary-expr |
+              (binary-expr |
+                (simple-var-ref a)
+                (simple-var-ref b))
+              (simple-var-ref c))
+            (simple-var-ref d)))))
       (var-def
         (variable v3 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$23))))
+          (binary-expr <<
+            (simple-var-ref c)
+            (simple-var-ref b)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v3)))))))

--- a/corpus/desugared/subset8/08-nillifting/4-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/4-v.txt
@@ -16,55 +16,15 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr +
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$4 (expr
-          (invocation c ()))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr +
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
-      (var-def
         (variable d (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$5))))
+          (binary-expr +
+            (binary-expr +
+              (simple-var-ref a)
+              (simple-var-ref b))
+            (invocation c ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref d))))
@@ -79,49 +39,15 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref f))))
-      (var-def
-        (variable $desugar$7 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$7)
-            (binary-expr +
-              (simple-var-ref e)
-              (simple-var-ref $desugar$6))))))
-      (var-def
-        (variable $desugar$8 (expr
-          (simple-var-ref $desugar$7))))
-      (var-def
-        (variable $desugar$9 (expr
-          (invocation g ()))))
-      (var-def
-        (variable $desugar$10 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$8))
-          (type-test-expr is
-            (simple-var-ref $desugar$9)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$10)
-            (binary-expr +
-              (simple-var-ref $desugar$8)
-              (simple-var-ref $desugar$9))))))
-      (var-def
         (variable h (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$10))))
+          (binary-expr +
+            (binary-expr +
+              (simple-var-ref e)
+              (simple-var-ref f))
+            (invocation g ())))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref h))))))

--- a/corpus/desugared/subset8/08-nillifting/5-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/5-v.txt
@@ -16,33 +16,13 @@
             (value-type null))) (expr
           (literal b))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref a))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref b))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr +
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
         (variable c (type
           (union-type
             (value-type string)
             (value-type null))) (expr
-          (simple-var-ref $desugar$2))))
+          (binary-expr +
+            (simple-var-ref a)
+            (simple-var-ref b)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref c))))
@@ -52,28 +32,8 @@
             (value-type string)
             (value-type null))) (expr
           (literal <nil>))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref c))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref d))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr +
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$5)))))))
+          (binary-expr +
+            (simple-var-ref c)
+            (simple-var-ref d))))))))

--- a/corpus/desugared/subset8/08-nillifting/8-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/8-v.txt
@@ -24,372 +24,122 @@
           (simple-var-ref m)
           (literal c))
         (literal 1))
-      (var-def
-        (variable $desugar$0 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$1 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
+      (expression-stmt
+        (invocation io println (
+          (binary-expr +
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))
+            (index-based-access
+              (simple-var-ref m)
+              (literal b))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr +
             (binary-expr +
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
+              (index-based-access
+                (simple-var-ref m)
+                (literal a))
+              (index-based-access
+                (simple-var-ref m)
+                (literal b)))
+            (index-based-access
+              (simple-var-ref m)
+              (literal c))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$4 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
+          (binary-expr -
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))
+            (index-based-access
+              (simple-var-ref m)
+              (literal b))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr -
             (binary-expr +
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$7 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr +
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
+              (index-based-access
+                (simple-var-ref m)
+                (literal a))
+              (index-based-access
+                (simple-var-ref m)
+                (literal b)))
+            (index-based-access
+              (simple-var-ref m)
+              (literal c))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$8))))
-      (var-def
-        (variable $desugar$9 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$10 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr -
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$11))))
-      (var-def
-        (variable $desugar$12 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$13 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$12))
-          (type-test-expr is
-            (simple-var-ref $desugar$13)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$14)
-            (binary-expr +
-              (simple-var-ref $desugar$12)
-              (simple-var-ref $desugar$13))))))
-      (var-def
-        (variable $desugar$15 (expr
-          (simple-var-ref $desugar$14))))
-      (var-def
-        (variable $desugar$16 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$17 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$15))
-          (type-test-expr is
-            (simple-var-ref $desugar$16)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$17)
-            (binary-expr -
-              (simple-var-ref $desugar$15)
-              (simple-var-ref $desugar$16))))))
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$17))))
-      (var-def
-        (variable $desugar$18 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$19 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$20 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$18))
-          (type-test-expr is
-            (simple-var-ref $desugar$19)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$20)
-            (binary-expr /
-              (simple-var-ref $desugar$18)
-              (simple-var-ref $desugar$19))))))
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$22 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$22)
-            (binary-expr /
-              (simple-var-ref $desugar$21)
-              (literal 3))))))
+          (binary-expr /
+            (index-based-access
+              (simple-var-ref m)
+              (literal b))
+            (index-based-access
+              (simple-var-ref m)
+              (literal c))))))
       (var-def
         (variable v5 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$22))))
+          (binary-expr /
+            (index-based-access
+              (simple-var-ref m)
+              (literal b))
+            (literal 3)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v5))))
-      (var-def
-        (variable $desugar$23 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$24 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$24)
-            (unary-expr -
-              (simple-var-ref $desugar$23))))))
       (var-def
         (variable v6 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$24))))
+          (unary-expr -
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v6))))
-      (var-def
-        (variable $desugar$25 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$26 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$25))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$26)
-            (unary-expr -
-              (simple-var-ref $desugar$25))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$26))))
+          (unary-expr -
+            (index-based-access
+              (simple-var-ref m)
+              (literal c))))))
       (var-def
         (variable d (type
           (value-type int)) (expr
           (literal 13))))
       (var-def
-        (variable $desugar$27 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$28 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$28)
-            (binary-expr +
-              (simple-var-ref $desugar$27)
-              (simple-var-ref d))))))
-      (var-def
         (variable v7 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$28))))
+          (binary-expr +
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))
+            (simple-var-ref d)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v7))))
-      (var-def
-        (variable $desugar$29 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$30 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$31 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$29))
-          (type-test-expr is
-            (simple-var-ref $desugar$30)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$31)
-            (binary-expr +
-              (simple-var-ref $desugar$29)
-              (simple-var-ref $desugar$30))))))
-      (var-def
-        (variable $desugar$32 (expr
-          (simple-var-ref $desugar$31))))
-      (var-def
-        (variable $desugar$33 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$34 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$32))
-          (type-test-expr is
-            (simple-var-ref $desugar$33)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$34)
-            (binary-expr +
-              (simple-var-ref $desugar$32)
-              (simple-var-ref $desugar$33))))))
-      (var-def
-        (variable $desugar$35 (expr
-          (simple-var-ref $desugar$34))))
-      (var-def
-        (variable $desugar$36 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$35))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$36)
-            (binary-expr +
-              (simple-var-ref $desugar$35)
-              (simple-var-ref d))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$36))))
+          (binary-expr +
+            (binary-expr +
+              (binary-expr +
+                (index-based-access
+                  (simple-var-ref m)
+                  (literal a))
+                (index-based-access
+                  (simple-var-ref m)
+                  (literal b)))
+              (index-based-access
+                (simple-var-ref m)
+                (literal c)))
+            (simple-var-ref d)))))
       (var-def
         (variable e (type
           (union-type
@@ -397,146 +147,38 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$37 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$38 (expr
-          (simple-var-ref e))))
-      (var-def
-        (variable $desugar$39 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$37))
-          (type-test-expr is
-            (simple-var-ref $desugar$38)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$39)
-            (binary-expr +
-              (simple-var-ref $desugar$37)
-              (simple-var-ref $desugar$38))))))
-      (var-def
         (variable v8 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$39))))
+          (binary-expr +
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))
+            (simple-var-ref e)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v8))))
-      (var-def
-        (variable $desugar$40 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$41 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$42 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$40))
-          (type-test-expr is
-            (simple-var-ref $desugar$41)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$42)
-            (binary-expr +
-              (simple-var-ref $desugar$40)
-              (simple-var-ref $desugar$41))))))
-      (var-def
-        (variable $desugar$43 (expr
-          (simple-var-ref $desugar$42))))
-      (var-def
-        (variable $desugar$44 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$45 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$43))
-          (type-test-expr is
-            (simple-var-ref $desugar$44)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$45)
-            (binary-expr +
-              (simple-var-ref $desugar$43)
-              (simple-var-ref $desugar$44))))))
-      (var-def
-        (variable $desugar$46 (expr
-          (simple-var-ref $desugar$45))))
-      (var-def
-        (variable $desugar$47 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$46))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$47)
-            (binary-expr +
-              (simple-var-ref $desugar$46)
-              (simple-var-ref d))))))
-      (var-def
-        (variable $desugar$48 (expr
-          (simple-var-ref $desugar$47))))
-      (var-def
-        (variable $desugar$49 (expr
-          (simple-var-ref e))))
-      (var-def
-        (variable $desugar$50 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$48))
-          (type-test-expr is
-            (simple-var-ref $desugar$49)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$50)
-            (binary-expr +
-              (simple-var-ref $desugar$48)
-              (simple-var-ref $desugar$49))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$50))))
-      (var-def
-        (variable $desugar$51 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$52 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$51))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$52)
-            (unary-expr -
-              (simple-var-ref $desugar$51))))))
+          (binary-expr +
+            (binary-expr +
+              (binary-expr +
+                (binary-expr +
+                  (index-based-access
+                    (simple-var-ref m)
+                    (literal a))
+                  (index-based-access
+                    (simple-var-ref m)
+                    (literal b)))
+                (index-based-access
+                  (simple-var-ref m)
+                  (literal c)))
+              (simple-var-ref d))
+            (simple-var-ref e)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$52)))))))
+          (unary-expr -
+            (index-based-access
+              (simple-var-ref m)
+              (literal a)))))))))

--- a/corpus/desugared/subset8/08-nillifting/9-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/9-v.txt
@@ -24,372 +24,122 @@
           (simple-var-ref m)
           (literal c))
         (literal 1))
-      (var-def
-        (variable $desugar$0 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$1 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
+      (expression-stmt
+        (invocation io println (
+          (binary-expr +
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))
+            (index-based-access
+              (simple-var-ref m)
+              (literal b))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr +
             (binary-expr +
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
+              (index-based-access
+                (simple-var-ref m)
+                (literal a))
+              (index-based-access
+                (simple-var-ref m)
+                (literal b)))
+            (index-based-access
+              (simple-var-ref m)
+              (literal c))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$4 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
+          (binary-expr -
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))
+            (index-based-access
+              (simple-var-ref m)
+              (literal b))))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr -
             (binary-expr +
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$7 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr +
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
+              (index-based-access
+                (simple-var-ref m)
+                (literal a))
+              (index-based-access
+                (simple-var-ref m)
+                (literal b)))
+            (index-based-access
+              (simple-var-ref m)
+              (literal c))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$8))))
-      (var-def
-        (variable $desugar$9 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$10 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr -
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$11))))
-      (var-def
-        (variable $desugar$12 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$13 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$12))
-          (type-test-expr is
-            (simple-var-ref $desugar$13)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$14)
-            (binary-expr +
-              (simple-var-ref $desugar$12)
-              (simple-var-ref $desugar$13))))))
-      (var-def
-        (variable $desugar$15 (expr
-          (simple-var-ref $desugar$14))))
-      (var-def
-        (variable $desugar$16 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$17 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$15))
-          (type-test-expr is
-            (simple-var-ref $desugar$16)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$17)
-            (binary-expr -
-              (simple-var-ref $desugar$15)
-              (simple-var-ref $desugar$16))))))
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$17))))
-      (var-def
-        (variable $desugar$18 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$19 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$20 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$18))
-          (type-test-expr is
-            (simple-var-ref $desugar$19)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$20)
-            (binary-expr /
-              (simple-var-ref $desugar$18)
-              (simple-var-ref $desugar$19))))))
-      (expression-stmt
-        (invocation io println (
-          (simple-var-ref $desugar$20))))
-      (var-def
-        (variable $desugar$21 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$22 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$21))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$22)
-            (binary-expr /
-              (simple-var-ref $desugar$21)
-              (literal 3))))))
+          (binary-expr /
+            (index-based-access
+              (simple-var-ref m)
+              (literal b))
+            (index-based-access
+              (simple-var-ref m)
+              (literal c))))))
       (var-def
         (variable v5 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$22))))
+          (binary-expr /
+            (index-based-access
+              (simple-var-ref m)
+              (literal b))
+            (literal 3)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v5))))
-      (var-def
-        (variable $desugar$23 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$24 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$23))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$24)
-            (unary-expr -
-              (simple-var-ref $desugar$23))))))
       (var-def
         (variable v6 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$24))))
+          (unary-expr -
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v6))))
-      (var-def
-        (variable $desugar$25 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$26 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$25))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$26)
-            (unary-expr -
-              (simple-var-ref $desugar$25))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$26))))
+          (unary-expr -
+            (index-based-access
+              (simple-var-ref m)
+              (literal c))))))
       (var-def
         (variable d (type
           (value-type float)) (expr
           (literal 13))))
       (var-def
-        (variable $desugar$27 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$28 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$27))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$28)
-            (binary-expr +
-              (simple-var-ref $desugar$27)
-              (simple-var-ref d))))))
-      (var-def
         (variable v7 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$28))))
+          (binary-expr +
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))
+            (simple-var-ref d)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v7))))
-      (var-def
-        (variable $desugar$29 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$30 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$31 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$29))
-          (type-test-expr is
-            (simple-var-ref $desugar$30)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$31)
-            (binary-expr +
-              (simple-var-ref $desugar$29)
-              (simple-var-ref $desugar$30))))))
-      (var-def
-        (variable $desugar$32 (expr
-          (simple-var-ref $desugar$31))))
-      (var-def
-        (variable $desugar$33 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$34 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$32))
-          (type-test-expr is
-            (simple-var-ref $desugar$33)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$34)
-            (binary-expr +
-              (simple-var-ref $desugar$32)
-              (simple-var-ref $desugar$33))))))
-      (var-def
-        (variable $desugar$35 (expr
-          (simple-var-ref $desugar$34))))
-      (var-def
-        (variable $desugar$36 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$35))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$36)
-            (binary-expr +
-              (simple-var-ref $desugar$35)
-              (simple-var-ref d))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$36))))
+          (binary-expr +
+            (binary-expr +
+              (binary-expr +
+                (index-based-access
+                  (simple-var-ref m)
+                  (literal a))
+                (index-based-access
+                  (simple-var-ref m)
+                  (literal b)))
+              (index-based-access
+                (simple-var-ref m)
+                (literal c)))
+            (simple-var-ref d)))))
       (var-def
         (variable e (type
           (union-type
@@ -397,146 +147,38 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$37 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$38 (expr
-          (simple-var-ref e))))
-      (var-def
-        (variable $desugar$39 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$37))
-          (type-test-expr is
-            (simple-var-ref $desugar$38)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$39)
-            (binary-expr +
-              (simple-var-ref $desugar$37)
-              (simple-var-ref $desugar$38))))))
-      (var-def
         (variable v8 (type
           (union-type
             (value-type float)
             (value-type null))) (expr
-          (simple-var-ref $desugar$39))))
+          (binary-expr +
+            (index-based-access
+              (simple-var-ref m)
+              (literal a))
+            (simple-var-ref e)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref v8))))
-      (var-def
-        (variable $desugar$40 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$41 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal b)))))
-      (var-def
-        (variable $desugar$42 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$40))
-          (type-test-expr is
-            (simple-var-ref $desugar$41)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$42)
-            (binary-expr +
-              (simple-var-ref $desugar$40)
-              (simple-var-ref $desugar$41))))))
-      (var-def
-        (variable $desugar$43 (expr
-          (simple-var-ref $desugar$42))))
-      (var-def
-        (variable $desugar$44 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal c)))))
-      (var-def
-        (variable $desugar$45 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$43))
-          (type-test-expr is
-            (simple-var-ref $desugar$44)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$45)
-            (binary-expr +
-              (simple-var-ref $desugar$43)
-              (simple-var-ref $desugar$44))))))
-      (var-def
-        (variable $desugar$46 (expr
-          (simple-var-ref $desugar$45))))
-      (var-def
-        (variable $desugar$47 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$46))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$47)
-            (binary-expr +
-              (simple-var-ref $desugar$46)
-              (simple-var-ref d))))))
-      (var-def
-        (variable $desugar$48 (expr
-          (simple-var-ref $desugar$47))))
-      (var-def
-        (variable $desugar$49 (expr
-          (simple-var-ref e))))
-      (var-def
-        (variable $desugar$50 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$48))
-          (type-test-expr is
-            (simple-var-ref $desugar$49)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$50)
-            (binary-expr +
-              (simple-var-ref $desugar$48)
-              (simple-var-ref $desugar$49))))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$50))))
-      (var-def
-        (variable $desugar$51 (expr
-          (index-based-access
-            (simple-var-ref m)
-            (literal a)))))
-      (var-def
-        (variable $desugar$52 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$51))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$52)
-            (unary-expr -
-              (simple-var-ref $desugar$51))))))
+          (binary-expr +
+            (binary-expr +
+              (binary-expr +
+                (binary-expr +
+                  (index-based-access
+                    (simple-var-ref m)
+                    (literal a))
+                  (index-based-access
+                    (simple-var-ref m)
+                    (literal b)))
+                (index-based-access
+                  (simple-var-ref m)
+                  (literal c)))
+              (simple-var-ref d))
+            (simple-var-ref e)))))
       (expression-stmt
         (invocation io println (
-          (simple-var-ref $desugar$52)))))))
+          (unary-expr -
+            (index-based-access
+              (simple-var-ref m)
+              (literal a)))))))))

--- a/corpus/desugared/subset8/08-nillifting/additive-1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/additive-1-v.txt
@@ -16,61 +16,21 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr +
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
         (variable a (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr -
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
+          (binary-expr +
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (var-def
         (variable b (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$5))))
+          (binary-expr -
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a))))
@@ -90,61 +50,21 @@
             (value-type null))) (expr
           (literal 10))))
       (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref j))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr +
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
-      (var-def
         (variable a1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$8))))
-      (var-def
-        (variable $desugar$9 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$10 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr -
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
+          (binary-expr +
+            (simple-var-ref i)
+            (simple-var-ref j)))))
       (var-def
         (variable b1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$11))))
+          (binary-expr -
+            (simple-var-ref i)
+            (simple-var-ref y)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a1))))

--- a/corpus/desugared/subset8/08-nillifting/additive-4-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/additive-4-v.txt
@@ -24,56 +24,16 @@
       (assignment
         (simple-var-ref y)
         (literal <nil>))
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr +
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
       (assignment
         (simple-var-ref a)
-        (simple-var-ref $desugar$2))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr -
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
+        (binary-expr +
+          (simple-var-ref x)
+          (simple-var-ref y)))
       (assignment
         (simple-var-ref b)
-        (simple-var-ref $desugar$5))))
+        (binary-expr -
+          (simple-var-ref x)
+          (simple-var-ref y)))))
   (function main () (
     (value-type null))
     (block-function-body

--- a/corpus/desugared/subset8/08-nillifting/binary-bitwise-1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/binary-bitwise-1-v.txt
@@ -16,89 +16,29 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr &
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
         (variable a (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr ^
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
+          (binary-expr &
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (var-def
         (variable b (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr |
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
+          (binary-expr ^
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (var-def
         (variable c (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$8))))
+          (binary-expr |
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a))))
@@ -121,89 +61,29 @@
             (value-type null))) (expr
           (literal 10))))
       (var-def
-        (variable $desugar$9 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$10 (expr
-          (simple-var-ref j))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr &
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
-      (var-def
         (variable a1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$11))))
-      (var-def
-        (variable $desugar$12 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$13 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$12))
-          (type-test-expr is
-            (simple-var-ref $desugar$13)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$14)
-            (binary-expr ^
-              (simple-var-ref $desugar$12)
-              (simple-var-ref $desugar$13))))))
+          (binary-expr &
+            (simple-var-ref i)
+            (simple-var-ref j)))))
       (var-def
         (variable b1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$14))))
-      (var-def
-        (variable $desugar$15 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$16 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$17 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$15))
-          (type-test-expr is
-            (simple-var-ref $desugar$16)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$17)
-            (binary-expr |
-              (simple-var-ref $desugar$15)
-              (simple-var-ref $desugar$16))))))
+          (binary-expr ^
+            (simple-var-ref i)
+            (simple-var-ref y)))))
       (var-def
         (variable c1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$17))))
+          (binary-expr |
+            (simple-var-ref i)
+            (simple-var-ref y)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a1))))

--- a/corpus/desugared/subset8/08-nillifting/binary-bitwise-4-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/binary-bitwise-4-v.txt
@@ -28,81 +28,21 @@
       (assignment
         (simple-var-ref y)
         (literal <nil>))
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr &
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
       (assignment
         (simple-var-ref a)
-        (simple-var-ref $desugar$2))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr ^
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
+        (binary-expr &
+          (simple-var-ref x)
+          (simple-var-ref y)))
       (assignment
         (simple-var-ref b)
-        (simple-var-ref $desugar$5))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr |
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
+        (binary-expr ^
+          (simple-var-ref x)
+          (simple-var-ref y)))
       (assignment
         (simple-var-ref c)
-        (simple-var-ref $desugar$8))))
+        (binary-expr |
+          (simple-var-ref x)
+          (simple-var-ref y)))))
   (function main () (
     (value-type null))
     (block-function-body

--- a/corpus/desugared/subset8/08-nillifting/match-guard1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/match-guard1-v.txt
@@ -1,0 +1,44 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable value (type
+          (value-type int)) (expr
+          (literal 1))))
+      (var-def
+        (variable n (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 0))))
+      (match
+        (simple-var-ref value)
+        (match-clause
+          (const-pattern
+            (literal 1))
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (literal first))))))
+        (match-clause
+          (wildcard-match-pattern)
+          (match-guard
+            (binary-expr ==
+              (binary-expr +
+                (invocation guardValue ())
+                (simple-var-ref n))
+              (literal 1)))
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (literal guarded)))))))))
+  (function guardValue () (
+    (value-type int))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (literal guard))))
+      (return
+        (literal 1)))))

--- a/corpus/desugared/subset8/08-nillifting/multiplicative-1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/multiplicative-1-v.txt
@@ -16,89 +16,29 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr *
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
         (variable a (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr /
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
+          (binary-expr *
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (var-def
         (variable b (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr %
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
+          (binary-expr /
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (var-def
         (variable c (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$8))))
+          (binary-expr %
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a))))
@@ -121,89 +61,29 @@
             (value-type null))) (expr
           (literal 10))))
       (var-def
-        (variable $desugar$9 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$10 (expr
-          (simple-var-ref j))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr *
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
-      (var-def
         (variable a1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$11))))
-      (var-def
-        (variable $desugar$12 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$13 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$12))
-          (type-test-expr is
-            (simple-var-ref $desugar$13)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$14)
-            (binary-expr /
-              (simple-var-ref $desugar$12)
-              (simple-var-ref $desugar$13))))))
+          (binary-expr *
+            (simple-var-ref i)
+            (simple-var-ref j)))))
       (var-def
         (variable b1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$14))))
-      (var-def
-        (variable $desugar$15 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$16 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$17 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$15))
-          (type-test-expr is
-            (simple-var-ref $desugar$16)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$17)
-            (binary-expr %
-              (simple-var-ref $desugar$15)
-              (simple-var-ref $desugar$16))))))
+          (binary-expr /
+            (simple-var-ref i)
+            (simple-var-ref y)))))
       (var-def
         (variable c1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$17))))
+          (binary-expr %
+            (simple-var-ref i)
+            (simple-var-ref y)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a1))))

--- a/corpus/desugared/subset8/08-nillifting/multiplicative-4-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/multiplicative-4-v.txt
@@ -28,81 +28,21 @@
       (assignment
         (simple-var-ref y)
         (literal <nil>))
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr *
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
       (assignment
         (simple-var-ref a)
-        (simple-var-ref $desugar$2))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr /
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
+        (binary-expr *
+          (simple-var-ref x)
+          (simple-var-ref y)))
       (assignment
         (simple-var-ref b)
-        (simple-var-ref $desugar$5))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr %
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
+        (binary-expr /
+          (simple-var-ref x)
+          (simple-var-ref y)))
       (assignment
         (simple-var-ref c)
-        (simple-var-ref $desugar$8))))
+        (binary-expr %
+          (simple-var-ref x)
+          (simple-var-ref y)))))
   (function main () (
     (value-type null))
     (block-function-body

--- a/corpus/desugared/subset8/08-nillifting/mutate1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/mutate1-v.txt
@@ -1,0 +1,51 @@
+(package
+  (import-package ballerina io (as io))
+  (variable number (type
+    (union-type
+      (value-type int)
+      (value-type null))))
+  (variable text (type
+    (union-type
+      (value-type string)
+      (value-type null))))
+  (function init () ()
+    (block-function-body
+      (assignment
+        (simple-var-ref number)
+        (literal 1))
+      (assignment
+        (simple-var-ref text)
+        (literal a))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (binary-expr +
+            (simple-var-ref number)
+            (invocation mutateNumber ())))))
+      (expression-stmt
+        (invocation io println (
+          (binary-expr +
+            (simple-var-ref text)
+            (invocation mutateText ())))))))
+  (function mutateNumber () (
+    (union-type
+      (value-type int)
+      (value-type null)))
+    (block-function-body
+      (assignment
+        (simple-var-ref number)
+        (literal 100))
+      (return
+        (literal 1))))
+  (function mutateText () (
+    (union-type
+      (value-type string)
+      (value-type null)))
+    (block-function-body
+      (assignment
+        (simple-var-ref text)
+        (literal mutated))
+      (return
+        (literal b)))))

--- a/corpus/desugared/subset8/08-nillifting/operand-eval1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/operand-eval1-v.txt
@@ -1,0 +1,32 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable nilValue (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal <nil>))))
+      (var-def
+        (variable result (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (binary-expr +
+            (invocation sideEffect ())
+            (simple-var-ref nilValue)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref result)
+            (value-type null)))))))
+  (function sideEffect () (
+    (value-type int))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (literal side-effect))))
+      (return
+        (literal 1)))))

--- a/corpus/desugared/subset8/08-nillifting/shift-1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/shift-1-v.txt
@@ -16,89 +16,29 @@
             (value-type null))) (expr
           (literal <nil>))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr <<
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
-      (var-def
         (variable a (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr >>
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
+          (binary-expr <<
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (var-def
         (variable b (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr >>>
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
+          (binary-expr >>
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (var-def
         (variable c (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$8))))
+          (binary-expr >>>
+            (simple-var-ref x)
+            (simple-var-ref y)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a))))
@@ -121,89 +61,29 @@
             (value-type null))) (expr
           (literal 10))))
       (var-def
-        (variable $desugar$9 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$10 (expr
-          (simple-var-ref j))))
-      (var-def
-        (variable $desugar$11 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$9))
-          (type-test-expr is
-            (simple-var-ref $desugar$10)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$11)
-            (binary-expr <<
-              (simple-var-ref $desugar$9)
-              (simple-var-ref $desugar$10))))))
-      (var-def
         (variable a1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$11))))
-      (var-def
-        (variable $desugar$12 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$13 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$14 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$12))
-          (type-test-expr is
-            (simple-var-ref $desugar$13)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$14)
-            (binary-expr >>
-              (simple-var-ref $desugar$12)
-              (simple-var-ref $desugar$13))))))
+          (binary-expr <<
+            (simple-var-ref i)
+            (simple-var-ref j)))))
       (var-def
         (variable b1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$14))))
-      (var-def
-        (variable $desugar$15 (expr
-          (simple-var-ref i))))
-      (var-def
-        (variable $desugar$16 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$17 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$15))
-          (type-test-expr is
-            (simple-var-ref $desugar$16)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$17)
-            (binary-expr >>>
-              (simple-var-ref $desugar$15)
-              (simple-var-ref $desugar$16))))))
+          (binary-expr >>
+            (simple-var-ref i)
+            (simple-var-ref y)))))
       (var-def
         (variable c1 (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$17))))
+          (binary-expr >>>
+            (simple-var-ref i)
+            (simple-var-ref y)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a1))))

--- a/corpus/desugared/subset8/08-nillifting/shift-4-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/shift-4-v.txt
@@ -28,81 +28,21 @@
       (assignment
         (simple-var-ref y)
         (literal <nil>))
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$1 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$2 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$0))
-          (type-test-expr is
-            (simple-var-ref $desugar$1)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$2)
-            (binary-expr <<
-              (simple-var-ref $desugar$0)
-              (simple-var-ref $desugar$1))))))
       (assignment
         (simple-var-ref a)
-        (simple-var-ref $desugar$2))
-      (var-def
-        (variable $desugar$3 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$3))
-          (type-test-expr is
-            (simple-var-ref $desugar$4)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (binary-expr >>
-              (simple-var-ref $desugar$3)
-              (simple-var-ref $desugar$4))))))
+        (binary-expr <<
+          (simple-var-ref x)
+          (simple-var-ref y)))
       (assignment
         (simple-var-ref b)
-        (simple-var-ref $desugar$5))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref x))))
-      (var-def
-        (variable $desugar$7 (expr
-          (simple-var-ref y))))
-      (var-def
-        (variable $desugar$8 (expr
-          (literal <nil>))))
-      (if
-        (binary-expr ||
-          (type-test-expr is
-            (simple-var-ref $desugar$6))
-          (type-test-expr is
-            (simple-var-ref $desugar$7)))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$8)
-            (binary-expr >>>
-              (simple-var-ref $desugar$6)
-              (simple-var-ref $desugar$7))))))
+        (binary-expr >>
+          (simple-var-ref x)
+          (simple-var-ref y)))
       (assignment
         (simple-var-ref c)
-        (simple-var-ref $desugar$8))))
+        (binary-expr >>>
+          (simple-var-ref x)
+          (simple-var-ref y)))))
   (function main () (
     (value-type null))
     (block-function-body

--- a/corpus/desugared/subset8/08-nillifting/trap1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/trap1-v.txt
@@ -1,0 +1,66 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable left (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 1))))
+      (var-def
+        (variable right (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 2))))
+      (var-def
+        (variable sum (expr
+          (trap-expr
+            (binary-expr +
+              (simple-var-ref left)
+              (simple-var-ref right))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref sum))))
+      (var-def
+        (variable negated (expr
+          (trap-expr
+            (unary-expr -
+              (simple-var-ref left))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref negated))))
+      (var-def
+        (variable nilValue (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal <nil>))))
+      (var-def
+        (variable nilSum (expr
+          (trap-expr
+            (binary-expr +
+              (simple-var-ref left)
+              (simple-var-ref nilValue))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref nilSum)
+            (value-type null)))))
+      (var-def
+        (variable zero (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 0))))
+      (var-def
+        (variable divided (expr
+          (trap-expr
+            (binary-expr /
+              (simple-var-ref left)
+              (simple-var-ref zero))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref divided)))))))

--- a/corpus/desugared/subset8/08-nillifting/trap2-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/trap2-v.txt
@@ -1,0 +1,31 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable b (type
+          (value-type boolean)) (expr
+          (literal true))))
+      (var-def
+        (variable zero (type
+          (value-type int)) (expr
+          (literal 0))))
+      (var-def
+        (variable result (expr
+          (trap-expr
+            (binary-expr &&
+              (simple-var-ref b)
+              (binary-expr >
+                (binary-expr /
+                  (invocation value ())
+                  (simple-var-ref zero))
+                (literal 0)))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref result))))))
+  (function value () (
+    (value-type int))
+    (block-function-body
+      (return
+        (literal 1)))))

--- a/corpus/desugared/subset8/08-nillifting/unary-1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/unary-1-v.txt
@@ -16,47 +16,19 @@
             (value-type null))) (expr
           (simple-var-ref base))))
       (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref base))))
-      (var-def
-        (variable $desugar$1 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$1)
-            (unary-expr -
-              (simple-var-ref $desugar$0))))))
-      (var-def
         (variable c (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$1))))
-      (var-def
-        (variable $desugar$2 (expr
-          (simple-var-ref base))))
-      (var-def
-        (variable $desugar$3 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$3)
-            (unary-expr ~
-              (simple-var-ref $desugar$2))))))
+          (unary-expr -
+            (simple-var-ref base)))))
       (var-def
         (variable d (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$3))))
+          (unary-expr ~
+            (simple-var-ref base)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref a))))
@@ -76,47 +48,19 @@
             (value-type null))) (expr
           (simple-var-ref base))))
       (var-def
-        (variable $desugar$4 (expr
-          (simple-var-ref base))))
-      (var-def
-        (variable $desugar$5 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$4))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$5)
-            (unary-expr -
-              (simple-var-ref $desugar$4))))))
-      (var-def
         (variable y (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$5))))
-      (var-def
-        (variable $desugar$6 (expr
-          (simple-var-ref base))))
-      (var-def
-        (variable $desugar$7 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$6))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$7)
-            (unary-expr ~
-              (simple-var-ref $desugar$6))))))
+          (unary-expr -
+            (simple-var-ref base)))))
       (var-def
         (variable z (type
           (union-type
             (value-type int)
             (value-type null))) (expr
-          (simple-var-ref $desugar$7))))
+          (unary-expr ~
+            (simple-var-ref base)))))
       (expression-stmt
         (invocation io println (
           (simple-var-ref x))))

--- a/corpus/desugared/subset8/08-nillifting/unary-5-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/unary-5-v.txt
@@ -24,42 +24,14 @@
       (assignment
         (simple-var-ref x)
         (simple-var-ref base2))
-      (var-def
-        (variable $desugar$0 (expr
-          (simple-var-ref base2))))
-      (var-def
-        (variable $desugar$1 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$0))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$1)
-            (unary-expr -
-              (simple-var-ref $desugar$0))))))
       (assignment
         (simple-var-ref y)
-        (simple-var-ref $desugar$1))
-      (var-def
-        (variable $desugar$2 (expr
-          (simple-var-ref base2))))
-      (var-def
-        (variable $desugar$3 (expr
-          (literal <nil>))))
-      (if
-        (type-test-expr is
-          (simple-var-ref $desugar$2))
-        (block-stmt) (
-        (block-stmt
-          (assignment
-            (simple-var-ref $desugar$3)
-            (unary-expr ~
-              (simple-var-ref $desugar$2))))))
+        (unary-expr -
+          (simple-var-ref base2)))
       (assignment
         (simple-var-ref z)
-        (simple-var-ref $desugar$3))))
+        (unary-expr ~
+          (simple-var-ref base2)))))
   (function main () (
     (value-type null))
     (block-function-body

--- a/corpus/desugared/subset8/08-nillifting/while-cond1-v.txt
+++ b/corpus/desugared/subset8/08-nillifting/while-cond1-v.txt
@@ -1,0 +1,26 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable current (type
+          (union-type
+            (value-type int)
+            (value-type null))) (expr
+          (literal 0))))
+      (while
+        (binary-expr !=
+          (binary-expr +
+            (simple-var-ref current)
+            (literal 1))
+          (literal 5))
+        (block-stmt
+          (assignment
+            (simple-var-ref current)
+            (binary-expr +
+              (simple-var-ref current)
+              (literal 1)))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref current)))))))

--- a/corpus/integration/subset8/08-nillifting/match-guard1-v.txtar
+++ b/corpus/integration/subset8/08-nillifting/match-guard1-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+first
+-- stderr --

--- a/corpus/integration/subset8/08-nillifting/mutate1-v.txtar
+++ b/corpus/integration/subset8/08-nillifting/mutate1-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+2
+ab
+-- stderr --

--- a/corpus/integration/subset8/08-nillifting/operand-eval1-v.txtar
+++ b/corpus/integration/subset8/08-nillifting/operand-eval1-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+side-effect
+true
+-- stderr --

--- a/corpus/integration/subset8/08-nillifting/trap1-v.txtar
+++ b/corpus/integration/subset8/08-nillifting/trap1-v.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+3
+-1
+true
+error("divide by zero")
+-- stderr --

--- a/corpus/integration/subset8/08-nillifting/trap2-v.txtar
+++ b/corpus/integration/subset8/08-nillifting/trap2-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+error("divide by zero")
+-- stderr --

--- a/corpus/integration/subset8/08-nillifting/while-cond1-v.txtar
+++ b/corpus/integration/subset8/08-nillifting/while-cond1-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+4
+-- stderr --

--- a/desugar/expression.go
+++ b/desugar/expression.go
@@ -205,117 +205,9 @@ func walkBinaryExpr(cx *functionContext, expr *ast.BLangBinaryExpr) desugaredNod
 		expr.RhsExpr = result.replacementNode.(ast.BLangExpression)
 	}
 
-	if !isNilLiftableBinaryOp(expr.OpKind) {
-		return desugaredNode[ast.BLangActionOrExpression]{
-			initStmts:       initStmts,
-			replacementNode: expr,
-		}
-	}
-
-	lhsTy := expr.LhsExpr.GetDeterminedType()
-	rhsTy := expr.RhsExpr.GetDeterminedType()
-	if semtypes.IsZero(lhsTy) || semtypes.IsZero(rhsTy) {
-		return desugaredNode[ast.BLangActionOrExpression]{
-			initStmts:       initStmts,
-			replacementNode: expr,
-		}
-	}
-	lhsHasNil := semtypes.ContainsBasicType(lhsTy, semtypes.Nil)
-	rhsHasNil := semtypes.ContainsBasicType(rhsTy, semtypes.Nil)
-
-	if !lhsHasNil && !rhsHasNil {
-		return desugaredNode[ast.BLangActionOrExpression]{
-			initStmts:       initStmts,
-			replacementNode: expr,
-		}
-	}
-
-	basePos := expr.GetPosition()
-	resultTy := expr.GetDeterminedType()
-
-	// Create temp vars for nullable operands
-	var lhsVarName *ast.BLangIdentifier
-	var lhsSymbol model.SymbolRef
-	if lhsHasNil {
-		lhsVarName, lhsSymbol, initStmts = createOperandTempVar(cx, lhsTy, expr.LhsExpr, basePos, initStmts)
-	}
-
-	var rhsVarName *ast.BLangIdentifier
-	var rhsSymbol model.SymbolRef
-	if rhsHasNil {
-		rhsVarName, rhsSymbol, initStmts = createOperandTempVar(cx, rhsTy, expr.RhsExpr, basePos, initStmts)
-	}
-
-	// Create result temp var initialized to nil
-	resultVarName, resultSymbol, initStmts := createNilResultVar(cx, resultTy, basePos, initStmts)
-
-	// Build the nil check condition
-	var nilCheckCond ast.BLangExpression
-	if lhsHasNil {
-		nilCheckCond = createNilTypeTest(lhsVarName, lhsSymbol, lhsTy, basePos)
-	}
-	if rhsHasNil {
-		rhsNilCheck := createNilTypeTest(rhsVarName, rhsSymbol, rhsTy, basePos)
-		if nilCheckCond == nil {
-			nilCheckCond = rhsNilCheck
-		} else {
-			orExpr := &ast.BLangBinaryExpr{
-				LhsExpr: nilCheckCond,
-				RhsExpr: rhsNilCheck,
-				OpKind:  model.OperatorKind_OR,
-			}
-			orExpr.SetDeterminedType(semtypes.Boolean)
-			orExpr.SetPosition(basePos)
-			nilCheckCond = orExpr
-		}
-	}
-
-	// Build the operation in the else branch
-	var lhsRef ast.BLangExpression
-	if lhsHasNil {
-		lhsRef = createVarRef(lhsVarName, lhsSymbol, semtypes.Diff(lhsTy, semtypes.Nil))
-	} else {
-		lhsRef = expr.LhsExpr
-	}
-
-	var rhsRef ast.BLangExpression
-	if rhsHasNil {
-		rhsRef = createVarRef(rhsVarName, rhsSymbol, semtypes.Diff(rhsTy, semtypes.Nil))
-	} else {
-		rhsRef = expr.RhsExpr
-	}
-
-	newBinaryExpr := &ast.BLangBinaryExpr{
-		LhsExpr: lhsRef,
-		RhsExpr: rhsRef,
-		OpKind:  expr.OpKind,
-	}
-	newBinaryExpr.SetDeterminedType(semtypes.Diff(resultTy, semtypes.Nil))
-	newBinaryExpr.SetPosition(basePos)
-
-	resultAssign := createResultAssignment(resultVarName, resultSymbol, resultTy, newBinaryExpr, basePos)
-
-	elseBody := &ast.BLangBlockStmt{
-		Stmts: []ast.StatementNode{resultAssign},
-	}
-	elseBody.SetDeterminedType(semtypes.Never)
-	ifStmt := &ast.BLangIf{
-		Expr:     nilCheckCond,
-		Body:     ast.BLangBlockStmt{},
-		ElseStmt: elseBody,
-	}
-	ifStmt.Body.SetDeterminedType(semtypes.Never)
-	ifStmt.SetDeterminedType(semtypes.Never)
-	ifStmt.SetScope(cx.currentScope())
-	setPositionIfMissing(ifStmt, basePos)
-	initStmts = append(initStmts, ifStmt)
-
-	replacementRef := createVarRef(resultVarName, resultSymbol, resultTy)
-	setPositionIfMissing(replacementRef, basePos)
-
 	return desugaredNode[ast.BLangActionOrExpression]{
 		initStmts:       initStmts,
-		replacementNode: replacementRef,
+		replacementNode: expr,
 	}
 }
 
@@ -336,69 +228,9 @@ func walkUnaryExpr(cx *functionContext, expr *ast.BLangUnaryExpr) desugaredNode[
 		}
 	}
 
-	if !isNilLiftableUnaryOp(expr.Operator) {
-		return desugaredNode[ast.BLangActionOrExpression]{
-			initStmts:       initStmts,
-			replacementNode: expr,
-		}
-	}
-
-	operandTy := expr.Expr.GetDeterminedType()
-	if !semtypes.ContainsBasicType(operandTy, semtypes.Nil) {
-		return desugaredNode[ast.BLangActionOrExpression]{
-			initStmts:       initStmts,
-			replacementNode: expr,
-		}
-	}
-
-	basePos := expr.GetPosition()
-	resultTy := expr.GetDeterminedType()
-
-	// Create operand temp var
-	operandVarName, operandSymbol, initStmts := createOperandTempVar(cx, operandTy, expr.Expr, basePos, initStmts)
-
-	// Create result temp var initialized to nil
-	resultVarName, resultSymbol, initStmts := createNilResultVar(cx, resultTy, basePos, initStmts)
-
-	// Build nil check: if ($operand is ()) { } else { ... }
-	nilCheck := createNilTypeTest(operandVarName, operandSymbol, operandTy, basePos)
-
-	// Build the operation for the if-body (operand is not nil)
-	nonNilTy := semtypes.Diff(operandTy, semtypes.Nil)
-	operandRef := createVarRef(operandVarName, operandSymbol, nonNilTy)
-
-	newUnary := &ast.BLangUnaryExpr{
-		Expr:     operandRef,
-		Operator: expr.Operator,
-	}
-	newUnary.SetDeterminedType(semtypes.Diff(resultTy, semtypes.Nil))
-	newUnary.SetPosition(basePos)
-	var opExpr ast.BLangExpression = newUnary
-
-	resultAssign := createResultAssignment(resultVarName, resultSymbol, resultTy, opExpr, basePos)
-
-	// if ($operand is ()) { } else { $result = op $operand }
-	elseBody := &ast.BLangBlockStmt{
-		Stmts: []ast.StatementNode{resultAssign},
-	}
-	elseBody.SetDeterminedType(semtypes.Never)
-	ifStmt := &ast.BLangIf{
-		Expr:     nilCheck,
-		Body:     ast.BLangBlockStmt{},
-		ElseStmt: elseBody,
-	}
-	ifStmt.Body.SetDeterminedType(semtypes.Never)
-	ifStmt.SetDeterminedType(semtypes.Never)
-	ifStmt.SetScope(cx.currentScope())
-	setPositionIfMissing(ifStmt, basePos)
-	initStmts = append(initStmts, ifStmt)
-
-	replacementRef := createVarRef(resultVarName, resultSymbol, resultTy)
-	setPositionIfMissing(replacementRef, basePos)
-
 	return desugaredNode[ast.BLangActionOrExpression]{
 		initStmts:       initStmts,
-		replacementNode: replacementRef,
+		replacementNode: expr,
 	}
 }
 
@@ -1334,28 +1166,6 @@ func walkMappingConstructorExpr(cx *functionContext, expr *ast.BLangMappingConst
 	return desugaredNode[ast.BLangActionOrExpression]{
 		initStmts:       initStmts,
 		replacementNode: expr,
-	}
-}
-
-func isNilLiftableBinaryOp(op model.OperatorKind) bool {
-	switch op {
-	case model.OperatorKind_ADD, model.OperatorKind_SUB,
-		model.OperatorKind_MUL, model.OperatorKind_DIV, model.OperatorKind_MOD,
-		model.OperatorKind_BITWISE_LEFT_SHIFT, model.OperatorKind_BITWISE_RIGHT_SHIFT,
-		model.OperatorKind_BITWISE_UNSIGNED_RIGHT_SHIFT,
-		model.OperatorKind_BITWISE_AND, model.OperatorKind_BITWISE_OR, model.OperatorKind_BITWISE_XOR:
-		return true
-	default:
-		return false
-	}
-}
-
-func isNilLiftableUnaryOp(op model.OperatorKind) bool {
-	switch op {
-	case model.OperatorKind_ADD, model.OperatorKind_SUB, model.OperatorKind_BITWISE_COMPLEMENT:
-		return true
-	default:
-		return false
 	}
 }
 

--- a/nodebuilder/node_builder.go
+++ b/nodebuilder/node_builder.go
@@ -814,12 +814,6 @@ func (n *nodeBuilder) createIgnoreIdentifier(node st.Node) ast.BLangIdentifier {
 	return identifier
 }
 
-// getNextAnonymousTypeKey generates the next anonymous type key
-// Placeholder function - to be implemented
-func (n *nodeBuilder) getNextAnonymousTypeKey(packageID *model.PackageID, suffixes []string) string {
-	return n.cx.GetNextAnonymousTypeKey(packageID)
-}
-
 // createTypeNode creates a type node from a syntax tree node
 // This delegates to the appropriate Transform method based on the node type
 func (n *nodeBuilder) createTypeNode(typeNode st.Node) ast.TypeDescriptor {


### PR DESCRIPTION
## Summary

- move nil-lifted unary and binary expression lowering from desugar to BIR generation
- preserve operand evaluation order and keep generated control flow inside trap regions
- add corpus coverage for traps, loop conditions, match guards, operand mutation, and evaluation order

## Testing

- `go test ./birgen/...`
- `go test ./corpus/...`

This is the root PR in the stack for #759.

Fixes #760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nullable unary and binary expressions now support nil-lifting.
  * Nil-lifted operations produce `()` when applicable operands are nil while preserving operand evaluation.
  * Improved nullable-expression behavior in conditions, match guards, mutations, and trapped expressions.
  * Trapped expressions now correctly report errors such as divide-by-zero.

* **Tests**
  * Added coverage for nil-lifting, side effects, control flow, match guards, and error trapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->