### PR TITLE
fix(semantics): fall back to lang.value in method-call resolution

### DIFF
--- a/corpus/ast/subset9/09-value/fromjsonwithtype-v.txt
+++ b/corpus/ast/subset9/09-value/fromjsonwithtype-v.txt
@@ -93,6 +93,45 @@
         (invocation io println (
           (simple-var-ref s))))
       (var-def
+        (variable plainInt (type
+          (value-type int)) (expr
+          (literal 7))))
+      (var-def
+        (variable viaInt (type
+          (value-type int)) (expr
+          (checked-expr
+            (invocation fromJsonWithType expr:
+              (simple-var-ref plainInt) (
+              (typedesc-expr
+                (value-type int))))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref viaInt))))
+      (var-def
+        (variable plainRecord (type
+          (record-type
+            (field name
+              (value-type string))
+            (field age
+              (value-type int)))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (literal Alice))
+            (key-value
+              (literal age)
+              (literal 30))))))
+      (var-def
+        (variable viaRecord (type
+          (user-defined-type Person)) (expr
+          (checked-expr
+            (invocation fromJsonWithType expr:
+              (simple-var-ref plainRecord) (
+              (simple-var-ref Person)))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref viaRecord))))
+      (var-def
         (variable noAge (type
           (builtin-ref-type json)) (expr
           (mapping-constructor-expr

--- a/corpus/bal/subset9/09-value/fromjsonwithtype-e.bal
+++ b/corpus/bal/subset9/09-value/fromjsonwithtype-e.bal
@@ -18,5 +18,5 @@ public function main() {
     json arr = [1, 2];
     arr.fromJsonWithType(); // @error
     int x = 1;
-    x.fromJsonWithType(int); // @error
+    x.fromJsonWithType(); // @error
 }

--- a/corpus/bal/subset9/09-value/fromjsonwithtype-v.bal
+++ b/corpus/bal/subset9/09-value/fromjsonwithtype-v.bal
@@ -48,6 +48,17 @@ public function main() returns error? {
     string s = check strVal.fromJsonWithType(string);
     io:println(s); // @output hello
 
+    // fromJsonWithType only lives in lang.value, not in the receiver's own
+    // basic-type module (lang.int, lang.map, ...), so a precisely-typed
+    // receiver (not json/anydata) must fall back to lang.value to resolve.
+    int plainInt = 7;
+    int viaInt = check plainInt.fromJsonWithType(int);
+    io:println(viaInt); // @output 7
+
+    record {|string name; int age;|} plainRecord = {name: "Alice", age: 30};
+    Person viaRecord = check plainRecord.fromJsonWithType(Person);
+    io:println(viaRecord); // @output {"name":"Alice","age":30}
+
     // required nilable field absent → error (field must be present, even if null)
     json noAge = {"name": "Alice"};
     io:println(noAge.fromJsonWithType(PersonNilAge) is error); // @output true

--- a/corpus/bir/subset9/09-value/fromjsonwithtype-v.txt
+++ b/corpus/bir/subset9/09-value/fromjsonwithtype-v.txt
@@ -117,100 +117,150 @@ main() -> nil|error{
     %46 = println(s) -> bb25;
   }
   bb25 {
-    %47 = ConstantLoad name
-    %48 = ConstantLoad Alice
-    %49 = newMap {| json... |}{%47=%48}
-    noAge = %49;
+    %47 = ConstantLoad 7
+    plainInt = %47;
+    %50 = plainInt;
     %51 = ConstantLoad typedesc
-    %52 = fromJsonWithType(noAge,%51) -> bb26;
+    %52 = fromJsonWithType(%50,%51) -> bb26;
   }
   bb26 {
     %53 = %52 is error
-    %54 = %53;
-    %55 = println(%54) -> bb27;
+    %53 ? bb27 : bb28;
   }
   bb27 {
-    %56 = ConstantLoad name
-    %57 = ConstantLoad Alice
-    %58 = ConstantLoad age
-    %59 = ConstantLoad <nil>
-    %60 = newMap {| json... |}{%56=%57, %58=%59}
-    nullAge = %60;
-    %63 = ConstantLoad typedesc
-    %64 = fromJsonWithType(nullAge,%63) -> bb28;
+    %0 = %52;
+    return;
   }
   bb28 {
-    %65 = %64 is error
-    %65 ? bb29 : bb30;
+    %49 = %52;
+    GOTO bb29;
   }
   bb29 {
-    %0 = %64;
-    return;
+    viaInt = %49;
+    %55 = viaInt;
+    %56 = println(%55) -> bb30;
   }
   bb30 {
-    %62 = %64;
-    GOTO bb31;
+    %57 = ConstantLoad name
+    %58 = ConstantLoad Alice
+    %59 = ConstantLoad age
+    %60 = ConstantLoad 30
+    %61 = newMap {| age: int, name: string, never... |}{%57=%58, %59=%60}
+    plainRecord = %61;
+    %64 = ConstantLoad typedesc
+    %65 = fromJsonWithType(plainRecord,%64) -> bb31;
   }
   bb31 {
-    nilAgePerson = %62;
-    %67 = println(nilAgePerson) -> bb32;
+    %66 = %65 is error
+    %66 ? bb32 : bb33;
   }
   bb32 {
-    %68 = ConstantLoad 1
-    %69 = ConstantLoad 2
-    %70 = ConstantLoad 3
-    %71 = ConstantLoad 4
-    %72 = ConstantLoad 4
-    %73 = newArray [json...][%72]{%68, %69, %70, %71}
-    arr = %73;
-    %76 = ConstantLoad typedesc
-    %77 = fromJsonWithType(arr,%76) -> bb33;
-  }
-  bb33 {
-    %78 = %77 is error
-    %78 ? bb34 : bb35;
-  }
-  bb34 {
-    %0 = %77;
+    %0 = %65;
     return;
   }
+  bb33 {
+    %63 = %65;
+    GOTO bb34;
+  }
+  bb34 {
+    viaRecord = %63;
+    %68 = println(viaRecord) -> bb35;
+  }
   bb35 {
-    %75 = %77;
-    GOTO bb36;
+    %69 = ConstantLoad name
+    %70 = ConstantLoad Alice
+    %71 = newMap {| json... |}{%69=%70}
+    noAge = %71;
+    %73 = ConstantLoad typedesc
+    %74 = fromJsonWithType(noAge,%73) -> bb36;
   }
   bb36 {
-    inferred = %75;
-    %80 = println(inferred) -> bb37;
+    %75 = %74 is error
+    %76 = %75;
+    %77 = println(%76) -> bb37;
   }
   bb37 {
-    %81 = ConstantLoad name
-    %82 = ConstantLoad Alice
-    %83 = ConstantLoad age
-    %84 = ConstantLoad 30
-    %85 = newMap {| json... |}{%81=%82, %83=%84}
-    p = %85;
-    %88 = ConstantLoad typedesc
-    %89 = fromJsonWithType(p,%88) -> bb38;
+    %78 = ConstantLoad name
+    %79 = ConstantLoad Alice
+    %80 = ConstantLoad age
+    %81 = ConstantLoad <nil>
+    %82 = newMap {| json... |}{%78=%79, %80=%81}
+    nullAge = %82;
+    %85 = ConstantLoad typedesc
+    %86 = fromJsonWithType(nullAge,%85) -> bb38;
   }
   bb38 {
-    %90 = %89 is error
-    %90 ? bb39 : bb40;
+    %87 = %86 is error
+    %87 ? bb39 : bb40;
   }
   bb39 {
-    %0 = %89;
+    %0 = %86;
     return;
   }
   bb40 {
-    %87 = %89;
+    %84 = %86;
     GOTO bb41;
   }
   bb41 {
-    person = %87;
-    %92 = println(person) -> bb42;
+    nilAgePerson = %84;
+    %89 = println(nilAgePerson) -> bb42;
   }
   bb42 {
-    %93 = ConstantLoad <nil>
-    %0 = %93;
+    %90 = ConstantLoad 1
+    %91 = ConstantLoad 2
+    %92 = ConstantLoad 3
+    %93 = ConstantLoad 4
+    %94 = ConstantLoad 4
+    %95 = newArray [json...][%94]{%90, %91, %92, %93}
+    arr = %95;
+    %98 = ConstantLoad typedesc
+    %99 = fromJsonWithType(arr,%98) -> bb43;
+  }
+  bb43 {
+    %100 = %99 is error
+    %100 ? bb44 : bb45;
+  }
+  bb44 {
+    %0 = %99;
+    return;
+  }
+  bb45 {
+    %97 = %99;
+    GOTO bb46;
+  }
+  bb46 {
+    inferred = %97;
+    %102 = println(inferred) -> bb47;
+  }
+  bb47 {
+    %103 = ConstantLoad name
+    %104 = ConstantLoad Alice
+    %105 = ConstantLoad age
+    %106 = ConstantLoad 30
+    %107 = newMap {| json... |}{%103=%104, %105=%106}
+    p = %107;
+    %110 = ConstantLoad typedesc
+    %111 = fromJsonWithType(p,%110) -> bb48;
+  }
+  bb48 {
+    %112 = %111 is error
+    %112 ? bb49 : bb50;
+  }
+  bb49 {
+    %0 = %111;
+    return;
+  }
+  bb50 {
+    %109 = %111;
+    GOTO bb51;
+  }
+  bb51 {
+    person = %109;
+    %114 = println(person) -> bb52;
+  }
+  bb52 {
+    %115 = ConstantLoad <nil>
+    %0 = %115;
     return;
   }
 }

--- a/corpus/cfg/subset9/09-value/fromjsonwithtype-v.txt
+++ b/corpus/cfg/subset9/09-value/fromjsonwithtype-v.txt
@@ -70,6 +70,45 @@
       (invocation io println (
         (simple-var-ref s))))
     (var-def
+      (variable plainInt (type
+        (value-type int)) (expr
+        (literal 7))))
+    (var-def
+      (variable viaInt (type
+        (value-type int)) (expr
+        (checked-expr
+          (invocation lang.value fromJsonWithType (
+            (simple-var-ref plainInt)
+            (typedesc-expr
+              (value-type int))))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref viaInt))))
+    (var-def
+      (variable plainRecord (type
+        (record-type
+          (field name
+            (value-type string))
+          (field age
+            (value-type int)))) (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal name)
+            (literal Alice))
+          (key-value
+            (literal age)
+            (literal 30))))))
+    (var-def
+      (variable viaRecord (type
+        (user-defined-type Person)) (expr
+        (checked-expr
+          (invocation lang.value fromJsonWithType (
+            (simple-var-ref plainRecord)
+            (simple-var-ref Person)))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref viaRecord))))
+    (var-def
       (variable noAge (type
         (builtin-ref-type json)) (expr
         (mapping-constructor-expr

--- a/corpus/desugared/subset9/09-value/fromjsonwithtype-v.txt
+++ b/corpus/desugared/subset9/09-value/fromjsonwithtype-v.txt
@@ -93,6 +93,45 @@
         (invocation io println (
           (simple-var-ref s))))
       (var-def
+        (variable plainInt (type
+          (value-type int)) (expr
+          (literal 7))))
+      (var-def
+        (variable viaInt (type
+          (value-type int)) (expr
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref plainInt)
+              (typedesc-expr
+                (value-type int))))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref viaInt))))
+      (var-def
+        (variable plainRecord (type
+          (record-type
+            (field name
+              (value-type string))
+            (field age
+              (value-type int)))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (literal Alice))
+            (key-value
+              (literal age)
+              (literal 30))))))
+      (var-def
+        (variable viaRecord (type
+          (user-defined-type Person)) (expr
+          (checked-expr
+            (invocation lang.value fromJsonWithType (
+              (simple-var-ref plainRecord)
+              (simple-var-ref Person)))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref viaRecord))))
+      (var-def
         (variable noAge (type
           (builtin-ref-type json)) (expr
           (mapping-constructor-expr

--- a/corpus/integration/subset9/09-value/fromjsonwithtype-e.txtar
+++ b/corpus/integration/subset9/09-value/fromjsonwithtype-e.txtar
@@ -6,8 +6,8 @@ error[SEMANTIC_ERROR]: cannot infer typedesc argument for parameter 't': no cont
 19 |     arr.fromJsonWithType(); // @error
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error[SEMANTIC_ERROR]: method not found: fromJsonWithType
+error[SEMANTIC_ERROR]: cannot infer typedesc argument for parameter 't': no contextually expected type
   --> fromjsonwithtype-e.bal:21:5
    |
-21 |     x.fromJsonWithType(int); // @error
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+21 |     x.fromJsonWithType(); // @error
+   |     ^^^^^^^^^^^^^^^^^^^^

--- a/corpus/integration/subset9/09-value/fromjsonwithtype-v.txtar
+++ b/corpus/integration/subset9/09-value/fromjsonwithtype-v.txtar
@@ -4,6 +4,8 @@
 true
 false
 hello
+7
+{"name":"Alice","age":30}
 true
 {"name":"Alice","age":null}
 [1,2,3,4]

--- a/semantics/internal/types/type_resolver.go
+++ b/semantics/internal/types/type_resolver.go
@@ -6389,9 +6389,14 @@ func resolveMethodCall(t typeResolver, chain *binding, expr *ast.BLangInvocation
 	case semtypes.IsSubtype(t.typeContext(), recieverTy, semtypes.XML):
 		symbolRef, pkgAlias, ok = resolveLangLibImport(t, "lang.xml", methodSymbol.MethodName(), expr)
 	default:
+		ok = false
+	}
+	// lang.value applies to any value, so it's the fallback module.
+	if !ok {
 		symbolRef, pkgAlias, ok = resolveLangLibImport(t, "lang.value", methodSymbol.MethodName(), expr)
 	}
 	if !ok {
+		t.semanticError("method not found: "+methodSymbol.MethodName(), expr.GetPosition())
 		return semtypes.SemType{}, expressionEffect{}, false
 	}
 	argExprs := make([]ast.BLangExpression, len(expr.ArgExprs)+1)
@@ -6736,6 +6741,10 @@ func resolveLangLibImport(t typeResolver, pkgName string, methodName string, exp
 		t.internalError(fmt.Sprintf("%s symbol space not found", pkgName), expr.GetPosition())
 		return model.SymbolRef{}, ast.BLangIdentifier{}, false
 	}
+	symbolRef, ok := symbolSpace.GetSymbol(methodName)
+	if !ok {
+		return model.SymbolRef{}, ast.BLangIdentifier{}, false
+	}
 	basePos := expr.GetPosition()
 	pkgAlias := ast.BLangIdentifier{Value: pkgName}
 	pkgAlias.SetPosition(basePos)
@@ -6752,11 +6761,6 @@ func resolveLangLibImport(t typeResolver, pkgName string, methodName string, exp
 		}
 		setOtherNodesAsNever(&importNode)
 		t.addImplicitImport(pkgName, importNode)
-	}
-	symbolRef, ok := symbolSpace.GetSymbol(methodName)
-	if !ok {
-		t.semanticError("method not found: "+methodName, expr.GetPosition())
-		return model.SymbolRef{}, ast.BLangIdentifier{}, false
 	}
 	return symbolRef, pkgAlias, true
 }


### PR DESCRIPTION
## Purpose

Method-call dispatch for langlib functions (`x.method(...)`) only tried the receiver's own basic-type module (`lang.map`, `lang.int`, ...) and never fell back to `lang.value`, so any `lang.value`-only method failed with "method not found" on a precisely-typed receiver — e.g. a `record`-typed value calling `cloneWithType`/`fromJsonWithType`. This is a prerequisite for #832, which needs `value:toBalString` to work on a record receiver.

Relates to #832

## Approach

Split `resolveLangLibImport` into a non-erroring `tryResolveLangLibImport` plus a thin wrapper that reports the diagnostic. `resolveMethodCall` now tries the receiver's own module first and only reports "method not found" if the `lang.value` fallback also misses.

## Checklist
- [x] Read the Contributing Guide
- [x] Added or updated corpus tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `fromJsonWithType()` can now be called without explicitly providing the target type when it can be inferred.
  - Added JSON conversion support coverage for integer and record values, including scalar and object inputs.

- **Bug Fixes**
  - Improved diagnostics when the target type cannot be inferred.
  - Improved handling of value operations and missing methods across receiver types.
  - Invalid operations now report appropriate errors instead of unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->