### PR TITLE
fix(ci): support stacked PRs in CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,7 @@
 reviews:
+  auto_review:
+    base_branches:
+      - ".*"
   path_filters:
     - "!bir/testdata/**/*.txt"
     - "!bir/testdata/**/*.bir"


### PR DESCRIPTION
## Purpose
Enable automatic CodeRabbit reviews for stacked PRs that target feature branches instead of the default branch.

## Approach
Configure `reviews.auto_review.base_branches` with the `.*` regex while retaining the existing path filters.

## Checklist
- [ ] Read the [Contributing Guide](CONTRIBUTING.md)
- [x] Corpus tests are not applicable to this configuration-only change.

## Remarks
Validated that `.coderabbit.yaml` parses successfully and that `git diff --check` passes.