### PR TITLE
feat(http): support client resource method calls

### DIFF
--- a/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
@@ -47,7 +47,7 @@ class $service$0 {
 
   $remote$greet() -> string{
     bb0 {
-      lock-start "$anon/.:$service.514.1.foo" GOTO bb1;
+      lock-start "$anon/.:$service.521.1.foo" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 2
@@ -55,7 +55,7 @@ class $service$0 {
       %0 = (1, self)[%1];
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.514.1.foo" GOTO bb2;
+      lock-end "$anon/.:$service.521.1.foo" GOTO bb2;
     }
     bb2 {
       return;
@@ -77,7 +77,7 @@ class $service$0 {
   resource get hello $resource$get$0(string) -> string{
     bb0 {
       _ = name;
-      lock-start "$anon/.:$service.514.1.foo" GOTO bb1;
+      lock-start "$anon/.:$service.521.1.foo" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 4
@@ -87,7 +87,7 @@ class $service$0 {
       %0 = + %1 %2;
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.514.1.foo" GOTO bb2;
+      lock-end "$anon/.:$service.521.1.foo" GOTO bb2;
     }
     bb2 {
       return;

--- a/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
@@ -113,7 +113,7 @@ class $service$0 {
 
   get() -> int{
     bb0 {
-      lock-start "$anon/.:$service.524.0.count" GOTO bb1;
+      lock-start "$anon/.:$service.531.0.count" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 2
@@ -121,7 +121,7 @@ class $service$0 {
       %0 = (1, self)[%1];
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.524.0.count" GOTO bb2;
+      lock-end "$anon/.:$service.531.0.count" GOTO bb2;
     }
     bb2 {
       return;
@@ -133,7 +133,7 @@ class $service$0 {
 
   inc() -> nil{
     bb0 {
-      lock-start "$anon/.:$service.524.0.count" GOTO bb1;
+      lock-start "$anon/.:$service.531.0.count" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 7
@@ -146,7 +146,7 @@ class $service$0 {
       %6 = ConstantLoad count
       (1, self)[%6] = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.524.0.count" GOTO bb2;
+      lock-end "$anon/.:$service.531.0.count" GOTO bb2;
     }
     bb2 {
       return;

--- a/corpus/extern/http_service_test.go
+++ b/corpus/extern/http_service_test.go
@@ -191,6 +191,25 @@ func TestHttpServiceClientMethods(t *testing.T) {
 	runExtern(t, fileCase("http-service/http-svc-client-methods-v"), newHTTPPal(palnative.NewHTTPClient), nil)
 }
 
+// TestHttpServiceClientResource exercises all seven client resource methods
+// (`client->/path.get()` and friends) against a service that echoes back the
+// method it dispatched on, so an accessor wired to the wrong native
+// implementation shows up as a mismatched verb.
+func TestHttpServiceClientResource(t *testing.T) {
+	skipIfNoLoopback(t)
+	t.Parallel()
+	runExtern(t, fileCase("http-service/http-svc-client-resource-v"), newHTTPPal(palnative.NewHTTPClient), nil)
+}
+
+// TestHttpServiceClientResourcePath asserts the request target a client
+// resource method builds: path segment rendering for every PathParamType
+// member, and query parameter assembly from the *QueryParams included record.
+func TestHttpServiceClientResourcePath(t *testing.T) {
+	skipIfNoLoopback(t)
+	t.Parallel()
+	runExtern(t, fileCase("http-service/http-svc-client-resource-path-v"), newHTTPPal(palnative.NewHTTPClient), nil)
+}
+
 // TestHttpServiceClientRedirect verifies the client follows a 302 redirect
 // (Location header) emitted by a local service and lands on the 200 target.
 func TestHttpServiceClientRedirect(t *testing.T) {

--- a/corpus/extern/testdata/expected/http-service/http-svc-client-resource-path-v.txtar
+++ b/corpus/extern/testdata/expected/http-service/http-svc-client-resource-path-v.txtar
@@ -1,0 +1,20 @@
+-- stdout --
+/p/0/42/-5
+/p/true/false
+/p/1.0/1.5/-2.75
+/p/1e10/1e-7
+/p/NaN/Infinity/-Infinity
+/p?bad=NaN&pi=Infinity
+/p/1.0/2.500
+/p/albums/tracks
+/p/albums/tracks
+/p/albums?tag=rock&count=3&exact=true
+/p/albums?tags=rock,jazz,folk
+/p/albums?ratio=1.5&big=1e10&dec=2.500
+/p/albums?q=a+b
+/p/albums?q=a%26b%3Dc
+/p/albums?tag=rock
+/p/albums?tag=rock
+/
+/?tag=rock
+-- stderr --

--- a/corpus/extern/testdata/expected/http-service/http-svc-client-resource-v.txtar
+++ b/corpus/extern/testdata/expected/http-service/http-svc-client-resource-v.txtar
@@ -1,0 +1,14 @@
+-- stdout --
+200
+GET
+/verb/albums/1
+POST
+PUT
+PATCH
+DELETE
+DELETE
+HEAD
+OPTIONS
+GET
+POST
+-- stderr --

--- a/corpus/extern/testdata/http-service/http-svc-client-resource-path-v.bal
+++ b/corpus/extern/testdata/http-service/http-svc-client-resource-path-v.bal
@@ -1,0 +1,134 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+
+// The service echoes the request target back so the path and query string the
+// client actually put on the wire can be asserted. Segments and query values use
+// Ballerina's own toString rendering, and query components are percent-encoded by
+// Go's net/url; both differ from jBallerina's wire format in the ways the http
+// README records under "Notable Behavioural Changes".
+service /p on new http:Listener(19223) {
+    resource function get [string... rest](http:Request req) returns http:Response {
+        return echoRawPath(req);
+    }
+
+    resource function post [string... rest](http:Request req) returns http:Response {
+        return echoRawPath(req);
+    }
+}
+
+// A second service mounted at the root base path, so an empty path segment
+// list — the `client->/` form — has somewhere to dispatch to.
+service / on new http:Listener(19224) {
+    resource function get [string... rest](http:Request req) returns http:Response {
+        return echoRawPath(req);
+    }
+}
+
+function echoRawPath(http:Request req) returns http:Response {
+    http:Response resp = new;
+    resp.setHeader("x-raw-path", req.rawPath);
+    return resp;
+}
+
+public function testMain() returns error? {
+    http:Client c = check new http:Client("http://localhost:19223", {});
+
+    // A path segment of each PathParamType member. Note the numeric renderings:
+    // a whole float keeps its ".0" and a decimal keeps its trailing zeros.
+    http:Response ints = check c->/p/[0]/[42]/[-5];
+    io:println(check ints.getHeader("x-raw-path")); // @output /p/0/42/-5
+
+    http:Response bools = check c->/p/[true]/[false];
+    io:println(check bools.getHeader("x-raw-path")); // @output /p/true/false
+
+    http:Response floats = check c->/p/[1.0]/[1.5]/[-2.75];
+    io:println(check floats.getHeader("x-raw-path")); // @output /p/1.0/1.5/-2.75
+
+    // Outside [1e-3, 1e7) a float switches to scientific notation, rendered the
+    // way lang.float:toString renders it (jBallerina's client would send
+    // "1.0E10" here, because it formats path segments with Java's
+    // Double.toString rather than with float:toString).
+    http:Response sci = check c->/p/[1.0e10]/[1.0e-7];
+    io:println(check sci.getHeader("x-raw-path")); // @output /p/1e10/1e-7
+
+    // Non-finite floats render with their Ballerina names rather than as a
+    // numeric literal.
+    float nan = 0.0 / 0.0;
+    float posInf = 1.0 / 0.0;
+    float negInf = -1.0 / 0.0;
+    http:Response nonFinite = check c->/p/[nan]/[posInf]/[negInf];
+    io:println(check nonFinite.getHeader("x-raw-path")); // @output /p/NaN/Infinity/-Infinity
+
+    http:Response nonFiniteQuery = check c->/p(bad = nan, pi = posInf);
+    io:println(check nonFiniteQuery.getHeader("x-raw-path")); // @output /p?bad=NaN&pi=Infinity
+
+    decimal whole = 1.0;
+    decimal trailing = 2.500;
+    http:Response decimals = check c->/p/[whole]/[trailing];
+    io:println(check decimals.getHeader("x-raw-path")); // @output /p/1.0/2.500
+
+    // A name segment and a computed string segment render identically.
+    http:Response names = check c->/p/albums/tracks;
+    io:println(check names.getHeader("x-raw-path")); // @output /p/albums/tracks
+
+    string seg = "albums";
+    http:Response computed = check c->/p/[seg]/["tracks"];
+    io:println(check computed.getHeader("x-raw-path")); // @output /p/albums/tracks
+
+    // Query parameters are appended after "?" and joined with "&", in the order
+    // the named arguments were written.
+    http:Response query = check c->/p/albums(tag = "rock", count = 3, exact = true);
+    io:println(check query.getHeader("x-raw-path")); // @output /p/albums?tag=rock&count=3&exact=true
+
+    // An array-valued query parameter becomes a single comma-joined pair rather
+    // than a repeated key.
+    http:Response arr = check c->/p/albums(tags = ["rock", "jazz", "folk"]);
+    io:println(check arr.getHeader("x-raw-path")); // @output /p/albums?tags=rock,jazz,folk
+
+    // Numeric query values use the same rendering as path segments.
+    http:Response numQuery = check c->/p/albums(ratio = 1.5, big = 1.0e10, dec = trailing);
+    io:println(check numQuery.getHeader("x-raw-path")); // @output /p/albums?ratio=1.5&big=1e10&dec=2.500
+
+    // Query keys and values are escaped with net/url, so a space becomes "+" and
+    // a value carrying a delimiter is encoded instead of splitting the parameter.
+    http:Response spaced = check c->/p/albums(q = "a b");
+    io:println(check spaced.getHeader("x-raw-path")); // @output /p/albums?q=a+b
+
+    http:Response delim = check c->/p/albums(q = "a&b=c");
+    io:println(check delim.getHeader("x-raw-path")); // @output /p/albums?q=a%26b%3Dc
+
+    // Query parameters combine with a body-carrying accessor.
+    http:Response withBody = check c->/p/albums.post("body", tag = "rock");
+    io:println(check withBody.getHeader("x-raw-path")); // @output /p/albums?tag=rock
+
+    // Headers and query parameters together.
+    map<string|string[]> headers = {"x-custom": "sent"};
+    http:Response both = check c->/p/albums(headers, tag = "rock");
+    io:println(check both.getHeader("x-raw-path")); // @output /p/albums?tag=rock
+
+    // An empty path segment list renders as the root path.
+    http:Client rootClient = check new http:Client("http://localhost:19224", {});
+    http:Response root = check rootClient->/;
+    io:println(check root.getHeader("x-raw-path")); // @output /
+
+    http:Response rootQuery = check rootClient->/(tag = "rock");
+    io:println(check rootQuery.getHeader("x-raw-path")); // @output /?tag=rock
+
+    return;
+}

--- a/corpus/extern/testdata/http-service/http-svc-client-resource-v.bal
+++ b/corpus/extern/testdata/http-service/http-svc-client-resource-v.bal
@@ -1,0 +1,103 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+
+// Each accessor echoes back the method the listener actually dispatched on, so a
+// client resource method bound to the wrong native implementation would surface
+// as a mismatched verb rather than passing silently. The extern lookup key of a
+// resource method embeds its declaration index within the class, which makes
+// that pairing worth asserting for every accessor.
+service /verb on new http:Listener(19222) {
+    resource function get [string... rest](http:Request req) returns http:Response {
+        return echoMethod(req);
+    }
+
+    resource function post [string... rest](http:Request req) returns http:Response {
+        return echoMethod(req);
+    }
+
+    resource function put [string... rest](http:Request req) returns http:Response {
+        return echoMethod(req);
+    }
+
+    resource function patch [string... rest](http:Request req) returns http:Response {
+        return echoMethod(req);
+    }
+
+    resource function delete [string... rest](http:Request req) returns http:Response {
+        return echoMethod(req);
+    }
+
+    resource function head [string... rest](http:Request req) returns http:Response {
+        return echoMethod(req);
+    }
+
+    resource function options [string... rest](http:Request req) returns http:Response {
+        return echoMethod(req);
+    }
+}
+
+function echoMethod(http:Request req) returns http:Response {
+    http:Response resp = new;
+    resp.setHeader("x-method", req.method);
+    resp.setHeader("x-raw-path", req.rawPath);
+    return resp;
+}
+
+public function testMain() returns error? {
+    http:Client c = check new http:Client("http://localhost:19222", {});
+
+    // `get` is the accessor used when the call site names none.
+    http:Response getResp = check c->/verb/albums/[1];
+    io:println(getResp.statusCode); // @output 200
+    io:println(check getResp.getHeader("x-method")); // @output GET
+    io:println(check getResp.getHeader("x-raw-path")); // @output /verb/albums/1
+
+    http:Response postResp = check c->/verb/albums.post("body");
+    io:println(check postResp.getHeader("x-method")); // @output POST
+
+    http:Response putResp = check c->/verb/albums.put("body");
+    io:println(check putResp.getHeader("x-method")); // @output PUT
+
+    http:Response patchResp = check c->/verb/albums.patch("body");
+    io:println(check patchResp.getHeader("x-method")); // @output PATCH
+
+    // `delete` takes an optional message, so both forms must dispatch.
+    http:Response deleteResp = check c->/verb/albums.delete();
+    io:println(check deleteResp.getHeader("x-method")); // @output DELETE
+
+    http:Response deleteBodyResp = check c->/verb/albums.delete("body");
+    io:println(check deleteBodyResp.getHeader("x-method")); // @output DELETE
+
+    http:Response headResp = check c->/verb/albums.head();
+    io:println(check headResp.getHeader("x-method")); // @output HEAD
+
+    http:Response optionsResp = check c->/verb/albums.options();
+    io:println(check optionsResp.getHeader("x-method")); // @output OPTIONS
+
+    // Request headers travel with a resource-method call, and the media type
+    // override reaches the server as the Content-Type.
+    map<string|string[]> headers = {"x-custom": "sent"};
+    http:Response hdrResp = check c->/verb/albums(headers);
+    io:println(check hdrResp.getHeader("x-method")); // @output GET
+
+    http:Response typedResp = check c->/verb/albums.post("body", mediaType = "text/plain");
+    io:println(check typedResp.getHeader("x-method")); // @output POST
+
+    return;
+}

--- a/corpus/integration/lib/subset3/http-client-resource-e.txtar
+++ b/corpus/integration/lib/subset3/http-client-resource-e.txtar
@@ -1,0 +1,25 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: no included record parameter accepts named argument 'mediaType'
+  --> http-client-resource-e.bal:34:40
+   |
+34 |     http:Response _ = check c->/albums(mediaType = "text/plain"); // @error mediaType is a never field
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: no included record parameter accepts named argument 'message'
+  --> http-client-resource-e.bal:33:40
+   |
+33 |     http:Response _ = check c->/albums(message = "body"); // @error message is a never field
+   |                                        ^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: no included record parameter accepts named argument 'targetType'
+  --> http-client-resource-e.bal:32:40
+   |
+32 |     http:Response _ = check c->/albums(targetType = "json"); // @error targetType is a never field
+   |                                        ^^^^^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: no matching resource method 'get'
+  --> http-client-resource-e.bal:28:29
+   |
+28 |     http:Response _ = check c->/albums/[album]; // @error record is not a PathParamType
+   |                             ^^^^^^^^^^^^^^^^^^

--- a/corpus/integration/lib/subset3/http-client-resource-query-e.txtar
+++ b/corpus/integration/lib/subset3/http-client-resource-query-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: incompatible type: expected boolean|int|float|decimal|string|[boolean|int|float|decimal|string...], got {| id: int, never... |}
+  --> http-client-resource-query-e.bal:31:46
+   |
+31 |     http:Response _ = check c->/albums(tag = album); // @error record is not a QueryParamType
+   |                                              ^^^^^

--- a/corpus/integration/lib/subset3/http-client-resource-v.txtar
+++ b/corpus/integration/lib/subset3/http-client-resource-v.txtar
@@ -1,0 +1,19 @@
+-- stdout --
+200
+test body
+test body
+test body
+test body
+test body
+test body
+200
+test body
+200
+200
+200
+200
+200
+200
+200
+test body
+-- stderr --

--- a/corpus/lib/subset3/http-client-resource-e.bal
+++ b/corpus/lib/subset3/http-client-resource-e.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+type Album record {|
+    int id;
+|};
+
+public function main() returns error? {
+    http:Client c = check new ("https://example.com");
+    Album album = {id: 1};
+
+    // A computed path segment must be a member of `PathParamType`; a record is not.
+    http:Response _ = check c->/albums/[album]; // @error record is not a PathParamType
+
+    // `QueryParams` declares headers, targetType, message and mediaType as `never`,
+    // so none of them can be supplied as a query parameter.
+    http:Response _ = check c->/albums(targetType = "json"); // @error targetType is a never field
+    http:Response _ = check c->/albums(message = "body"); // @error message is a never field
+    http:Response _ = check c->/albums(mediaType = "text/plain"); // @error mediaType is a never field
+
+    return;
+}

--- a/corpus/lib/subset3/http-client-resource-query-e.bal
+++ b/corpus/lib/subset3/http-client-resource-query-e.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+type Album record {|
+    int id;
+|};
+
+// The compiler reports only the first failing client resource access in a
+// function, so this check lives in its own test rather than alongside the
+// other client resource method errors.
+public function main() returns error? {
+    http:Client c = check new ("https://example.com");
+    Album album = {id: 1};
+
+    // A query parameter value must be a `QueryParamType`.
+    http:Response _ = check c->/albums(tag = album); // @error record is not a QueryParamType
+
+    return;
+}

--- a/corpus/lib/subset3/http-client-resource-v.bal
+++ b/corpus/lib/subset3/http-client-resource-v.bal
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+
+public function main() returns error? {
+    http:Client c = check new ("https://example.com");
+
+    // Every accessor is reachable through the client resource access syntax and
+    // returns the raw response. `get` is the accessor when the call names none.
+    http:Response getResp = check c->/albums/[1];
+    io:println(getResp.statusCode); // @output 200
+    io:println(check getResp.getTextPayload()); // @output test body
+
+    http:Response postResp = check c->/albums.post("req");
+    io:println(check postResp.getTextPayload()); // @output test body
+
+    http:Response putResp = check c->/albums/[1].put("req");
+    io:println(check putResp.getTextPayload()); // @output test body
+
+    http:Response patchResp = check c->/albums/[1].patch("req");
+    io:println(check patchResp.getTextPayload()); // @output test body
+
+    // `delete` takes an optional message, so both forms are valid.
+    http:Response deleteResp = check c->/albums/[1].delete();
+    io:println(check deleteResp.getTextPayload()); // @output test body
+
+    http:Response deleteBodyResp = check c->/albums/[1].delete("req");
+    io:println(check deleteBodyResp.getTextPayload()); // @output test body
+
+    http:Response headResp = check c->/albums.head();
+    io:println(headResp.statusCode); // @output 200
+
+    http:Response optionsResp = check c->/albums.options();
+    io:println(check optionsResp.getTextPayload()); // @output test body
+
+    // A path may be the bare root, a chain of name segments, or a mix of name
+    // and computed segments covering every `PathParamType` member.
+    http:Response rootResp = check c->/;
+    io:println(rootResp.statusCode); // @output 200
+
+    http:Response nameResp = check c->/albums/tracks/comments;
+    io:println(nameResp.statusCode); // @output 200
+
+    decimal price = 2.5;
+    http:Response mixedResp = check c->/albums/[1]/[true]/[1.5]/[price]/["name"];
+    io:println(mixedResp.statusCode); // @output 200
+
+    // Headers and query parameters are both accepted, separately and together.
+    // Query parameters are named arguments gathered by `*QueryParams`.
+    http:Response hdrResp = check c->/albums({"X-Custom": "value"});
+    io:println(hdrResp.statusCode); // @output 200
+
+    http:Response queryResp = check c->/albums(tag = "rock", count = 3, exact = true);
+    io:println(queryResp.statusCode); // @output 200
+
+    http:Response arrQueryResp = check c->/albums(tags = ["rock", "jazz"]);
+    io:println(arrQueryResp.statusCode); // @output 200
+
+    http:Response bothResp = check c->/albums({"X-Custom": "value"}, tag = "rock");
+    io:println(bothResp.statusCode); // @output 200
+
+    // Query parameters also combine with a body-carrying accessor, alongside an
+    // explicit media type override.
+    http:Response postQueryResp = check c->/albums.post("req", mediaType = "text/plain", tag = "rock");
+    io:println(check postQueryResp.getTextPayload()); // @output test body
+
+    return;
+}

--- a/doc/library/subset3.md
+++ b/doc/library/subset3.md
@@ -123,6 +123,8 @@ The `LineStream` and `BlockStream` public helper classes are not declared;
 
 The client remote methods now bind the response payload directly to the contextually expected type instead of only returning an `http:Response`.
 
+The client can also address a resource with the client resource access syntax (`client->/albums/[id]`) rather than only through a remote method with a string path.
+
 ### Client — response data binding
 
 Every remote method except `head` takes a trailing `targetType` parameter with an inferred typedesc default:
@@ -183,6 +185,62 @@ The nilable form of such a target binds the same way: an absent body gives `()`,
 An `xml` target is the one builder that rejects an empty body outright: there is no empty `xml` value to bind, so a non-nilable `xml` target returns an error named `NoContentError` with the message `No content`. The nilable form `xml?` still gives `()`.
 
 Not covered in this subset: `stream<http:SseEvent, error?>` targets, status code response records (`http:StatusCodeClient`, `getStatusCodeRecord()`), and the `validation` / `laxDataBinding` client configuration flags.
+
+### Client — resource methods
+
+All seven accessors are declared as resource methods on `http:Client`, so a request can be written as a path rather than as a string argument:
+
+```ballerina
+resource isolated function get [PathParamType... path](map<string|string[]>? headers = (),
+        *QueryParams params) returns Response|error = external;
+```
+
+`PathParamType` is `boolean|int|float|decimal|string`. Each segment of the call site's path becomes one element of `path`, whether it was written as a name or as a computed segment, and `get` is the accessor used when the call site names none:
+
+```ballerina
+http:Client c = check new ("https://example.com");
+
+http:Response a = check c->/albums/[42]/tracks;      // GET /albums/42/tracks
+http:Response b = check c->/albums.post(payload);    // POST /albums
+http:Response d = check c->/albums/[42].delete();    // DELETE /albums/42
+http:Response e = check c->/;                        // GET /
+```
+
+`post`, `put`, `patch` and `delete` take a leading `message`, plus `headers` and `mediaType`, exactly as their remote counterparts do; `delete`'s `message` is defaultable. `head` and `options` take only `headers`.
+
+Query parameters are named arguments, collected by the `*QueryParams` included record parameter:
+
+```ballerina
+public type QueryParamType SimpleQueryParamType[]|SimpleQueryParamType;
+
+public type QueryParams record {|
+    never headers?;
+    never targetType?;
+    never message?;
+    never mediaType?;
+    QueryParamType...;
+|};
+```
+
+The four `never` fields reserve the names the method's own parameters use, so `headers`, `targetType`, `message` and `mediaType` cannot be smuggled in as query parameters.
+
+| Call | Request target |
+|---|---|
+| `c->/albums(tag = "rock", count = 3)` | `/albums?tag=rock&count=3` |
+| `c->/albums(tags = ["rock", "jazz"])` | `/albums?tags=rock,jazz` |
+| `c->/albums(q = "a b")` | `/albums?q=a+b` |
+| `c->/albums(q = "a&b=c")` | `/albums?q=a%26b%3Dc` |
+| `c->/p/[1.0]/[1.0e10]` | `/p/1.0/1e10` |
+| `c->/p/[d]` where `decimal d = 2.500` | `/p/2.500` |
+
+An array-valued query parameter is rendered as a single comma-joined pair rather than as a repeated key, and parameters keep the order the named arguments were written in.
+
+Two renderings deliberately differ from jBallerina's wire format, in both cases by preferring the Go-native or language-consistent behaviour over byte-level parity. Each is recorded in the [`http` README](../../lib/stdlibs/ballerina/http/0.0.1/go1.26/README.md) under **Notable Behavioural Changes** and is open to revisiting:
+
+- **Values use Ballerina's `toString`.** jBallerina formats a segment with Java's `String.valueOf`, so a `float` goes out as `Double.toString` gives it — `1.0E10`. Here every segment and query value goes through Ballerina's own `toString`, giving `1e10`. `int`, `boolean`, `decimal` and `string` are identical either way; a whole float still keeps its `.0` and a decimal still keeps its trailing zeros.
+- **Query components are escaped.** jBallerina concatenates the target and lets the transport encode only the space, so a value containing `&` or `=` silently splits into extra parameters. Here keys and values are escaped with `url.QueryEscape`, so such a value stays one parameter — at the cost of a space rendering as `+` rather than `%20`.
+
+Not covered in this subset: the `targetType` parameter. jBallerina's resource methods are dependently typed on `TargetType targetType = <>`, which the interpreter does not yet support for resource methods (#825), so these methods return the raw `http:Response` and a target of any other type is a compile error. Use the remote method form when the payload needs binding. The `@http:Query` annotation for renaming a query parameter on the wire is also not supported.
 
 ### Response
 

--- a/lib/stdlibs/ballerina/README.md
+++ b/lib/stdlibs/ballerina/README.md
@@ -14,7 +14,7 @@ in each package's support table (Supported + Partially Supported + Not Yet Suppo
 |---------------------------------------------------|---|---|---|---|
 | [avro](avro/0.0.1/go1.26/README.md)               | 15 | 1 | 0 | 94% |
 | [crypto](crypto/0.0.1/go1.26/README.md)           | 26 | 1 | 5 | 81% |
-| [http](http/0.0.1/go1.26/README.md)               | 28 | 7 | 38 | 38% |
+| [http](http/0.0.1/go1.26/README.md)               | 28 | 8 | 37 | 38% |
 | [io](io/0.0.1/go1.26/README.md)                   | 21 | 2 | 4 | 78% |
 | [log](log/0.0.1/go1.26/README.md)                 | 7 | 2 | 15 | 29% |
 | [math.vector](math.vector/0.0.1/go1.26/README.md) | 5 | 0 | 0 | 100% |
@@ -22,7 +22,7 @@ in each package's support table (Supported + Partially Supported + Not Yet Suppo
 | [random](random/0.0.1/go1.26/README.md)           | 3 | 1 | 1 | 60% |
 | [time](time/0.0.1/go1.26/README.md)               | 31 | 1 | 0 | 97% |
 | [url](url/0.0.1/go1.26/README.md)                 | 3 | 0 | 1 | 75% |
-| **Total**                                         | **150** | **16** | **64** | **65%** |
+| **Total**                                         | **150** | **17** | **63** | **65%** |
 
 ## Notable Behavioural Changes
 
@@ -54,6 +54,8 @@ tables instead.
 - **A nil target type discards the payload.** jBallerina routes a `()` target through the string payload builder, so a non-empty body is handed back as a `string` even though `()` was requested. The Go-native version returns `()` and drops the body, keeping the bound value inside the requested type.
 - **Status-code error messages use the registered reason phrase.** jBallerina reports the reason phrase the server actually sent. The PAL transport contract surfaces only the status code, so the Go-native version derives the message from the status code's registered phrase (for example `Not Found` for 404). A code outside the IANA registry — 499, which nginx sends for a client-closed request, among others — has no registered phrase, and the message becomes `status code <code>` rather than being left empty.
 - **A status error with an absent body keeps its reason phrase.** jBallerina extracts the error response body with the builder its `Content-Type` selects, and an extraction failure replaces the reason phrase with `http:ApplicationResponseError creation failed: <code> response payload extraction failed`. A 4xx or 5xx sent with `Content-Type: application/json` and no body at all trips that path, because a JSON decoder rejects an empty document. The Go-native version treats an absent body as having no payload, so the message stays the reason phrase and the error detail's `body` is `()`.
+- **Request targets are percent-encoded, where jBallerina leaves them mostly raw.** jBallerina builds the request target by string concatenation and lets Netty encode only the space, so a path or query value carrying a delimiter changes the request's meaning — `q=a&b=c` arrives as two query parameters, and `<`, `>`, `"`, `|`, `\`, `^`, `` ` ``, `{`, `}` and non-ASCII bytes go out raw in a technically invalid request line. The Go-native version escapes path segments through Go's `net/url` and query keys and values with `url.QueryEscape`, so a delimiter inside a value stays inside that value and every target is a valid URI. Two consequences: a space in a query value becomes `+` rather than `%20`, and a literal `%` that does not begin a valid escape (`/a%b`) makes Go's URL parser reject the path, returning an `error` where jBallerina sends it raw. This is a deliberate choice of the stricter behaviour over byte-level parity, and is open to revisiting if a real client depends on jBallerina's raw form.
+- **Path and query values use Ballerina's `toString`, not Java's.** jBallerina renders a path segment or query value with Java's `String.valueOf`, which for `float` is `Double.toString` — so it emits `1.0E10` and `1.0E-7`, diverging from what `lang.float:toString` produces for the same value. The Go-native version renders every segment and query value with Ballerina's own `toString` semantics, giving `1e10` and `1e-7`; `int`, `boolean`, `decimal` and `string` are unaffected and match jBallerina exactly. This keeps one rendering rule across the language and the library instead of reproducing a Java-specific format, and is likewise open to revisiting.
 - **`gracefulStop` waits for in-flight requests to drain.** In jBallerina, `gracefulStop` effectively behaves like an immediate stop — it returns promptly without waiting for active requests, so calling it from within a resource on its own listener succeeds. The Go-native version implements the `http:Listener` contract literally and blocks until in-flight requests complete or the graceful-stop timeout (default 60s) elapses. A resource that calls `gracefulStop` on the listener serving it therefore self-deadlocks until the timeout elapses and then returns an error, rather than succeeding.
 
 ### io

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/README.md
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/README.md
@@ -32,27 +32,27 @@ import ballerina/io;
 
 public function main() returns error? {
     // Plain HTTP client with a 10-second timeout and custom pool settings
-    http:Client client = check new ("http://httpbin.org", {
+    http:Client httpClient = check new ("http://httpbin.org", {
         timeout: 10,
         poolConfig: {maxIdleConnections: 50}
     });
 
     // GET request
-    http:Response getResp = check client->get("/get");
+    http:Response getResp = check httpClient->get("/get");
     io:println("Status: ", getResp.statusCode);
     json body = check getResp.getJsonPayload();
     io:println("Body: ", body);
 
     // POST request with a JSON payload
     json payload = {name: "Alice", age: 30};
-    http:Response postResp = check client->post("/post", payload);
+    http:Response postResp = check httpClient->post("/post", payload);
     io:println("POST status: ", postResp.statusCode);
 
     // Forward an inbound request to an upstream service
     http:Request req = new;
     req.method = "PUT";
     req.setJsonPayload({id: 1, data: "updated"});
-    http:Response fwdResp = check client->forward("/resource/1", req);
+    http:Response fwdResp = check httpClient->forward("/resource/1", req);
     io:println("Forward status: ", fwdResp.statusCode);
 
     // TLS client with a custom CA certificate

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/README.md
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/README.md
@@ -8,11 +8,12 @@ This module provides the HTTP client and listener APIs for building and consumin
 
 **Service / Listener** — an HTTP listener with configurable host, TLS, HTTP version, and request limits; service definition with path-based routing and resource function dispatch; automatic binding of path parameters, query parameters, headers, and payloads in resource signatures; caller-based response dispatch; request/response interceptor pipeline; service-level and resource-level annotations (`@http:ServiceConfig`, `@http:ResourceConfig`, `@http:Payload`, `@http:Header`, `@http:Query`, `@http:Cache`); CORS configuration; listener authentication and authorization (File user store, LDAP, JWT, OAuth2); status code response types from resources; and SSE streaming responses.
 
-The Go Native Interpreter supports the **HTTP client subset**: the nine core remote methods (including `forward`), TLS/mTLS (PEM-based), redirect following, connection pooling, and both manual payload extraction and automatic response data binding to the contextually expected type. It also supports a native **listener**: creating an `http:Listener`, attaching and detaching services, and starting and stopping it (`'start`, `gracefulStop`, `immediateStop`); attached services are dispatched by path-based routing to resource functions. See the Listener and Service tables below for the current support status of listener configuration, TLS, and broader service-side features.
+The Go Native Interpreter supports the **HTTP client subset**: the nine core remote methods (including `forward`), the client resource access syntax (`client->/albums/[id]`) for all seven accessors, TLS/mTLS (PEM-based), redirect following, connection pooling, and both manual payload extraction and automatic response data binding to the contextually expected type. It also supports a native **listener**: creating an `http:Listener`, attaching and detaching services, and starting and stopping it (`'start`, `gracefulStop`, `immediateStop`); attached services are dispatched by path-based routing to resource functions. See the Listener and Service tables below for the current support status of listener configuration, TLS, and broader service-side features.
 
 ## Key Functionalities
 
 - Send HTTP requests using GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, and custom verbs.
+- Address a resource with the client resource access syntax (`client->/albums/[id].put(payload)`), passing query parameters as named arguments.
 - Forward inbound requests to upstream services preserving method, headers, and body (`forward`).
 - Configure request timeout, HTTP version (1.1/2.0), redirect behaviour, connection pool settings, and compression negotiation.
 - Secure connections with TLS and mutual TLS using PEM certificate and key files.
@@ -47,6 +48,17 @@ public function main() returns error? {
     json payload = {name: "Alice", age: 30};
     http:Response postResp = check httpClient->post("/post", payload);
     io:println("POST status: ", postResp.statusCode);
+
+    // Client resource access syntax: path segments and query parameters.
+    // These always return the raw response — see the Client support table.
+    http:Response albumResp = check httpClient->/albums/[42]/tracks;
+    io:println("Resource status: ", albumResp.statusCode);
+
+    http:Response searchResp = check httpClient->/albums(genre = "rock", 'limit = 10);
+    io:println("Search status: ", searchResp.statusCode);
+
+    http:Response createResp = check httpClient->/albums.post({name: "Kind of Blue"});
+    io:println("Created: ", createResp.statusCode);
 
     // Forward an inbound request to an upstream service
     http:Request req = new;
@@ -109,7 +121,7 @@ Support Levels:
 | Proxy support | Supported | `ProxyConfig` is supported via the top-level `proxy` field in `ClientConfiguration`. Proxy auth (`userName`/`password`) is forwarded via HTTP CONNECT for HTTPS targets and `Proxy-Authorization` for HTTP targets. The deprecated `http1Settings.proxy` path is not supported (we have no `http1Settings`). DNS resolution of the proxy hostname is lazy (per-request) rather than eager at client init — initialization does not fail on an unresolvable proxy host. |
 | Async request submission | Not Yet Supported | `submit`, `getResponse`, and `HttpFuture` are not implemented. |
 | HTTP/2 server push | Not Yet Supported | `hasPromise`, `getNextPromise`, `getPromisedResponse`, and `rejectPromise` are not implemented. |
-| Resource function call syntax | Not Yet Supported | The `client->/path.get(...)` path-template syntax is not supported; use the remote method form instead. |
+| Resource function call syntax | Partially Supported | All seven accessors (`get`, `post`, `put`, `patch`, `delete`, `head`, `options`) are callable with the client resource access syntax — `client->/albums/[id].get(...)`, with `get` implied when no accessor is named. Path segments are typed `PathParamType` (`boolean\|int\|float\|decimal\|string`) values, and query parameters are passed as named arguments collected by the `*QueryParams` included record parameter. The `targetType` parameter is absent, so these methods always return the raw `http:Response` rather than binding the payload; a target other than `http:Response` is a compile error. Use the remote method form when data binding is needed. The `@http:Query` annotation for overriding a query parameter's name on the wire is not supported. |
 
 ### Request
 
@@ -189,4 +201,6 @@ Support Levels:
 - **A nil target type discards the payload.** jBallerina routes a `()` target through the string payload builder, so a non-empty body is handed back as a `string` even though `()` was requested. The Go-native version returns `()` and drops the body, keeping the bound value inside the requested type.
 - **Status-code error messages use the registered reason phrase.** jBallerina reports the reason phrase the server actually sent. The PAL transport contract surfaces only the status code, so the Go-native version derives the message from the status code's registered phrase (for example `Not Found` for 404). A code outside the IANA registry — 499, which nginx sends for a client-closed request, among others — has no registered phrase, and the message becomes `status code <code>` rather than being left empty.
 - **A status error with an absent body keeps its reason phrase.** jBallerina extracts the error response body with the builder its `Content-Type` selects, and an extraction failure replaces the reason phrase with `http:ApplicationResponseError creation failed: <code> response payload extraction failed`. A 4xx or 5xx sent with `Content-Type: application/json` and no body at all trips that path, because a JSON decoder rejects an empty document. The Go-native version treats an absent body as having no payload, so the message stays the reason phrase and the error detail's `body` is `()`.
+- **Request targets are percent-encoded, where jBallerina leaves them mostly raw.** jBallerina builds the request target by string concatenation and lets Netty encode only the space, so a path or query value carrying a delimiter changes the request's meaning — `q=a&b=c` arrives as two query parameters, and `<`, `>`, `"`, `|`, `\`, `^`, `` ` ``, `{`, `}` and non-ASCII bytes go out raw in a technically invalid request line. The Go-native version escapes path segments through Go's `net/url` and query keys and values with `url.QueryEscape`, so a delimiter inside a value stays inside that value and every target is a valid URI. Two consequences: a space in a query value becomes `+` rather than `%20`, and a literal `%` that does not begin a valid escape (`/a%b`) makes Go's URL parser reject the path, returning an `error` where jBallerina sends it raw. This is a deliberate choice of the stricter behaviour over byte-level parity, and is open to revisiting if a real client depends on jBallerina's raw form.
+- **Path and query values use Ballerina's `toString`, not Java's.** jBallerina renders a path segment or query value with Java's `String.valueOf`, which for `float` is `Double.toString` — so it emits `1.0E10` and `1.0E-7`, diverging from what `lang.float:toString` produces for the same value. The Go-native version renders every segment and query value with Ballerina's own `toString` semantics, giving `1e10` and `1e-7`; `int`, `boolean`, `decimal` and `string` are unaffected and match jBallerina exactly. This keeps one rendering rule across the language and the library instead of reproducing a Java-specific format, and is likewise open to revisiting.
 - **`gracefulStop` waits for in-flight requests to drain.** In jBallerina, `gracefulStop` effectively behaves like an immediate stop — it returns promptly without waiting for active requests, so calling it from within a resource on its own listener succeeds. The Go-native version implements the `http:Listener` contract literally and blocks until in-flight requests complete or the graceful-stop timeout (default 60s) elapses. A resource that calls `gracefulStop` on the listener serving it therefore self-deadlocks until the timeout elapses and then returns an error, rather than succeeding.

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/http.bal
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/http.bal
@@ -542,6 +542,28 @@ public type RequestMessage anydata|Request;
 # in this implementation, since Server-Sent Events are not available.
 public type TargetType typedesc<Response|anydata>;
 
+# Defines the path parameter types.
+public type PathParamType boolean|int|float|decimal|string;
+
+# Defines the possible simple query parameter types.
+public type SimpleQueryParamType boolean|int|float|decimal|string;
+
+# Defines the query parameter type supported with client resource methods.
+public type QueryParamType SimpleQueryParamType[]|SimpleQueryParamType;
+
+# Defines the record type of query parameters supported with client resource methods.
+# + headers - headers which cannot be used as a query field
+# + targetType - targetType which cannot be used as a query field
+# + message - message which cannot be used as a query field
+# + mediaType - mediaType which cannot be used as a query field
+public type QueryParams record {|
+    never headers?;
+    never targetType?;
+    never message?;
+    never mediaType?;
+    QueryParamType...;
+|};
+
 // Represents HTTP methods.
 public enum Method {
     GET,
@@ -793,4 +815,90 @@ public isolated client class Client {
     #             if the request or the data binding fails
     remote isolated function forward(string path, Request request,
             TargetType targetType = <>) returns targetType|error = external;
+
+    # Retrieves a representation of the specified resource, addressed with the client resource
+    # access path syntax (`client->/albums/[id]`).
+    #
+    # The `targetType` parameter of jBallerina's client resource methods is absent here, so the
+    # raw `Response` is always returned; see the README's *Resource function call syntax* row.
+    #
+    # + path - The resource path segments, appended to the base URL
+    # + headers - Optional request headers as a `map<string|string[]>`
+    # + params - Query parameters, supplied as named arguments
+    # + return - The `http:Response`, or an `error` if the request fails
+    isolated resource function get [PathParamType... path](map<string|string[]>? headers = (),
+            *QueryParams params) returns Response|error = external;
+
+    # Creates a new resource or submits data to a resource for processing, addressed with the
+    # client resource access path syntax (`client->/albums.post(payload)`).
+    #
+    # + path - The resource path segments, appended to the base URL
+    # + message - The request body (`string`, `byte[]`, JSON-compatible value, or `http:Request`)
+    # + headers - Optional request headers as a `map<string|string[]>`
+    # + mediaType - Optional `Content-Type` override; inferred from `message` if omitted
+    # + params - Query parameters, supplied as named arguments
+    # + return - The `http:Response`, or an `error` if the request fails
+    isolated resource function post [PathParamType... path](RequestMessage message,
+            map<string|string[]>? headers = (), string? mediaType = (),
+            *QueryParams params) returns Response|error = external;
+
+    # Creates a new resource or replaces a representation of the specified resource, addressed
+    # with the client resource access path syntax (`client->/albums/[id].put(payload)`).
+    #
+    # + path - The resource path segments, appended to the base URL
+    # + message - The request body (`string`, `byte[]`, JSON-compatible value, or `http:Request`)
+    # + headers - Optional request headers as a `map<string|string[]>`
+    # + mediaType - Optional `Content-Type` override; inferred from `message` if omitted
+    # + params - Query parameters, supplied as named arguments
+    # + return - The `http:Response`, or an `error` if the request fails
+    isolated resource function put [PathParamType... path](RequestMessage message,
+            map<string|string[]>? headers = (), string? mediaType = (),
+            *QueryParams params) returns Response|error = external;
+
+    # Applies a partial modification to the specified resource, addressed with the client
+    # resource access path syntax (`client->/albums/[id].patch(payload)`).
+    #
+    # + path - The resource path segments, appended to the base URL
+    # + message - The request body (`string`, `byte[]`, JSON-compatible value, or `http:Request`)
+    # + headers - Optional request headers as a `map<string|string[]>`
+    # + mediaType - Optional `Content-Type` override; inferred from `message` if omitted
+    # + params - Query parameters, supplied as named arguments
+    # + return - The `http:Response`, or an `error` if the request fails
+    isolated resource function patch [PathParamType... path](RequestMessage message,
+            map<string|string[]>? headers = (), string? mediaType = (),
+            *QueryParams params) returns Response|error = external;
+
+    # Deletes the specified resource, addressed with the client resource access path syntax
+    # (`client->/albums/[id].delete()`).
+    #
+    # + path - The resource path segments, appended to the base URL
+    # + message - An optional request body (`string`, `byte[]`, JSON-compatible value, or
+    #             `http:Request`)
+    # + headers - Optional request headers as a `map<string|string[]>`
+    # + mediaType - Optional `Content-Type` override; inferred from `message` if omitted
+    # + params - Query parameters, supplied as named arguments
+    # + return - The `http:Response`, or an `error` if the request fails
+    isolated resource function delete [PathParamType... path](RequestMessage message = (),
+            map<string|string[]>? headers = (), string? mediaType = (),
+            *QueryParams params) returns Response|error = external;
+
+    # Retrieves the headers of the specified resource without a body, addressed with the client
+    # resource access path syntax (`client->/albums/[id].head()`).
+    #
+    # + path - The resource path segments, appended to the base URL
+    # + headers - Optional request headers as a `map<string|string[]>`
+    # + params - Query parameters, supplied as named arguments
+    # + return - The `http:Response`, or an `error` if the request fails
+    isolated resource function head [PathParamType... path](map<string|string[]>? headers = (),
+            *QueryParams params) returns Response|error = external;
+
+    # Retrieves the communication options available for the specified resource, addressed with
+    # the client resource access path syntax (`client->/albums.options()`).
+    #
+    # + path - The resource path segments, appended to the base URL
+    # + headers - Optional request headers as a `map<string|string[]>`
+    # + params - Query parameters, supplied as named arguments
+    # + return - The `http:Response`, or an `error` if the request fails
+    isolated resource function options [PathParamType... path](map<string|string[]>? headers = (),
+            *QueryParams params) returns Response|error = external;
 }

--- a/lib/stdlibs/ballerina/http/0.0.1/go1.26/native/http_native.go
+++ b/lib/stdlibs/ballerina/http/0.0.1/go1.26/native/http_native.go
@@ -434,36 +434,31 @@ func initHttpModule(rt *runtime.Runtime) {
 		return bytes.NewReader(b), int64(len(b)), ct
 	}
 
-	// execBody serves post, put, patch and delete, whose parameter lists are identical:
-	// [self, path, message, headers, mediaType, targetType].
-	execBody := func(ctx *extern.Context, verb string, args []values.BalValue) (values.BalValue, error) {
-		self := args[0].(*values.Object)
-		path := args[1].(string)
+	// sendBody issues a request carrying a payload and returns the raw Response. It backs
+	// post, put, patch and delete in both their remote and client-resource forms. Exactly one
+	// of the two results is non-nil.
+	sendBody := func(ctx *extern.Context, verb, path string, self *values.Object,
+		msg, headersArg, mediaTypeArg values.BalValue) (*values.Object, values.BalValue) {
 		var bodyReader io.Reader
 		var contentLength int64
 		contentType := ""
-		if len(args) > 2 && args[2] != nil {
+		if msg != nil {
 			var ct string
-			bodyReader, contentLength, ct = msgToBody(ctx.TypeCtx(), args[2])
+			bodyReader, contentLength, ct = msgToBody(ctx.TypeCtx(), msg)
 			if bodyReader == nil && ct == "json_error" {
-				return values.NewErrorWithMessage("failed to serialize body to JSON"), nil
+				return nil, values.NewErrorWithMessage("failed to serialize body to JSON")
 			}
 			contentType = ct
 		}
-		var reqHeaders map[string][]string
-		if len(args) > 3 {
-			reqHeaders = extractHeaders(args[3])
-			for hdrKey, hdrVals := range reqHeaders {
-				if strings.EqualFold(hdrKey, "content-type") && len(hdrVals) > 0 {
-					contentType = hdrVals[0]
-					break
-				}
+		reqHeaders := extractHeaders(headersArg)
+		for hdrKey, hdrVals := range reqHeaders {
+			if strings.EqualFold(hdrKey, "content-type") && len(hdrVals) > 0 {
+				contentType = hdrVals[0]
+				break
 			}
 		}
-		if len(args) > 4 {
-			if mt, ok := args[4].(string); ok && mt != "" {
-				contentType = mt
-			}
+		if mt, ok := mediaTypeArg.(string); ok && mt != "" {
+			contentType = mt
 		}
 		reqHeaders = applyCompressionHeaders(compressionModeOf(self), reqHeaders)
 		urlVal, _ := self.Get("url")
@@ -471,9 +466,35 @@ func initHttpModule(rt *runtime.Runtime) {
 		statusCode, respHeaders, respBodyStream, err := clientHandle.(pal.HTTPClient).Execute(
 			goCtxOrBackground(ctx), verb, urlVal.(string)+path, bodyReader, contentLength, contentType, reqHeaders)
 		if err != nil {
-			return values.NewErrorWithMessage(err.Error()), nil
+			return nil, values.NewErrorWithMessage(err.Error())
 		}
-		resp := buildResponse(ctx.TypeCtx(), statusCode, respHeaders, respBodyStream)
+		return buildResponse(ctx.TypeCtx(), statusCode, respHeaders, respBodyStream), nil
+	}
+
+	// sendSimple issues a request with no payload and returns the raw Response. It backs get,
+	// head and options in both their remote and client-resource forms. Exactly one of the two
+	// results is non-nil.
+	sendSimple := func(ctx *extern.Context, verb, path string, self *values.Object,
+		headersArg values.BalValue) (*values.Object, values.BalValue) {
+		reqHeaders := applyCompressionHeaders(compressionModeOf(self), extractHeaders(headersArg))
+		urlVal, _ := self.Get("url")
+		clientHandle, _ := self.Get("$httpClient")
+		statusCode, respHeaders, respBodyStream, err := clientHandle.(pal.HTTPClient).Execute(
+			goCtxOrBackground(ctx), verb, urlVal.(string)+path, nil, 0, "", reqHeaders)
+		if err != nil {
+			return nil, values.NewErrorWithMessage(err.Error())
+		}
+		return buildResponse(ctx.TypeCtx(), statusCode, respHeaders, respBodyStream), nil
+	}
+
+	// execBody serves the remote post, put, patch and delete methods, whose parameter lists
+	// are identical: [self, path, message, headers, mediaType, targetType].
+	execBody := func(ctx *extern.Context, verb string, args []values.BalValue) (values.BalValue, error) {
+		resp, errVal := sendBody(ctx, verb, args[1].(string), args[0].(*values.Object),
+			args[2], args[3], args[4])
+		if errVal != nil {
+			return errVal, nil
+		}
 		return bindResponse(ctx, &types, resp, args[5]), nil
 	}
 
@@ -500,8 +521,51 @@ func initHttpModule(rt *runtime.Runtime) {
 			"$remote$execute": {FunctionLookupKey: "ballerina/http:Client.$remote$execute"},
 			"$remote$forward": {FunctionLookupKey: "ballerina/http:Client.$remote$forward"},
 		},
+		RTable: make(map[string][]bir.BIRResourceMethod, len(clientResourceAccessors)),
+	}
+	// A resource method's extern lookup key embeds its declaration index within the class
+	// (mangledResourceMethodName), so this list must stay in the same order as the resource
+	// methods on `Client` in http.bal. A mismatch binds an accessor to the wrong verb, which
+	// corpus/extern/testdata/http-service/http-svc-client-resource-v.bal catches by asserting
+	// the method each accessor actually puts on the wire.
+	for idx, accessor := range clientResourceAccessors {
+		clientClassDef.RTable[accessor] = []bir.BIRResourceMethod{{
+			RestSegmentTy: pathParamType(),
+			Fn: &bir.BIRFunction{
+				FunctionLookupKey: "ballerina/http:" + clientResourceExternKey(accessor, idx),
+			},
+		}}
 	}
 	runtime.RegisterExternClassDef(rt, clientClassDef)
+
+	for idx, accessor := range clientResourceAccessors {
+		verb := strings.ToUpper(accessor)
+		switch accessor {
+		case "get", "head", "options":
+			// args = [self, path, headers, params]
+			runtime.RegisterExternFunction(rt, orgName, moduleName, clientResourceExternKey(accessor, idx),
+				func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+					path := resourceRequestPath(args[1].(*values.List), args[3])
+					resp, errVal := sendSimple(ctx, verb, path, args[0].(*values.Object), args[2])
+					if errVal != nil {
+						return errVal, nil
+					}
+					return resp, nil
+				})
+		default:
+			// args = [self, path, message, headers, mediaType, params]
+			runtime.RegisterExternFunction(rt, orgName, moduleName, clientResourceExternKey(accessor, idx),
+				func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+					path := resourceRequestPath(args[1].(*values.List), args[5])
+					resp, errVal := sendBody(ctx, verb, path, args[0].(*values.Object),
+						args[2], args[3], args[4])
+					if errVal != nil {
+						return errVal, nil
+					}
+					return resp, nil
+				})
+		}
+	}
 
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "parseHeader",
 		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
@@ -777,21 +841,10 @@ func initHttpModule(rt *runtime.Runtime) {
 
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "Client.$remote$get",
 		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
-			self := args[0].(*values.Object)
-			path := args[1].(string)
-			var reqHeaders map[string][]string
-			if len(args) > 2 {
-				reqHeaders = extractHeaders(args[2])
+			resp, errVal := sendSimple(ctx, "GET", args[1].(string), args[0].(*values.Object), args[2])
+			if errVal != nil {
+				return errVal, nil
 			}
-			reqHeaders = applyCompressionHeaders(compressionModeOf(self), reqHeaders)
-			urlVal, _ := self.Get("url")
-			clientHandle, _ := self.Get("$httpClient")
-			statusCode, respHeaders, respBodyStream, err := clientHandle.(pal.HTTPClient).Execute(
-				goCtxOrBackground(ctx), "GET", urlVal.(string)+path, nil, 0, "", reqHeaders)
-			if err != nil {
-				return values.NewErrorWithMessage(err.Error()), nil
-			}
-			resp := buildResponse(ctx.TypeCtx(), statusCode, respHeaders, respBodyStream)
 			return bindResponse(ctx, &types, resp, args[3]), nil
 		})
 
@@ -802,40 +855,19 @@ func initHttpModule(rt *runtime.Runtime) {
 
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "Client.$remote$head",
 		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
-			self := args[0].(*values.Object)
-			path := args[1].(string)
-			var reqHeaders map[string][]string
-			if len(args) > 2 {
-				reqHeaders = extractHeaders(args[2])
+			resp, errVal := sendSimple(ctx, "HEAD", args[1].(string), args[0].(*values.Object), args[2])
+			if errVal != nil {
+				return errVal, nil
 			}
-			reqHeaders = applyCompressionHeaders(compressionModeOf(self), reqHeaders)
-			urlVal, _ := self.Get("url")
-			clientHandle, _ := self.Get("$httpClient")
-			statusCode, respHeaders, respBodyStream, err := clientHandle.(pal.HTTPClient).Execute(
-				goCtxOrBackground(ctx), "HEAD", urlVal.(string)+path, nil, 0, "", reqHeaders)
-			if err != nil {
-				return values.NewErrorWithMessage(err.Error()), nil
-			}
-			return buildResponse(ctx.TypeCtx(), statusCode, respHeaders, respBodyStream), nil
+			return resp, nil
 		})
 
 	runtime.RegisterExternFunction(rt, orgName, moduleName, "Client.$remote$options",
 		func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
-			self := args[0].(*values.Object)
-			path := args[1].(string)
-			var reqHeaders map[string][]string
-			if len(args) > 2 {
-				reqHeaders = extractHeaders(args[2])
+			resp, errVal := sendSimple(ctx, "OPTIONS", args[1].(string), args[0].(*values.Object), args[2])
+			if errVal != nil {
+				return errVal, nil
 			}
-			reqHeaders = applyCompressionHeaders(compressionModeOf(self), reqHeaders)
-			urlVal, _ := self.Get("url")
-			clientHandle, _ := self.Get("$httpClient")
-			statusCode, respHeaders, respBodyStream, err := clientHandle.(pal.HTTPClient).Execute(
-				goCtxOrBackground(ctx), "OPTIONS", urlVal.(string)+path, nil, 0, "", reqHeaders)
-			if err != nil {
-				return values.NewErrorWithMessage(err.Error()), nil
-			}
-			resp := buildResponse(ctx.TypeCtx(), statusCode, respHeaders, respBodyStream)
 			return bindResponse(ctx, &types, resp, args[3]), nil
 		})
 
@@ -1839,4 +1871,80 @@ func headerListValues(hdrs *values.Map, name string) []string {
 // toJSONBytes serializes a Ballerina value to JSON bytes.
 func toJSONBytes(v values.BalValue) ([]byte, error) {
 	return values.ToJSONByteArray(v)
+}
+
+// clientResourceAccessors lists the resource methods declared on the `Client` class in their
+// http.bal declaration order. That order is load-bearing: a resource method's symbol name is
+// mangled as `$resource$<accessor>$<index>` from its position in the class, so the extern
+// lookup keys are derived from this list rather than written out per method.
+var clientResourceAccessors = []string{"get", "post", "put", "patch", "delete", "head", "options"}
+
+func clientResourceExternKey(accessor string, idx int) string {
+	return fmt.Sprintf("Client.$resource$%s$%d", accessor, idx)
+}
+
+// pathParamType is the `http:PathParamType` union, used as the rest-segment type of every
+// client resource method so the compiler coerces each path segment to a member of it.
+func pathParamType() semtypes.SemType {
+	return semtypes.Union(semtypes.Boolean,
+		semtypes.Union(semtypes.Int,
+			semtypes.Union(semtypes.Float,
+				semtypes.Union(semtypes.Decimal, semtypes.String))))
+}
+
+// resourceRequestPath renders client resource access path segments and query parameters into a
+// request path: segments are joined with "/", then any query parameters are appended after "?".
+// An empty segment list yields "/". Every segment and query value is rendered with Ballerina's
+// own `toString` semantics, and query keys and values are percent-encoded by net/url — see the
+// README's "Notable Behavioural Changes" for how both differ from jBallerina's wire format.
+func resourceRequestPath(segments *values.List, params values.BalValue) string {
+	var sb strings.Builder
+	for i := range segments.Len() {
+		sb.WriteByte('/')
+		sb.WriteString(balString(segments.Get(i)))
+	}
+	if sb.Len() == 0 {
+		sb.WriteByte('/')
+	}
+	if query := queryParamString(params); query != "" {
+		sb.WriteByte('?')
+		sb.WriteString(query)
+	}
+	return sb.String()
+}
+
+// queryParamString renders a `QueryParams` record as "k=v" pairs joined with "&", in field
+// insertion order. An array-valued field becomes a single comma-joined pair ("k=a,b,c") rather
+// than a repeated key, matching jBallerina's constructQueryString.
+func queryParamString(params values.BalValue) string {
+	// The compiler always materialises the included record, even when the call
+	// supplies no query arguments, so this is never anything but a map.
+	paramMap := params.(*values.Map)
+	pairs := make([]string, 0, paramMap.Len())
+	for _, key := range paramMap.Keys() {
+		val, _ := paramMap.Get(key)
+		pairs = append(pairs, url.QueryEscape(key)+"="+queryParamValueString(val))
+	}
+	return strings.Join(pairs, "&")
+}
+
+// queryParamValueString escapes each element separately so the comma joining array elements
+// stays a delimiter rather than becoming part of an escaped value.
+func queryParamValueString(v values.BalValue) string {
+	list, ok := v.(*values.List)
+	if !ok {
+		return url.QueryEscape(balString(v))
+	}
+	parts := make([]string, list.Len())
+	for i := range list.Len() {
+		parts[i] = url.QueryEscape(balString(list.Get(i)))
+	}
+	return strings.Join(parts, ",")
+}
+
+// balString renders a PathParamType or SimpleQueryParamType value the way Ballerina's own
+// `toString` would. The visited set is only consulted for structured values, which these
+// never are.
+func balString(v values.BalValue) string {
+	return values.String(v, map[uintptr]bool{})
 }


### PR DESCRIPTION
Advances: https://github.com/ballerina-nutcracker/ballerina/issues/653 (the syntax lands here; the data-binding half is blocked)

Blocked by: https://github.com/ballerina-nutcracker/ballerina/issues/825 (dependently-typed resource methods — filed from this work)

Stacked on: https://github.com/ballerina-nutcracker/ballerina/pull/814 — base is `revamp-lib-tests`, review only the top two commits

## Summary

Declares all seven accessors on `http:Client` as resource methods, so a request can be addressed with the client resource access syntax (`client->/albums/[id].put(payload)`) instead of a string path. Promotes *Resource function call syntax* in the module README from **Not Yet Supported** to **Partially Supported**.

- `get`, `post`, `put`, `patch`, `delete`, `head` and `options` are all callable as resource methods, with `get` implied when the call site names no accessor
- Path segments are typed `PathParamType` (`boolean|int|float|decimal|string`) values; name segments and computed segments render identically
- Query parameters are named arguments gathered by the `*QueryParams` included record parameter. `PathParamType`, `SimpleQueryParamType`, `QueryParamType` and `QueryParams` are copied verbatim from jBallerina's `http_commons.bal`, including the four `never` fields that reserve the method's own parameter names
- An array-valued query parameter becomes a single comma-joined pair (`?tags=rock,jazz`) rather than a repeated key, matching jBallerina's `constructQueryString`
- `sendSimple` and `sendBody` are extracted so the remote and resource forms share one request path, which also removes the duplication between the remote `get`, `head` and `options` implementations

**Why Partially Supported and not Supported.** Every jBallerina client resource method except `head` is dependently typed on `TargetType targetType = <>`, and the interpreter does not support dependent typing for resource methods (#825 — plain functions and remote methods are fine, resource methods are not). So these methods omit `targetType` and always return the raw `http:Response`; a target of any other type is a compile error, and the remote form remains the way to bind a payload. Everything else about the feature — rest path segments, typed computed segments, extern dispatch, included record parameters — already worked, so this is the whole feature minus one parameter.

Adding `targetType` later is source-compatible: `http:Response r = check c->/albums;` keeps working, because a `Response` target already yields the raw response on the dependently-typed remote methods today. Shipping the syntax now also keeps `never targetType?` in `QueryParams`, so the name cannot be squatted by a query parameter in the meantime.

## Example

```ballerina
import ballerina/http;
import ballerina/io;

public function main() returns error? {
    http:Client c = check new ("http://localhost:8080");

    // `get` is implied when the call site names no accessor
    http:Response album = check c->/albums/[42]/tracks;
    io:println(album.statusCode);

    // Query parameters are named arguments
    http:Response search = check c->/albums(genre = "rock", 'limit = 10);

    // An array query parameter is comma-joined into one pair
    http:Response tagged = check c->/albums(tags = ["rock", "jazz"]);

    // Body-carrying accessors take the message first, then headers,
    // mediaType, and any query parameters
    http:Response created = check c->/albums.post({name: "Kind of Blue"});
    http:Response typed = check c->/albums.post("raw", mediaType = "text/plain", tag = "rock");

    // `delete`'s message is optional; `head` and `options` take no body
    http:Response removed = check c->/albums/[42].delete();
    http:Response meta = check c->/albums.head();

    // An empty path segment list is the root path
    http:Response root = check c->/;
}
```

## Notes

- **The extern lookup key of a resource method embeds its declaration index.** `mangledResourceMethodName` names a resource method `$resource$<accessor>$<index>` from its position among the class's resource methods, so the keys are `Client.$resource$get$0` … `Client.$resource$options$6`. Reordering the methods in `http.bal` without reordering `clientResourceAccessors` would silently bind each accessor to the wrong native implementation. There is one ordered list as the source of truth, and `http-svc-client-resource-v.bal` catches a mismatch by asserting the verb each accessor actually puts on the wire. A stable mangled name in the compiler would be the real fix and belongs with #825's work.
- **The synthetic `BIRClassDef` needs an `RTable`.** Without one the call fails with a bare nil dereference rather than naming the missing extern — filed as #826, since the remote path produces a clean `function not found` for the same mistake.
- **Two renderings deliberately differ from jBallerina, both open to revisiting.** These are choices to prefer the Go-native or language-consistent behaviour over byte-level parity, not gaps; both are recorded under **Notable Behavioural Changes**.
  - Segments and query values go through Ballerina's own `toString` (`values.String`) rather than Java's `String.valueOf`. jBallerina formats a `float` with `Double.toString` and emits `1.0E10`, which diverges from what `lang.float:toString` gives for the same value; this emits `1e10`. `int`, `boolean`, `decimal` and `string` are identical either way. One rendering rule now covers the language and the library instead of reproducing a Java-specific format.
  - Query keys and values are escaped with `url.QueryEscape` rather than concatenated raw. jBallerina lets Netty encode only the space, so a value containing `&` or `=` silently splits into extra parameters — `q=a&b=c` arrives as two. Here it stays one parameter (`?q=a%26b%3Dc`). The cost is that a space renders as `+` rather than `%20`.
  - An earlier revision reproduced both jBallerina behaviours exactly, which needed a hand-written `Double.toString` equivalent and a custom minimal-escape routine. Dropping them removed five functions and ~85 lines of formatting code, and eliminated the only partially-covered branch in the new code.
- **Path segments are percent-encoded more strictly than jBallerina's, pre-existing.** Go's `net/http` encodes every character RFC 3986 disallows in a path, where Netty passes them raw. This applies equally to the remote methods and is not introduced here — verified by running the same characters through `c->get(path)` — but path parameters make it much easier to reach, so it is now documented.
- **`ClientError` is still `error`.** The distinct `http:ClientError` hierarchy is not declared in this port, so these methods return `Response|error` where jBallerina returns `targetType|ClientError`. This follows the existing package-wide decision rather than adding a divergence; every other method already does the same.
- **`@http:Query` is not supported.** jBallerina reads field annotations off the `QueryParams` record to override a query parameter's name on the wire. Recorded in the support row.
- Public contract checked against jBallerina `module-ballerina-http` 2201.13.5: the four public types match byte for byte, and every parameter name, order, type and default matches — including `delete`'s defaultable `message`. The only deltas are the two tracked ones above (`targetType`, `ClientError`). `http.bal` is purely additive: 108 insertions, no deletions, so no existing signature moved.
- Documented in `doc/library/subset3.md`; the module README row was promoted and the top-level aggregator recounted (http 26/7/40 → 26/8/39, 36% unchanged; Total 148/16/66 → 148/17/65, 64% unchanged).

## Behavioural parity

Verified by pointing both jBallerina 2201.13.5 and this interpreter at a raw request-line echo server and diffing the observed request targets.

| Case | jBallerina | Go native |
|---|---|---|
| `int`, `boolean` segments | `/p/0/42/-5`, `/p/true/false` | same |
| `float` in `[1e-3, 1e7)` | `/p/1.0/1.5/-2.75` | same |
| `decimal`, trailing zeros kept | `/p/1.0/2.500` | same |
| Non-finite `float` | `/p/NaN/Infinity/-Infinity` | same |
| Name and computed string segments | `/p/albums/tracks` | same |
| Empty segment list | `/` | same |
| Query pairs, insertion order kept | `?tag=rock&count=3&exact=true` | same |
| Array query parameter | `?tags=rock,jazz,folk` | same |
| `float` outside `[1e-3, 1e7)` | `/p/1.0E10/1.0E-7` | **`/p/1e10/1e-7`** — deliberate, see Notes |
| Space in a query value | `?q=a%20b` | **`?q=a+b`** — deliberate, see Notes |
| Delimiter in a query value, `q = "a&b=c"` | `?q=a&b=c` (splits into two) | **`?q=a%26b%3Dc`** (stays one) — deliberate |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt` clean; stdlib README format checker passes
- [x] New `corpus/extern/testdata/http-service/http-svc-client-resource-v.bal` drives all seven accessors against a real `http:Listener` over loopback, with the service echoing back the method it dispatched on — so an accessor bound to the wrong native implementation surfaces as a mismatched verb. Covers both `delete` forms, request headers, and a `mediaType` override
- [x] New `corpus/extern/testdata/http-service/http-svc-client-resource-path-v.bal` asserts the request target the client actually builds, by echoing `req.rawPath`: every `PathParamType` member, non-finite floats, scientific-notation floats, decimals with trailing zeros, the root path via a service mounted at `/`, query assembly and ordering, comma-joined arrays, and both escaping cases
- [x] New `corpus/lib/subset3/http-client-resource-v.bal` covers the callable surface through the stub transport
- [x] New `corpus/lib/subset3/http-client-resource-e.bal` and `http-client-resource-query-e.bal` cover the compile-time errors: a record as a path segment, and `targetType` / `message` / `mediaType` / a non-`QueryParamType` value as query parameters. Split across two files because the compiler reports only the first failing resource access per function
- [x] Every new native function at 100% of statements, exercised entirely from Ballerina — no Go unit tests were needed once the real-listener fixtures could assert the request target

Also found while writing the tests, unrelated to this change and pre-existing on `main`: `trap` applied to any action panics the compiler with no diagnostic (https://github.com/ballerina-nutcracker/ballerina/issues/829). Not worked around here — the affected test case was simply dropped.
