### PR TITLE
feat(semantics): support dependently typed resource methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ parser/testdata/**/*.json
 coverage_report.html
 .claude/
 .pi/
+.codex/
 
 # Ephemeral report produced by the validate-stdlib-contract skill
 CONTRACT_VALIDATION.md

--- a/corpus/bal/subset9/09-object/dependent-resource-method1-e.bal
+++ b/corpus/bal/subset9/09-object/dependent-resource-method1-e.bal
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+client class Client {
+    resource function get clientClass(typedesc<anydata> targetType = <>) returns targetType|error { // @error
+        return error("client");
+    }
+}
+
+service class ServiceClass {
+    resource function get serviceClass(typedesc<anydata> targetType = <>) returns targetType|error { // @error
+        return error("service class");
+    }
+}
+
+class Listener {
+    public function attach(service object {} svc, () attachPoint = ()) returns error? {
+        _ = svc;
+        _ = attachPoint;
+    }
+
+    public function detach(service object {} svc) returns error? {
+        _ = svc;
+    }
+
+    public function 'start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+    }
+
+    public function immediateStop() returns error? {
+    }
+}
+
+service / on new Listener() {
+    resource function get directService(typedesc<anydata> targetType = <>) returns targetType|error { // @error
+        return error("direct service");
+    }
+}
+
+public function main() {
+}

--- a/corpus/bal/subset9/09-object/dependent-resource-method2-fe.bal
+++ b/corpus/bal/subset9/09-object/dependent-resource-method2-fe.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Technically this is also not an error but nothing in standard library uses this.
+client class Client {
+    resource function get path(typedesc<anydata> targetType = <>, int... rest) returns targetType|error = external; // @error
+}
+
+public function main() {
+}

--- a/corpus/extern/extern_test.go
+++ b/corpus/extern/extern_test.go
@@ -290,6 +290,107 @@ func TestExternResourceMethod(t *testing.T) {
 	runExtern(t, projectCase("resource-method-v"), testharness.NewTestPal(), externs)
 }
 
