### PR TITLE
chore(lint): enable reassign and iota mixing checks

### DIFF
--- a/.golangci/no-panic.yml
+++ b/.golangci/no-panic.yml
@@ -7,6 +7,7 @@ linters:
     - dupl
     - exhaustive
     - iface
+    - iotamixing
     - reassign
     - unparam
     - forbidigo

--- a/.golangci/no-panic.yml
+++ b/.golangci/no-panic.yml
@@ -7,9 +7,13 @@ linters:
     - dupl
     - exhaustive
     - iface
+    - reassign
     - unparam
     - forbidigo
   settings:
+    reassign:
+      patterns:
+        - ".*"
     exhaustive:
       default-signifies-exhaustive: true
     forbidigo:

--- a/.golangci/strict.yml
+++ b/.golangci/strict.yml
@@ -7,6 +7,7 @@ linters:
     - dupl
     - exhaustive
     - iface
+    - iotamixing
     - reassign
     - unparam
   settings:

--- a/.golangci/strict.yml
+++ b/.golangci/strict.yml
@@ -7,8 +7,12 @@ linters:
     - dupl
     - exhaustive
     - iface
+    - reassign
     - unparam
   settings:
+    reassign:
+      patterns:
+        - ".*"
     exhaustive:
       default-signifies-exhaustive: true
     depguard:


### PR DESCRIPTION
## Purpose

Enable additional lint checks for frontend, values, and runtime code.

## Approach

- Enable `reassign` to detect reassignment of package-level variables.
- Enable `iotamixing` to prevent mixing iota and non-iota declarations in const blocks.

## Checklist
- [x] Read the [Contributing Guide](CONTRIBUTING.md)
- [x] Corpus tests are not applicable to lint configuration changes

## Remarks

All affected modules pass lint and targeted tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality checks to detect mixed integer and unsigned integer operations.
  * Added checks for unintended variable reassignment in strict and no-panic validation configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->