+func TestDependentlyTypedResourceMethod(t *testing.T) {
+	t.Parallel()
+	projectDir := filepath.Join(testDataDir, "dependently-typed-resource-method-v")
+	absProjectDir, err := filepath.Abs(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := projects.Load(os.DirFS(absProjectDir), ".", projects.ProjectLoadConfig{
+		BallerinaEnvFs: os.DirFS(getBallerinaEnvPath(t)),
+	})
+	if err != nil {
+		t.Fatalf("failed to load project: %v", err)
+	}
+	compilation := result.Project().CurrentPackage().Compilation()
+	if compilation.DiagnosticResult().HasErrors() {
+		for _, d := range compilation.DiagnosticResult().Diagnostics() {
+			t.Logf("diagnostic: %v", d)
+		}
+		t.Fatal("compilation had errors")
+	}
+	backend := projects.NewBallerinaBackend(compilation)
+	apiID := semantics.PackageIdentifier{OrgName: "testorg", ModuleName: "dependentresourcemethod.api"}
+	exported, ok := backend.ExportedSymbols()[apiID]
+	if !ok {
+		t.Fatal("exported symbols not found for dependentresourcemethod.api")
+	}
+	symBytes, err := symbolpool.Marshal(exported, result.Project().Environment().CompilerEnvironment())
+	if err != nil {
+		t.Fatalf("symbol Marshal: %v", err)
+	}
+	freshEnv := context.NewCompilerEnvironment(semtypes.CreateTypeEnv(), false)
+	deserialized, err := symbolpool.Unmarshal(freshEnv, symBytes)
+	if err != nil {
+		t.Fatalf("symbol Unmarshal: %v", err)
+	}
+	var clientRef model.SymbolRef
+	for _, space := range deserialized.MainSpaces {
+		if ref, found := space.GetSymbol("Client"); found {
+			clientRef = ref
+			break
+		}
+	}
+	if clientRef.IsEmpty() {
+		t.Fatal("deserialized Client symbol not found")
+	}
+	clientSym, ok := freshEnv.GetSymbol(clientRef).(*model.NetworkClassSymbol)
+	if !ok {
+		t.Fatalf("expected network class symbol, got %T", freshEnv.GetSymbol(clientRef))
+	}
+	resourceRefs := clientSym.ResourceMethods()
+	if len(resourceRefs) != 1 {
+		t.Fatalf("expected one resource method, got %d", len(resourceRefs))
+	}
+	resourceRef := resourceRefs[0]
+	resourceSym, ok := freshEnv.GetSymbol(resourceRef).(model.DependentlyTypedResourceMethodSymbol)
+	if !ok {
+		t.Fatalf("expected dependent resource method symbol, got %T", freshEnv.GetSymbol(resourceRef))
+	}
+	if resourceSym.MethodName() != "get" || semtypes.IsZero(resourceSym.PathListType()) {
+		t.Fatal("resource accessor or path-list type was not preserved")
+	}
+	if len(resourceSym.PathParams()) != 0 {
+		t.Fatal("declaration-local path parameters must not be serialized")
+	}
+	if len(resourceSym.ParamTypes()) != 1 {
+		t.Fatal("dependent parameter types or return TypeOp were not preserved")
+	}
+	retOp, ok := resourceSym.ReturnType().(*model.BinaryTypeOp)
+	if !ok || retOp.Kind != model.TypeOpUnion {
+		t.Fatalf("expected union return TypeOp, got %T", resourceSym.ReturnType())
+	}
+	dependentRef, ok := retOp.Lhs.(*model.RefTypeOp)
+	if !ok {
+		t.Fatalf("expected dependent return reference, got %T", retOp.Lhs)
+	}
+	if dependentRef.Index != 0 {
+		t.Fatalf("expected dependent return reference to targetType (index 0), got index %d", dependentRef.Index)
+	}
+	if _, ok := freshEnv.FunctionSignatureRef(resourceRef); !ok {
+		t.Fatal("resource function signature association was not preserved")
+	}
+
+	externs := []testharness.ExternRegistration{{
+		Org: "testorg", Module: "dependentresourcemethod.api", FuncName: "Client.$resource$get$0",
+		Impl: func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+			td, ok := args[len(args)-1].(*values.TypeDesc)
+			if !ok {
+				return nil, fmt.Errorf("expected typedesc argument, got %T", args[len(args)-1])
+			}
+			switch {
+			case semtypes.IsSubtype(ctx.TypeCtx(), td.Type, semtypes.String):
+				return "explicit", nil
+			case semtypes.IsSubtype(ctx.TypeCtx(), td.Type, semtypes.Int):
+				return int64(42), nil
+			}
+			panic(values.NewErrorWithMessage("unsupported targetType"))
+		},
+	}}
+	runExtern(t, projectCase("dependently-typed-resource-method-v"), testharness.NewTestPal(), externs)
+}
+
 func TestListenerDispatch(t *testing.T) {
 	// `trigger` writes through pal.IO.Stdout directly to mirror what
 	// io:println does at runtime, without requiring a closure over the

--- a/corpus/extern/testdata/dependently-typed-resource-method-v/Ballerina.toml
+++ b/corpus/extern/testdata/dependently-typed-resource-method-v/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "dependentresourcemethod"
+version = "0.1.0"

--- a/corpus/extern/testdata/dependently-typed-resource-method-v/main.bal
+++ b/corpus/extern/testdata/dependently-typed-resource-method-v/main.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import dependentresourcemethod.api;
+import ballerina/io;
+
+public function main() {
+    api:Client c = new ();
+
+    string explicit = checkpanic c->/values/one/two(string);
+    io:println(explicit); // @output explicit
+
+    int inferred = checkpanic c->/values/three();
+    io:println(inferred); // @output 42
+}

--- a/corpus/extern/testdata/dependently-typed-resource-method-v/modules/api/client.bal
+++ b/corpus/extern/testdata/dependently-typed-resource-method-v/modules/api/client.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+public client class Client {
+    public function init() {
+    }
+
+    resource function get values/[string... path](typedesc<anydata> targetType = <>) returns targetType|error = external;
+}

--- a/corpus/extern/testdata/expected/project/dependently-typed-resource-method-v.txtar
+++ b/corpus/extern/testdata/expected/project/dependently-typed-resource-method-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+explicit
+42
+-- stderr --

--- a/corpus/integration/subset9/09-object/dependent-resource-method1-e.txtar
+++ b/corpus/integration/subset9/09-object/dependent-resource-method1-e.txtar
@@ -1,0 +1,31 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: dependently typed function must be external
+  --> dependent-resource-method1-e.bal:17:5
+   |
+17 |     resource function get clientClass(typedesc<anydata> targetType = <>) returns targetType|error { // @error
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+18 |         return error("client");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+19 |     }
+   |     ^
+
+error[SEMANTIC_ERROR]: dependently typed function must be external
+  --> dependent-resource-method1-e.bal:23:5
+   |
+23 |     resource function get serviceClass(typedesc<anydata> targetType = <>) returns targetType|error { // @error
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+24 |         return error("service class");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+25 |     }
+   |     ^
+
+error[SEMANTIC_ERROR]: dependently typed function must be external
+  --> dependent-resource-method1-e.bal:49:5
+   |
+49 |     resource function get directService(typedesc<anydata> targetType = <>) returns targetType|error { // @error
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+50 |         return error("direct service");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+51 |     }
+   |     ^

--- a/corpus/integration/subset9/09-object/dependent-resource-method2-fe.txtar
+++ b/corpus/integration/subset9/09-object/dependent-resource-method2-fe.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+fatal[UNIMPLEMENTED_ERROR]: rest parameters are not supported on dependently-typed functions
+  --> dependent-resource-method2-fe.bal:19:5
+   |
+19 |     resource function get path(typedesc<anydata> targetType = <>, int... rest) returns targetType|error = external; // @error
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/model/symbol.go
+++ b/model/symbol.go
@@ -109,6 +109,17 @@ type FunctionSymbol interface {
 	SetTypedSignature(TypedFunctionSignature)
 }
 
+// ResourceMethodSymbol represents a resource method and the path metadata used
+// to select it during resource-access dispatch.
+type ResourceMethodSymbol interface {
+	FunctionSymbol
+	MethodName() string
+	PathListType() semtypes.SemType
+	SetPathListType(semtypes.SemType)
+	PathParams() []SymbolRef
+	SetPathParams([]SymbolRef)
+}
+
 // DependentlyTypedFunctionSymbol represents a [dependently typed function]. Actual function signature
 // is determined at each call site by calling Monomorphize.
 // TODO: this is very similar to [GenericFunctionSymbol]; merge both. #389
@@ -120,6 +131,13 @@ type DependentlyTypedFunctionSymbol interface {
 	FuncFlags() FuncSymbolFlags
 	SetParamTypes(types []semtypes.SemType)
 	SetReturnType(op TypeOp)
+}
+
+// DependentlyTypedResourceMethodSymbol represents a resource method whose
+// return type is determined from typedesc arguments at each call site.
+type DependentlyTypedResourceMethodSymbol interface {
+	ResourceMethodSymbol
+	DependentlyTypedFunctionSymbol
 }
 
 // MonomorphicFunctionSymbol represent a polymorphic function after monomrophizisation.
@@ -384,11 +402,15 @@ type (
 		polymorhpicFn SymbolRef
 	}
 
-	ResourceMethodSymbol struct {
-		functionSymbol
+	resourceMethodBase struct {
 		methodName   string
 		pathListType semtypes.SemType
 		pathParams   []SymbolRef
+	}
+
+	resourceMethodSymbol struct {
+		functionSymbol
+		resourceMethodBase
 	}
 
 	dependentlyTypedFunctionSymbol struct {
@@ -398,6 +420,11 @@ type (
 		// Populated by type resolver at stage 4.
 		paramTypes []semtypes.SemType
 		retType    TypeOp
+	}
+
+	dependentlyTypedResourceMethodSymbol struct {
+		dependentlyTypedFunctionSymbol
+		resourceMethodBase
 	}
 
 	ParamFlag uint8
@@ -647,38 +674,39 @@ var (
 )
 
 var (
-	_ Scope                          = &ModuleScope{}
-	_ Scope                          = &PackageScope{}
-	_ Scope                          = &FunctionScope{}
-	_ Scope                          = &BlockScope{}
-	_ Symbol                         = &TypeSymbol{}
-	_ Symbol                         = &AnnotationSymbol{}
-	_ Symbol                         = &classSymbol{}
-	_ Symbol                         = &NetworkClassSymbol{}
-	_ ClassSymbol                    = &classSymbol{}
-	_ ClassSymbol                    = &NetworkClassSymbol{}
-	_ Symbol                         = &RecordSymbol{}
-	_ Symbol                         = &ObjectTypeSymbol{}
-	_ MemberCarrier                  = &classSymbol{}
-	_ MemberCarrier                  = &NetworkClassSymbol{}
-	_ MemberCarrier                  = &RecordSymbol{}
-	_ MemberCarrier                  = &ObjectTypeSymbol{}
-	_ ObjectType                     = &classSymbol{}
-	_ ObjectType                     = &NetworkClassSymbol{}
-	_ ObjectType                     = &ObjectTypeSymbol{}
-	_ Symbol                         = &VariableSymbol{}
-	_ Symbol                         = &ConstantValueSymbol{}
-	_ ValueSymbol                    = &VariableSymbol{}
-	_ ValueSymbol                    = &ConstantValueSymbol{}
-	_ Symbol                         = &XMLNSSymbol{}
-	_ Symbol                         = &functionSymbol{}
-	_ FunctionSymbol                 = &functionSymbol{}
-	_ DependentlyTypedFunctionSymbol = &dependentlyTypedFunctionSymbol{}
-	_ MonomorphicFunctionSymbol      = &monomorphicFunctionSymbol{}
-	_ FunctionSymbol                 = &ResourceMethodSymbol{}
-	_ Symbol                         = &SymbolRef{}
-	_ SymbolSpaceProvider            = &ModuleScope{}
-	_ SymbolSpaceProvider            = &PackageScope{}
+	_ Scope                                = &ModuleScope{}
+	_ Scope                                = &PackageScope{}
+	_ Scope                                = &FunctionScope{}
+	_ Scope                                = &BlockScope{}
+	_ Symbol                               = &TypeSymbol{}
+	_ Symbol                               = &AnnotationSymbol{}
+	_ Symbol                               = &classSymbol{}
+	_ Symbol                               = &NetworkClassSymbol{}
+	_ ClassSymbol                          = &classSymbol{}
+	_ ClassSymbol                          = &NetworkClassSymbol{}
+	_ Symbol                               = &RecordSymbol{}
+	_ Symbol                               = &ObjectTypeSymbol{}
+	_ MemberCarrier                        = &classSymbol{}
+	_ MemberCarrier                        = &NetworkClassSymbol{}
+	_ MemberCarrier                        = &RecordSymbol{}
+	_ MemberCarrier                        = &ObjectTypeSymbol{}
+	_ ObjectType                           = &classSymbol{}
+	_ ObjectType                           = &NetworkClassSymbol{}
+	_ ObjectType                           = &ObjectTypeSymbol{}
+	_ Symbol                               = &VariableSymbol{}
+	_ Symbol                               = &ConstantValueSymbol{}
+	_ ValueSymbol                          = &VariableSymbol{}
+	_ ValueSymbol                          = &ConstantValueSymbol{}
+	_ Symbol                               = &XMLNSSymbol{}
+	_ Symbol                               = &functionSymbol{}
+	_ FunctionSymbol                       = &functionSymbol{}
+	_ DependentlyTypedFunctionSymbol       = &dependentlyTypedFunctionSymbol{}
+	_ MonomorphicFunctionSymbol            = &monomorphicFunctionSymbol{}
+	_ ResourceMethodSymbol                 = &resourceMethodSymbol{}
+	_ DependentlyTypedResourceMethodSymbol = &dependentlyTypedResourceMethodSymbol{}
+	_ Symbol                               = &SymbolRef{}
+	_ SymbolSpaceProvider                  = &ModuleScope{}
+	_ SymbolSpaceProvider                  = &PackageScope{}
 )
 
 func (space *SymbolSpace) AddSymbol(name string, symbol Symbol) {
@@ -1461,36 +1489,51 @@ func (c *classSymbolBase) AddResourceMethod(ref SymbolRef) {
 	c.resourceMethods = append(c.resourceMethods, ref)
 }
 
-func NewResourceMethodSymbol(name, methodName string, isPublic bool, location diagnostics.Location) *ResourceMethodSymbol {
-	return &ResourceMethodSymbol{
+func NewResourceMethodSymbol(name, methodName string, isPublic bool, location diagnostics.Location) ResourceMethodSymbol {
+	return &resourceMethodSymbol{
 		functionSymbol: functionSymbol{
 			symbolBase: symbolBase{name: name, isPublic: isPublic, location: location},
 		},
-		methodName: methodName,
+		resourceMethodBase: resourceMethodBase{methodName: methodName},
 	}
 }
 
-func (r *ResourceMethodSymbol) MethodName() string {
+func NewDependentlyTypedResourceMethodSymbol(name, methodName string, flags FuncSymbolFlags, isPublic bool, location diagnostics.Location) DependentlyTypedResourceMethodSymbol {
+	return &dependentlyTypedResourceMethodSymbol{
+		dependentlyTypedFunctionSymbol: dependentlyTypedFunctionSymbol{
+			symbolBase: symbolBase{name: name, isPublic: isPublic, location: location},
+			Flags:      flags,
+		},
+		resourceMethodBase: resourceMethodBase{methodName: methodName},
+	}
+}
+
+func (r *resourceMethodBase) MethodName() string {
 	return r.methodName
 }
 
-func (r *ResourceMethodSymbol) PathListType() semtypes.SemType {
+func (r *resourceMethodBase) PathListType() semtypes.SemType {
 	return r.pathListType
 }
 
-func (r *ResourceMethodSymbol) SetPathListType(ty semtypes.SemType) {
+func (r *resourceMethodBase) SetPathListType(ty semtypes.SemType) {
 	r.pathListType = ty
 }
 
-func (r *ResourceMethodSymbol) PathParams() []SymbolRef {
+func (r *resourceMethodBase) PathParams() []SymbolRef {
 	return r.pathParams
 }
 
-func (r *ResourceMethodSymbol) SetPathParams(params []SymbolRef) {
+func (r *resourceMethodBase) SetPathParams(params []SymbolRef) {
 	r.pathParams = params
 }
 
-func (r *ResourceMethodSymbol) Copy() Symbol {
+func (r *resourceMethodSymbol) Copy() Symbol {
+	cp := *r
+	return &cp
+}
+
+func (r *dependentlyTypedResourceMethodSymbol) Copy() Symbol {
 	cp := *r
 	return &cp
 }

--- a/model/symbol_location_test.go
+++ b/model/symbol_location_test.go
@@ -37,6 +37,7 @@ func TestSymbolConstructorsSetLocation(t *testing.T) {
 		NewClassSymbol("class", false, location),
 		NewNetworkClassSymbol("client", false, location),
 		NewResourceMethodSymbol("resource", "get", false, location),
+		NewDependentlyTypedResourceMethodSymbol("dependent resource", "get", 0, false, location),
 		&record,
 		&object,
 		NewDependentlyTypedFunctionSymbol("dependent", 0, false, location),

--- a/model/symbolpool/deserializer.go
+++ b/model/symbolpool/deserializer.go
@@ -102,6 +102,32 @@ func (sr *symbolReader) readResourceMethodSymbol(space *model.SymbolSpace) {
 	}
 }
 
+func (sr *symbolReader) readDependentlyTypedResourceMethodSymbol(space *model.SymbolSpace) {
+	name := sr.readStringCP()
+	var isPublic bool
+	read(sr.r, &isPublic)
+	methodName := sr.readStringCP()
+	pathType := sr.readType()
+	var paramCount int64
+	read(sr.r, &paramCount)
+	paramTypes := make([]semtypes.SemType, paramCount)
+	for i := int64(0); i < paramCount; i++ {
+		paramTypes[i] = sr.readType()
+	}
+	var flags uint8
+	read(sr.r, &flags)
+	sym := model.NewDependentlyTypedResourceMethodSymbol(name, methodName, model.FuncSymbolFlags(flags), isPublic, diagnostics.NewBuiltinLocation())
+	sym.SetPathListType(pathType)
+	sym.SetParamTypes(paramTypes)
+	var sigHandle int64
+	read(sr.r, &sigHandle)
+	sym.SetReturnType(sr.readTypeOp())
+	ref := addDeserializedSymbol(space, name, sym)
+	if sigHandle >= 0 {
+		sr.env.AssociateFunctionSignature(ref, sr.sigHandles[sigHandle])
+	}
+}
+
 func addDeserializedSymbol(space *model.SymbolSpace, name string, sym model.Symbol) model.SymbolRef {
 	if !sym.IsPublic() {
 		if _, exists := space.GetSymbol(name); exists {
@@ -239,6 +265,8 @@ func (sr *symbolReader) readSymbol(space *model.SymbolSpace, opaque []model.Symb
 		sr.readDependentlyTypedFunctionSymbol(space)
 	case symTagResourceMethod:
 		sr.readResourceMethodSymbol(space)
+	case symTagDependentlyTypedResourceMethod:
+		sr.readDependentlyTypedResourceMethodSymbol(space)
 	default:
 		panic(fmt.Sprintf("unknown symbol tag: %d", tag))
 	}

--- a/model/symbolpool/serializer.go
+++ b/model/symbolpool/serializer.go
@@ -46,6 +46,7 @@ const (
 	symTagConstantValue
 	symTagOpaque
 	symTagErrorType
+	symTagDependentlyTypedResourceMethod
 )
 
 const (
@@ -348,10 +349,12 @@ func (sw *symbolWriter) writeSymbol(buf *bytes.Buffer, ref model.SymbolRef, sym 
 		return sw.writeValueSymbol(buf, ref, s)
 	case *model.AnnotationSymbol:
 		return sw.writeAnnotationSymbol(buf, s)
+	case model.DependentlyTypedResourceMethodSymbol:
+		return sw.writeDependentlyTypedResourceMethodSymbol(buf, ref, s)
+	case model.ResourceMethodSymbol:
+		return sw.writeResourceMethodSymbol(buf, ref, s)
 	case model.DependentlyTypedFunctionSymbol:
 		return sw.writeDependentlyTypedFunctionSymbol(buf, ref, s)
-	case *model.ResourceMethodSymbol:
-		return sw.writeResourceMethodSymbol(buf, ref, s)
 	case model.FunctionSymbol:
 		return sw.writeFunctionSymbol(buf, ref, s)
 	default:
@@ -721,7 +724,7 @@ func (sw *symbolWriter) writeFunctionSignatureBody(buf *bytes.Buffer, ref model.
 	return sw.writeFunctionSignatureIndex(buf, ref)
 }
 
-func (sw *symbolWriter) writeResourceMethodSymbol(buf *bytes.Buffer, ref model.SymbolRef, sym *model.ResourceMethodSymbol) error {
+func (sw *symbolWriter) writeResourceMethodSymbol(buf *bytes.Buffer, ref model.SymbolRef, sym model.ResourceMethodSymbol) error {
 	if err := write(buf, symTagResourceMethod); err != nil {
 		return err
 	}
@@ -735,6 +738,40 @@ func (sw *symbolWriter) writeResourceMethodSymbol(buf *bytes.Buffer, ref model.S
 		return err
 	}
 	return sw.writeFunctionSignatureBody(buf, ref, sym.TypedSignature())
+}
+
+func (sw *symbolWriter) writeDependentlyTypedResourceMethodSymbol(buf *bytes.Buffer, ref model.SymbolRef, sym model.DependentlyTypedResourceMethodSymbol) error {
+	if err := write(buf, symTagDependentlyTypedResourceMethod); err != nil {
+		return err
+	}
+	if err := sw.writeStringCP(buf, sym.Name()); err != nil {
+		return err
+	}
+	if err := write(buf, sym.IsPublic()); err != nil {
+		return err
+	}
+	if err := sw.writeStringCP(buf, sym.MethodName()); err != nil {
+		return err
+	}
+	if err := sw.writeType(buf, sym.PathListType()); err != nil {
+		return err
+	}
+	paramTypes := sym.ParamTypes()
+	if err := write(buf, int64(len(paramTypes))); err != nil {
+		return err
+	}
+	for _, pt := range paramTypes {
+		if err := sw.writeType(buf, pt); err != nil {
+			return err
+		}
+	}
+	if err := write(buf, uint8(sym.FuncFlags())); err != nil {
+		return err
+	}
+	if err := sw.writeFunctionSignatureIndex(buf, ref); err != nil {
+		return err
+	}
+	return sw.writeTypeOp(buf, sym.ReturnType())
 }
 
 func (sw *symbolWriter) writeDependentlyTypedFunctionSymbol(buf *bytes.Buffer, ref model.SymbolRef, sym model.DependentlyTypedFunctionSymbol) error {

--- a/semantics/internal/analysis/semantic_analyzer.go
+++ b/semantics/internal/analysis/semantic_analyzer.go
@@ -1744,7 +1744,7 @@ func analyzeClientResourceAccessAction[A analyzer](a A, expr *ast.BLangClientRes
 
 func resolvedResourceMethodPathType[A analyzer](a A, expr *ast.BLangClientResourceAccessAction) semtypes.SemType {
 	ref := expr.MethodSymbol()
-	rmSym, ok := a.getSymbol(ref).(*model.ResourceMethodSymbol)
+	rmSym, ok := a.getSymbol(ref).(model.ResourceMethodSymbol)
 	if !ok {
 		return semtypes.SemType{}
 	}
@@ -2180,13 +2180,13 @@ func validateDuplicateResourceMethods[A analyzer](a A, rms []*ast.BLangResourceM
 	tyCtx := a.tyCtx()
 	ctx := a.ctx()
 	for i := 1; i < len(rms); i++ {
-		later, ok := ctx.GetSymbol(rms[i].Symbol()).(*model.ResourceMethodSymbol)
+		later, ok := ctx.GetSymbol(rms[i].Symbol()).(model.ResourceMethodSymbol)
 		if !ok {
 			a.internalErr("expected resource method symbol", rms[i].GetPosition())
 			continue
 		}
 		for j := 0; j < i; j++ {
-			earlier, ok := ctx.GetSymbol(rms[j].Symbol()).(*model.ResourceMethodSymbol)
+			earlier, ok := ctx.GetSymbol(rms[j].Symbol()).(model.ResourceMethodSymbol)
 			if !ok {
 				a.internalErr("expected resource method symbol", rms[j].GetPosition())
 				continue

--- a/semantics/internal/common/function.go
+++ b/semantics/internal/common/function.go
@@ -23,6 +23,7 @@ import (
 
 type FunctionDecl interface {
 	ast.InvokableNode
+	ast.FunctionSignature
 	ast.BNodeWithSymbol
 	Scope() model.Scope
 	IsIsolated() bool

--- a/semantics/internal/symbols/symbol_resolver.go
+++ b/semantics/internal/symbols/symbol_resolver.go
@@ -519,13 +519,13 @@ func (ms *compilationUnitSymbolResolver) allocateFunctionSymbolInner(fn *ast.BLa
 
 // isDependentlyTyped reports whether a function's return type references one of its typedesc
 // parameters by name.
-func (ms *compilationUnitSymbolResolver) isDependentlyTyped(fn *ast.BLangFunction) bool {
+func (ms *compilationUnitSymbolResolver) isDependentlyTyped(fn ast.InvokableNode) bool {
 	retTd := fn.GetReturnTypeDescriptor()
 	if retTd == nil {
 		return false
 	}
 	typedescParams := make(map[string]struct{})
-	for _, param := range fn.RequiredParams {
+	for _, param := range fn.GetParameters() {
 		if param.Name == nil {
 			continue
 		}
@@ -1879,7 +1879,7 @@ func resolveServiceDefinition(ms *compilationUnitSymbolResolver, svc *ast.BLangS
 	svcResolver := newBlockSymbolResolverWithBlockScope(ms, svc)
 	svc.SetScope(svcResolver.scope)
 
-	allocateServiceResourceMethodSymbols(svcResolver, svc.ResourceMethods)
+	allocateServiceResourceMethodSymbols(ms, svcResolver, svc.ResourceMethods)
 
 	finishResolveClassDefinition(ms, svcResolver, svc.Fields, svc.Methods, svc.ResourceMethods, svc.InitFunction, nil, svcResolver.scope, serviceMethodSymbolName, resourceMethodsAreNetworkClass)
 
@@ -2005,20 +2005,31 @@ func allocateObjectResourceMethodSymbols(ms *compilationUnitSymbolResolver, bloc
 			continue
 		}
 		mangledName := className + "." + mangledResourceMethodName(rm.Name.GetValue(), idx)
-		symRef := allocateResourceMethodSymbol(ms.scope, rm, mangledName, classDef.IsPublic() && rm.IsPublic())
+		symRef := ms.allocateResourceMethodSymbol(ms.scope, rm, mangledName, classDef.IsPublic() && rm.IsPublic())
 		networkClassSym.AddResourceMethod(symRef)
 	}
 }
 
-func allocateServiceResourceMethodSymbols(blockRes *blockSymbolResolver, resourceMethods []*ast.BLangResourceMethod) {
+func allocateServiceResourceMethodSymbols(ms *compilationUnitSymbolResolver, blockRes *blockSymbolResolver, resourceMethods []*ast.BLangResourceMethod) {
 	for idx, rm := range resourceMethods {
 		key := mangledResourceMethodName(rm.Name.GetValue(), idx)
-		allocateResourceMethodSymbol(blockRes.scope, rm, key, rm.IsPublic())
+		ms.allocateResourceMethodSymbol(blockRes.scope, rm, key, rm.IsPublic())
 	}
 }
 
-func allocateResourceMethodSymbol(targetScope methodSymbolTargetScope, rm *ast.BLangResourceMethod, symbolName string, isPublic bool) model.SymbolRef {
-	symbol := model.NewResourceMethodSymbol(symbolName, rm.Name.GetValue(), isPublic, symbolLocationForNode(rm))
+func (ms *compilationUnitSymbolResolver) allocateResourceMethodSymbol(targetScope methodSymbolTargetScope, rm *ast.BLangResourceMethod, symbolName string, isPublic bool) model.SymbolRef {
+	var symbol model.ResourceMethodSymbol
+	if ms.isDependentlyTyped(rm) {
+		if rm.GetRestParam() != nil {
+			ms.moduleResolver.ctx.Unimplemented("rest parameters are not supported on dependently-typed functions", rm.GetPosition())
+		}
+		if _, isExtern := rm.GetBody().(*ast.BLangExternFunctionBody); !isExtern {
+			ms.moduleResolver.ctx.SemanticError("dependently typed function must be external", rm.GetPosition())
+		}
+		symbol = model.NewDependentlyTypedResourceMethodSymbol(symbolName, rm.Name.GetValue(), rm.FuncSymbolFlags(), isPublic, symbolLocationForNode(rm))
+	} else {
+		symbol = model.NewResourceMethodSymbol(symbolName, rm.Name.GetValue(), isPublic, symbolLocationForNode(rm))
+	}
 	targetScope.AddSymbol(symbolName, symbol)
 	symRef, _ := targetScope.MainSpace().GetSymbol(symbolName)
 	rm.SetSymbol(symRef)

--- a/semantics/internal/types/type_resolver.go
+++ b/semantics/internal/types/type_resolver.go
@@ -2103,10 +2103,10 @@ func validateIncludedRecordParamMetadata(t typeResolver, ref model.FunctionSigna
 	return true
 }
 
-func resolveDependentlyTypedFunctionSignature(t typeResolver, fn *ast.BLangFunction, sym model.DependentlyTypedFunctionSymbol, depth int) (semtypes.SemType, bool) {
-	paramTypes := make([]semtypes.SemType, len(fn.RequiredParams))
-	paramsByName := make(map[string]param, len(fn.RequiredParams))
+func resolveDependentlyTypedFunctionSignature(t typeResolver, fn common.FunctionDecl, sym model.DependentlyTypedFunctionSymbol, depth int) (semtypes.SemType, bool) {
 	params := fn.GetParameters()
+	paramTypes := make([]semtypes.SemType, len(params))
+	paramsByName := make(map[string]param, len(params))
 	for i := range params {
 		p := &params[i]
 		resolveSimpleVariableInner(t, nil, p, depth+1)
@@ -6629,7 +6629,7 @@ func resolveResourceMethodSignature(t typeResolver, isClient bool, isService boo
 		t.semanticError("resource methods are only allowed in client or service classes", method.GetPosition())
 		return false
 	}
-	sym, ok := t.getSymbol(method.Symbol()).(*model.ResourceMethodSymbol)
+	sym, ok := t.getSymbol(method.Symbol()).(model.ResourceMethodSymbol)
 	if !ok {
 		t.internalError("expected resource method symbol", method.GetPosition())
 		return false
@@ -6641,6 +6641,10 @@ func resolveResourceMethodSignature(t typeResolver, isClient bool, isService boo
 	sym.SetPathListType(pathTy)
 	sym.SetPathParams(pathParamRefs)
 
+	if depSym, dependent := sym.(model.DependentlyTypedFunctionSymbol); dependent {
+		_, ok = resolveDependentlyTypedFunctionSignature(t, method, depSym, depth)
+		return ok
+	}
 	_, ok = resolveInvokableSignature(t, method, sym, method.GetParameters(), depth)
 	if !ok {
 		return false
@@ -6735,7 +6739,7 @@ func resolveClientResourceAccessAction(t typeResolver, chain *binding, expr *ast
 	methodName := expr.MethodName
 	var matches []model.SymbolRef
 	for _, rmRef := range networkSym.ResourceMethods() {
-		rmSym, ok := t.getSymbol(rmRef).(*model.ResourceMethodSymbol)
+		rmSym, ok := t.getSymbol(rmRef).(model.ResourceMethodSymbol)
 		if !ok {
 			t.internalError("expected resource method symbol", expr.GetPosition())
 			return semtypes.SemType{}, expressionEffect{}, false


### PR DESCRIPTION
## Purpose

Resource methods whose return type depends on a typedesc parameter are currently allocated as plain resource symbols. This prevents inferred typedesc arguments and call-site return-type substitution.

Closes #825

## Approach

- represent plain and dependently typed resource methods through a shared resource symbol interface
- preserve dependent signatures and resource path metadata during symbol serialization
- detect and validate dependent resource declarations across client classes, service classes, and directly declared services
- reuse the existing dependent-call monomorphization and native-resource BIR paths
- add declaration-error and cross-module extern corpus coverage, including rest-path and symbol round-trip validation

## Checklist

- [x] Read the [Contributing Guide](CONTRIBUTING.md)
- [x] Added or updated [corpus tests](AGENTS.md#corpus-tests)

## Remarks

Resource rest-path segments remain dispatch metadata and are not treated as function rest parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resource methods whose return type is determined by the requested typedesc at call time.
  - Preserved dependent resource method metadata across compilation and execution.
  - Added coverage for client, service, and direct resource method scenarios.

- **Bug Fixes**
  - Improved compiler validation and diagnostics for dependent resource methods.
  - Enforced external implementation requirements and reported unsupported rest-parameter usage clearly.

- **Tests**
  - Added runtime verification for explicit string and inferred integer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->