### PR TITLE
feat(semantics): support dependent array return types

### DIFF
--- a/bir/codec/SPEC.md
+++ b/bir/codec/SPEC.md
@@ -8,8 +8,6 @@ The BIR binary file has the following structure:
 +------------------+
 | Magic (4 bytes)  | 0xBA 0x10 0xC0 0xDE
 +------------------+
-| Version (4 bytes)| int32 (currently 82)
-+------------------+
 | Constant Pool    | See Constant Pool Format
 +------------------+
 | Package Data     | See Package Structure

--- a/bir/codec/deserializer.go
+++ b/bir/codec/deserializer.go
@@ -58,13 +58,6 @@ func (br *birReader) readPackage() (pkg *bir.BIRPackage, err error) {
 		panic(fmt.Sprintf("invalid BIR magic: %x", magic))
 	}
 
-	var version int32
-	br.read(&version)
-
-	if version != BIR_VERSION {
-		panic(fmt.Sprintf("unsupported BIR version: %d", version))
-	}
-
 	br.readTypePool()
 	br.readConstantPool()
 

--- a/bir/codec/serializer.go
+++ b/bir/codec/serializer.go
@@ -29,10 +29,7 @@ import (
 	"github.com/ballerina-nutcracker/ballerina/values"
 )
 
-const (
-	BIR_MAGIC   = "\xba\x10\xc0\xde"
-	BIR_VERSION = 84
-)
+const BIR_MAGIC = "\xba\x10\xc0\xde"
 
 type birWriter struct {
 	cp           *ConstantPool
@@ -70,8 +67,6 @@ func (bw *birWriter) serialize(pkg *bir.BIRPackage) (result []byte, err error) {
 	if err != nil {
 		panic(fmt.Sprintf("writing BIR magic: %v", err))
 	}
-
-	write(buf, int32(BIR_VERSION))
 
 	tpBytes := semtypes.MarshalTypePool(bw.tp, bw.env).Bytes()
 	write(buf, int64(len(tpBytes)))

--- a/corpus/bal/subset8/08-function/dependent-fn-array-e.bal
+++ b/corpus/bal/subset8/08-function/dependent-fn-array-e.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function open(typedesc T = <>) returns T[] = external;
+function fixed(typedesc T = <>) returns T[2] = external;
+function zero(typedesc T = <>) returns T[0] = external;
+function nested(typedesc T = <>) returns T[][] = external;
+function outsideUnion(typedesc T = <>) returns T[]|error = external;
+function insideUnion(typedesc<anydata> T = <>) returns (T|error)[] = external;
+function insideIntersection(typedesc T = <>) returns (T & readonly)[] = external;
+function constrained(typedesc<int|string> T = <>) returns T[] = external;
+function fixedArraySibling(typedesc<string> T = <>) returns T[]|int[1] = external;
+
+type StringArray string[];
+
+public function main() {
+    string[] _ = open();
+    string[2] _ = fixed();
+    string[0] _ = zero();
+    string[][] _ = nested();
+    string[]|error _ = outsideUnion();
+    (string|error)[] _ = insideUnion();
+    (string & readonly)[] _ = insideIntersection();
+    string[][] _ = open(StringArray);
+    string[]|int[1] _ = fixedArraySibling();
+
+    string _ = open(); // @error
+    string[3] _ = fixed(); // @error
+    var _ = open(); // @error
+    float[] _ = constrained(); // @error
+}

--- a/corpus/extern/extern_test.go
+++ b/corpus/extern/extern_test.go
@@ -186,6 +186,13 @@ func TestDependentlyTyped(t *testing.T) {
 			}
 			panic(values.NewErrorWithMessage("inferredMaybeError: expected error to be in typedesc"))
 		}},
+		{Org: org, Module: mod, FuncName: "inferredOpenArray", Impl: dependentArrayExtern(arrayReturnOpen)},
+		{Org: org, Module: mod, FuncName: "inferredFixedArray", Impl: dependentArrayExtern(arrayReturnFixed)},
+		{Org: org, Module: mod, FuncName: "inferredZeroArray", Impl: dependentArrayExtern(arrayReturnZero)},
+		{Org: org, Module: mod, FuncName: "inferredNestedArray", Impl: dependentArrayExtern(arrayReturnNested)},
+		{Org: org, Module: mod, FuncName: "inferredArrayOutsideUnion", Impl: dependentArrayExtern(arrayReturnOutsideUnion)},
+		{Org: org, Module: mod, FuncName: "inferredArrayInsideUnion", Impl: dependentArrayExtern(arrayReturnInsideUnion)},
+		{Org: org, Module: mod, FuncName: "inferredArrayInsideIntersection", Impl: dependentArrayExtern(arrayReturnInsideIntersection)},
 		{Org: org, Module: mod, FuncName: "Getter." + model.RemoteMethodName("get"), Impl: func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
 			td, ok := args[1].(*values.TypeDesc)
 			if !ok {
@@ -198,6 +205,82 @@ func TestDependentlyTyped(t *testing.T) {
 		}},
 	}
 	runExtern(t, fileCase("dependently-typed-v"), testharness.NewTestPal(), externs)
+}
+
+type arrayReturnKind uint8
+
+const (
+	arrayReturnOpen arrayReturnKind = iota
+	arrayReturnFixed
+	arrayReturnZero
+	arrayReturnNested
+	arrayReturnOutsideUnion
+	arrayReturnInsideUnion
+	arrayReturnInsideIntersection
+)
+
+func dependentArrayExtern(kind arrayReturnKind) extern.NativeFunc {
+	return func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+		td, ok := args[0].(*values.TypeDesc)
+		if !ok {
+			return nil, fmt.Errorf("expected typedesc argument, got %T", args[0])
+		}
+		if kind == arrayReturnZero {
+			if !semtypes.IsSameType(ctx.TypeCtx(), td.Type, semtypes.Val) && !semtypes.IsSameType(ctx.TypeCtx(), td.Type, semtypes.String) {
+				return nil, fmt.Errorf("expected maximal or explicit string typedesc constraint for zero-length array, got %s", semtypes.ToString(ctx.TypeCtx(), td.Type))
+			}
+		} else if !semtypes.IsSubtype(ctx.TypeCtx(), td.Type, semtypes.List) && !semtypes.IsSameType(ctx.TypeCtx(), td.Type, semtypes.String) {
+			return nil, fmt.Errorf("expected string or explicit array typedesc constraint, got %s", semtypes.ToString(ctx.TypeCtx(), td.Type))
+		}
+		element := td.Type
+		label := "open"
+		size := 1
+		switch kind {
+		case arrayReturnFixed:
+			label = "fixed"
+			size = 2
+		case arrayReturnZero:
+			return newExternList(ctx, externArrayType(ctx, element, 0, false), nil), nil
+		case arrayReturnNested:
+			inner := newExternList(ctx, externArrayType(ctx, element, 0, true), []values.BalValue{"nested"})
+			return newExternList(ctx, externArrayType(ctx, inner.Type, 0, true), []values.BalValue{inner}), nil
+		case arrayReturnOutsideUnion:
+			label = "outside"
+		case arrayReturnInsideUnion:
+			element = semtypes.Union(element, semtypes.Error)
+			label = "inside"
+		case arrayReturnInsideIntersection:
+			element = semtypes.Intersect(element, semtypes.ValReadonly)
+			label = "readonly"
+		}
+		if semtypes.IsSubtype(ctx.TypeCtx(), td.Type, semtypes.List) {
+			inner := newExternList(ctx, td.Type, []values.BalValue{"explicit"})
+			return newExternList(ctx, externArrayType(ctx, td.Type, 0, true), []values.BalValue{inner}), nil
+		}
+		items := make([]values.BalValue, size)
+		for i := range items {
+			items[i] = label
+		}
+		length := 0
+		isOpen := true
+		if kind == arrayReturnFixed {
+			length = 2
+			isOpen = false
+		}
+		return newExternList(ctx, externArrayType(ctx, element, length, isOpen), items), nil
+	}
+}
+
+func externArrayType(ctx *extern.Context, element semtypes.SemType, length int, isOpen bool) semtypes.SemType {
+	definition := semtypes.NewListDefinition()
+	if isOpen {
+		return definition.Define(ctx.TypeEnv(), nil, semtypes.ListRest(element))
+	}
+	return definition.Define(ctx.TypeEnv(), []semtypes.SemType{element}, semtypes.ListFixedLength(length))
+}
+
+func newExternList(ctx *extern.Context, ty semtypes.SemType, items []values.BalValue) *values.List {
+	return values.NewList(ty, semtypes.ToListAtomicType(ctx.TypeEnv(), ty), false, nil, len(items), items)
 }
 
 func TestDependentlyTypedAlias(t *testing.T) {
@@ -1047,6 +1130,17 @@ func TestDependentlyTypedCrossModuleRoundtrip(t *testing.T) {
 		}
 		panic(values.NewErrorWithMessage("unsupported inferred typedesc constraint"))
 	})
+	runtime.RegisterExternFunction(rt, org, helperMod, "inferredNestedFixedArray", func(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+		td, ok := args[0].(*values.TypeDesc)
+		if !ok {
+			return nil, fmt.Errorf("expected typedesc argument, got %T", args[0])
+		}
+		innerTy := externArrayType(ctx, td.Type, 0, true)
+		first := newExternList(ctx, innerTy, []values.BalValue{"first"})
+		second := newExternList(ctx, innerTy, []values.BalValue{"serialized"})
+		outerTy := externArrayType(ctx, innerTy, 2, false)
+		return newExternList(ctx, outerTy, []values.BalValue{first, second}), nil
+	})
 	for _, pkg := range deserializedPkgs {
 		if err := rt.Init(*pkg); err != nil {
 			t.Fatalf("runtime error: %v", err)
@@ -1055,7 +1149,7 @@ func TestDependentlyTypedCrossModuleRoundtrip(t *testing.T) {
 	rt.Listen()
 	<-rt.ExitStatus
 
-	const expected = "1\nfoo\n"
+	const expected = "1\nfoo\nserialized\n"
 	if got := pal.Stdout(); got != expected {
 		t.Errorf("expected %q, got %q", expected, got)
 	}

--- a/corpus/extern/testdata/cross-module-dependent-fn-v/main.bal
+++ b/corpus/extern/testdata/cross-module-dependent-fn-v/main.bal
@@ -22,4 +22,6 @@ public function main() {
     io:println(a);
     string b = helper:inferred(1);
     io:println(b);
+    string[2][] values = helper:inferredNestedFixedArray();
+    io:println(values[1][0]);
 }

--- a/corpus/extern/testdata/cross-module-dependent-fn-v/modules/helper/helper.bal
+++ b/corpus/extern/testdata/cross-module-dependent-fn-v/modules/helper/helper.bal
@@ -15,3 +15,5 @@
 // under the License.
 
 public function inferred(int val, typedesc retTy = <>) returns retTy = external;
+
+public function inferredNestedFixedArray(typedesc retTy = <>) returns retTy[2][] = external;

--- a/corpus/extern/testdata/dependently-typed-v.bal
+++ b/corpus/extern/testdata/dependently-typed-v.bal
@@ -17,6 +17,7 @@
 import ballerina/io;
 
 type Point record {| int x; int y; |};
+type StringArray string[];
 
 public function main() {
     int a = inferred(0);
@@ -70,6 +71,49 @@ public function main() {
     future<string> contextual = start inferred(2);
     string|error contextualResult = wait contextual;
     io:println(contextualResult); // @output foo
+
+    string[] openArray = inferredOpenArray();
+    io:println(openArray[0]); // @output open
+
+    string[]|error openArrayInUnion = inferredOpenArray();
+    if openArrayInUnion is string[] {
+        io:println(openArrayInUnion[0]); // @output open
+    }
+
+    string[2] fixedArray = inferredFixedArray();
+    io:println(fixedArray[1]); // @output fixed
+
+    string[] fixedArrayAsOpen = inferredFixedArray();
+    io:println(fixedArrayAsOpen[0]); // @output fixed
+
+    string[0] zeroArray = inferredZeroArray();
+    io:println(zeroArray.length()); // @output 0
+
+    string[][] nestedArray = inferredNestedArray();
+    io:println(nestedArray[0][0]); // @output nested
+
+    string[]|error outsideUnion = inferredArrayOutsideUnion();
+    if outsideUnion is string[] {
+        io:println(outsideUnion[0]); // @output outside
+    }
+
+    (string|error)[] insideUnion = inferredArrayInsideUnion();
+    io:println(insideUnion[0]); // @output inside
+
+    (string & readonly)[] insideIntersection = inferredArrayInsideIntersection();
+    io:println(insideIntersection[0]); // @output readonly
+
+    string[][] explicitArray = inferredOpenArray(StringArray);
+    io:println(explicitArray[0][0]); // @output explicit
+
+    string[2] explicitFixedArray = inferredFixedArray(string);
+    io:println(explicitFixedArray[0]); // @output fixed
+
+    string[0] explicitZeroArray = inferredZeroArray(string);
+    io:println(explicitZeroArray.length()); // @output 0
+
+    string[][] explicitNestedArray = inferredNestedArray(string);
+    io:println(explicitNestedArray[0][0]); // @output nested
 }
 
 function inferred(int val, typedesc retTy = <>) returns retTy = external;
@@ -83,6 +127,20 @@ function shiftBy(Point p, int dx, int dy, typedesc retTy = <>) returns retTy = e
 function inferredWithDefault(int val = 42, typedesc retTy = <>) returns retTy = external;
 
 function inferredMaybeError(typedesc<any|error> retTy = <>) returns retTy = external;
+
+function inferredOpenArray(typedesc retTy = <>) returns retTy[] = external;
+
+function inferredFixedArray(typedesc retTy = <>) returns retTy[2] = external;
+
+function inferredZeroArray(typedesc retTy = <>) returns retTy[0] = external;
+
+function inferredNestedArray(typedesc retTy = <>) returns retTy[][] = external;
+
+function inferredArrayOutsideUnion(typedesc retTy = <>) returns retTy[]|error = external;
+
+function inferredArrayInsideUnion(typedesc<anydata> retTy = <>) returns (retTy|error)[] = external;
+
+function inferredArrayInsideIntersection(typedesc retTy = <>) returns (retTy & readonly)[] = external;
 
 isolated client class Getter {
     isolated remote function get(typedesc<anydata> targetType = <>) returns targetType & readonly = external;

--- a/corpus/extern/testdata/expected/dependently-typed-v.txtar
+++ b/corpus/extern/testdata/expected/dependently-typed-v.txtar
@@ -16,4 +16,17 @@ bar
 error
 immutable
 foo
+open
+open
+fixed
+fixed
+0
+nested
+outside
+inside
+readonly
+explicit
+fixed
+0
+nested
 -- stderr --

--- a/corpus/integration/subset8/08-function/dependent-fn-array-e.txtar
+++ b/corpus/integration/subset8/08-function/dependent-fn-array-e.txtar
@@ -1,0 +1,25 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: cannot infer maximal type such that it is a subtype of both int|string and [float...]
+  --> dependent-fn-array-e.bal:43:17
+   |
+43 |     float[] _ = constrained(); // @error
+   |                 ^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: cannot infer typedesc argument for parameter 'T': no contextually expected type
+  --> dependent-fn-array-e.bal:42:13
+   |
+42 |     var _ = open(); // @error
+   |             ^^^^^^
+
+error[SEMANTIC_ERROR]: cannot infer typedesc argument from incompatible expected array type [string, string, string, never...]
+  --> dependent-fn-array-e.bal:41:19
+   |
+41 |     string[3] _ = fixed(); // @error
+   |                   ^^^^^^^
+
+error[SEMANTIC_ERROR]: cannot infer typedesc argument from incompatible expected array type string
+  --> dependent-fn-array-e.bal:40:16
+   |
+40 |     string _ = open(); // @error
+   |                ^^^^^^

--- a/model/symbol.go
+++ b/model/symbol.go
@@ -160,7 +160,7 @@ const (
 type TypeOp interface {
 	Apply(ctx semtypes.Context, args []semtypes.SemType) semtypes.SemType
 	// FixedPart returns the part of the return type that does not depend on any typedesc parameter.
-	FixedPart() semtypes.SemType
+	FixedPart(ctx semtypes.Context) semtypes.SemType
 }
 
 type BinaryTypeOp struct {
@@ -178,9 +178,9 @@ func (binary *BinaryTypeOp) Apply(ctx semtypes.Context, args []semtypes.SemType)
 	return semtypes.Intersect(lhs, rhs)
 }
 
-func (binary *BinaryTypeOp) FixedPart() semtypes.SemType {
-	lhs := binary.Lhs.FixedPart()
-	rhs := binary.Rhs.FixedPart()
+func (binary *BinaryTypeOp) FixedPart(ctx semtypes.Context) semtypes.SemType {
+	lhs := binary.Lhs.FixedPart(ctx)
+	rhs := binary.Rhs.FixedPart(ctx)
 	if binary.Kind == TypeOpUnion {
 		return semtypes.Union(lhs, rhs)
 	}
@@ -195,7 +195,7 @@ func (identity *IdentityTypeOp) Apply(_ semtypes.Context, _ []semtypes.SemType) 
 	return identity.Type
 }
 
-func (identity *IdentityTypeOp) FixedPart() semtypes.SemType {
+func (identity *IdentityTypeOp) FixedPart(_ semtypes.Context) semtypes.SemType {
 	return identity.Type
 }
 
@@ -208,9 +208,42 @@ func (ref *RefTypeOp) Apply(ctx semtypes.Context, args []semtypes.SemType) semty
 	return semtypes.TypedescConstraint(ctx, args[ref.Index])
 }
 
-func (ref *RefTypeOp) FixedPart() semtypes.SemType {
+func (ref *RefTypeOp) FixedPart(_ semtypes.Context) semtypes.SemType {
 	return semtypes.Never
 }
+
+// ArrayTypeOp applies one array dimension to the type produced by Element.
+// When IsOpen is true, the operation produces Element[] and Length is ignored.
+// Otherwise, the operation produces Element[Length], including when Length is zero.
+// Multidimensional arrays are represented by nested ArrayTypeOp values.
+type ArrayTypeOp struct {
+	Element TypeOp
+	Length  int
+	IsOpen  bool
+}
+
+func (op *ArrayTypeOp) Apply(ctx semtypes.Context, args []semtypes.SemType) semtypes.SemType {
+	return op.arrayType(ctx, op.Element.Apply(ctx, args))
+}
+
+func (op *ArrayTypeOp) FixedPart(ctx semtypes.Context) semtypes.SemType {
+	return op.arrayType(ctx, op.Element.FixedPart(ctx))
+}
+
+func (op *ArrayTypeOp) arrayType(ctx semtypes.Context, element semtypes.SemType) semtypes.SemType {
+	definition := semtypes.NewListDefinition()
+	if op.IsOpen {
+		return definition.Define(ctx.Env(), nil, semtypes.ListRest(element))
+	}
+	return definition.Define(ctx.Env(), []semtypes.SemType{element}, semtypes.ListFixedLength(op.Length))
+}
+
+var (
+	_ TypeOp = &ArrayTypeOp{}
+	_ TypeOp = &BinaryTypeOp{}
+	_ TypeOp = &IdentityTypeOp{}
+	_ TypeOp = &RefTypeOp{}
+)
 
 type SymbolKind uint
 

--- a/model/symbolpool/deserializer.go
+++ b/model/symbolpool/deserializer.go
@@ -62,12 +62,6 @@ func (sr *symbolReader) deserialize() (result model.ExportedSymbolSpace, err err
 		panic(fmt.Sprintf("invalid symbol magic: %x", magic))
 	}
 
-	var version int32
-	read(sr.r, &version)
-	if version != symVersion {
-		panic(fmt.Sprintf("unsupported symbol version: %d", version))
-	}
-
 	var tpSize int64
 	read(sr.r, &tpSize)
 	tpBytes := make([]byte, tpSize)

--- a/model/symbolpool/deserializer.go
+++ b/model/symbolpool/deserializer.go
@@ -724,6 +724,13 @@ func (sr *symbolReader) readTypeOp() model.TypeOp {
 		lhs := sr.readTypeOp()
 		rhs := sr.readTypeOp()
 		return &model.BinaryTypeOp{Kind: model.TypeOpIntersection, Lhs: lhs, Rhs: rhs}
+	case typeOpTagArray:
+		element := sr.readTypeOp()
+		var length int64
+		read(sr.r, &length)
+		var isOpen bool
+		read(sr.r, &isOpen)
+		return &model.ArrayTypeOp{Element: element, Length: int(length), IsOpen: isOpen}
 	default:
 		panic(fmt.Sprintf("unknown TypeOp tag: %d", tag))
 	}

--- a/model/symbolpool/serializer.go
+++ b/model/symbolpool/serializer.go
@@ -27,10 +27,7 @@ import (
 	"github.com/ballerina-nutcracker/ballerina/values"
 )
 
-const (
-	symMagic   = "\x53\x59\x4d\x42"
-	symVersion = 10
-)
+const symMagic = "\x53\x59\x4d\x42"
 
 const (
 	symTagType uint8 = iota
@@ -129,9 +126,6 @@ func (sw *symbolWriter) serialize(exported model.ExportedSymbolSpace) ([]byte, e
 	buf := &bytes.Buffer{}
 	if _, err := buf.Write([]byte(symMagic)); err != nil {
 		return nil, fmt.Errorf("writing magic: %v", err)
-	}
-	if err := write(buf, int32(symVersion)); err != nil {
-		return nil, err
 	}
 	tpBytes := tpEncoding.Bytes()
 	if err := write(buf, int64(len(tpBytes))); err != nil {

--- a/model/symbolpool/serializer.go
+++ b/model/symbolpool/serializer.go
@@ -54,6 +54,7 @@ const (
 	typeOpTagRef
 	typeOpTagUnion
 	typeOpTagIntersect
+	typeOpTagArray
 )
 
 const (
@@ -828,6 +829,17 @@ func (sw *symbolWriter) writeTypeOp(buf *bytes.Buffer, op model.TypeOp) error {
 			return err
 		}
 		return sw.writeTypeOp(buf, o.Rhs)
+	case *model.ArrayTypeOp:
+		if err := write(buf, typeOpTagArray); err != nil {
+			return err
+		}
+		if err := sw.writeTypeOp(buf, o.Element); err != nil {
+			return err
+		}
+		if err := write(buf, int64(o.Length)); err != nil {
+			return err
+		}
+		return write(buf, o.IsOpen)
 	default:
 		return fmt.Errorf("unsupported TypeOp: %T", op)
 	}

--- a/semantics/internal/analysis/semantic_analyzer.go
+++ b/semantics/internal/analysis/semantic_analyzer.go
@@ -622,6 +622,8 @@ func typeOpReferencesIndex(op model.TypeOp, i int) bool {
 		return o.Index == i
 	case *model.BinaryTypeOp:
 		return typeOpReferencesIndex(o.Lhs, i) || typeOpReferencesIndex(o.Rhs, i)
+	case *model.ArrayTypeOp:
+		return typeOpReferencesIndex(o.Element, i)
 	}
 	return false
 }
@@ -636,6 +638,8 @@ func checkDependentReturnParts(a analyzer, ctx semtypes.Context, op model.TypeOp
 		// IdentityTypeOp is a defined/concrete return part, e.g. error or int.
 		// A single part has no sibling to overlap with, so it is disjoint by itself.
 		return false, true
+	case *model.ArrayTypeOp:
+		return checkDependentReturnParts(a, ctx, o.Element, paramTypes, loc)
 	case *model.BinaryTypeOp:
 		lhsDepends, lhsDisjoint := checkDependentReturnParts(a, ctx, o.Lhs, paramTypes, loc)
 		rhsDepends, rhsDisjoint := checkDependentReturnParts(a, ctx, o.Rhs, paramTypes, loc)

--- a/semantics/internal/symbols/symbol_resolver.go
+++ b/semantics/internal/symbols/symbol_resolver.go
@@ -549,6 +549,8 @@ func returnTypeReferencesTypedescParam(node ast.BLangNode, typedescParams map[st
 		}
 		_, ok := typedescParams[n.TypeName.Value]
 		return ok
+	case *ast.BLangArrayType:
+		return returnTypeReferencesTypedescParam(n.Elemtype.TypeDescriptor.(ast.BLangNode), typedescParams)
 	case *ast.BLangUnionTypeNode:
 		if lhs, ok := n.Lhs().TypeDescriptor.(ast.BLangNode); ok && returnTypeReferencesTypedescParam(lhs, typedescParams) {
 			return true

--- a/semantics/internal/types/type_resolver.go
+++ b/semantics/internal/types/type_resolver.go
@@ -2176,7 +2176,7 @@ type param struct {
 
 // buildReturnTypeOp translates a return-type-descriptor AST node into a TypeOp tree.
 // A user-defined-type node whose name matches a typedesc parameter becomes a RefTypeOp.
-// Union and intersection nodes recurse. Everything else is resolved to a concrete semtype
+// Array, union, and intersection nodes recurse. Everything else is resolved to a concrete semtype
 // and wrapped in an IdentityTypeOp.
 func buildReturnTypeOp(t typeResolver, params map[string]param, node ast.BLangNode) (model.TypeOp, bool) {
 	switch n := node.(type) {
@@ -2202,6 +2202,24 @@ func buildReturnTypeOp(t typeResolver, params map[string]param, node ast.BLangNo
 			return nil, false
 		}
 		return &model.BinaryTypeOp{Kind: model.TypeOpIntersection, Lhs: lhs, Rhs: rhs}, true
+	case *ast.BLangArrayType:
+		element, ok := buildReturnTypeOp(t, params, n.Elemtype.TypeDescriptor.(ast.BLangNode))
+		if !ok {
+			return nil, false
+		}
+		for i := len(n.Sizes); i > 0; i-- {
+			lengthExpr := n.Sizes[i-1]
+			if lengthExpr == nil {
+				element = &model.ArrayTypeOp{Element: element, IsOpen: true}
+				continue
+			}
+			length, ok := resolveFixedArraySize(t, lengthExpr)
+			if !ok {
+				return nil, false
+			}
+			element = &model.ArrayTypeOp{Element: element, Length: length}
+		}
+		return element, true
 	case *ast.BLangUserDefinedType:
 		if n.PkgAlias.GetValue() == "" {
 			if p, ok := params[n.TypeName.Value]; ok && semtypes.IsSubtype(t.typeContext(), p.ty, semtypes.Typedesc) {
@@ -7082,7 +7100,7 @@ func lowerInvocationArgsInner(t typeResolver, args []ast.BLangExpression, sig mo
 				return nil, false
 			}
 			constraint := semtypes.TypedescConstraint(t.typeContext(), paramTypes[i])
-			defaultArg, ok := lowerInferredTypedescDefaultArg(t, constraint, expectedType, depSym.ReturnType().FixedPart(), pos)
+			defaultArg, ok := lowerInferredTypedescDefaultArg(t, constraint, expectedType, depSym.ReturnType(), i, pos)
 			if !ok {
 				return nil, false
 			}
@@ -7102,14 +7120,15 @@ func lowerInvocationArgsInner(t typeResolver, args []ast.BLangExpression, sig mo
 	return newArgs, true
 }
 
-func lowerInferredTypedescDefaultArg(t typeResolver, constraint, expectedType, fixedReturnType semtypes.SemType, pos diagnostics.Location) (ast.BLangExpression, bool) {
+func lowerInferredTypedescDefaultArg(t typeResolver, constraint, expectedType semtypes.SemType, returnOp model.TypeOp, paramIndex int, pos diagnostics.Location) (ast.BLangExpression, bool) {
 	ctx := t.typeContext()
-	inferred := semtypes.Diff(expectedType, fixedReturnType)
-	if semtypes.IsEmpty(ctx, inferred) {
-		inferred = expectedType
+	inferred, referenced, ok := inferTypedescConstraint(t, returnOp, paramIndex, constraint, expectedType, pos)
+	if !ok {
+		return nil, false
 	}
-	if !semtypes.IsSubtype(ctx, inferred, constraint) {
-		inferred = semtypes.Intersect(constraint, inferred)
+	if !referenced {
+		t.internalError("inferred typedesc parameter is not referenced by return type", pos)
+		return nil, false
 	}
 	if semtypes.IsEmpty(ctx, inferred) {
 		t.semanticError(fmt.Sprintf("cannot infer maximal type such that it is a subtype of both %s and %s",
@@ -7121,6 +7140,100 @@ func lowerInferredTypedescDefaultArg(t typeResolver, constraint, expectedType, f
 	expr.SetPosition(pos)
 	setExpectedType(expr, ty)
 	return expr, true
+}
+
+func inferTypedescConstraint(t typeResolver, op model.TypeOp, paramIndex int, constraint, candidate semtypes.SemType, pos diagnostics.Location) (semtypes.SemType, bool, bool) {
+	ctx := t.typeContext()
+	switch current := op.(type) {
+	case *model.RefTypeOp:
+		if current.Index != paramIndex {
+			return semtypes.Never, false, true
+		}
+		if !semtypes.IsSubtype(ctx, candidate, constraint) {
+			candidate = semtypes.Intersect(constraint, candidate)
+		}
+		return candidate, true, true
+	case *model.IdentityTypeOp:
+		return semtypes.Never, false, true
+	case *model.ArrayTypeOp:
+		if !typeOpReferencesParam(current.Element, paramIndex) {
+			return semtypes.Never, false, true
+		}
+		shape := arraySemType(ctx, semtypes.Val, current.Length, current.IsOpen)
+		compatibleCandidate := semtypes.Intersect(candidate, shape)
+		if semtypes.IsEmpty(ctx, compatibleCandidate) {
+			t.semanticError(fmt.Sprintf("cannot infer typedesc argument from incompatible expected array type %s", semtypes.ToString(ctx, candidate)), pos)
+			return semtypes.Never, true, false
+		}
+		member := semtypes.ListProj(ctx, compatibleCandidate, semtypes.Int)
+		if semtypes.IsEmpty(ctx, member) {
+			return constraint, true, true
+		}
+		return inferTypedescConstraint(t, current.Element, paramIndex, constraint, member, pos)
+	case *model.BinaryTypeOp:
+		lhsDepends := typeOpReferencesParam(current.Lhs, paramIndex)
+		rhsDepends := typeOpReferencesParam(current.Rhs, paramIndex)
+		if !lhsDepends && !rhsDepends {
+			return semtypes.Never, false, true
+		}
+		if lhsDepends && !rhsDepends {
+			return inferTypedescConstraint(t, current.Lhs, paramIndex, constraint,
+				inferBinaryOperandCandidate(ctx, current.Kind, candidate, current.Rhs.FixedPart(ctx)), pos)
+		}
+		if rhsDepends && !lhsDepends {
+			return inferTypedescConstraint(t, current.Rhs, paramIndex, constraint,
+				inferBinaryOperandCandidate(ctx, current.Kind, candidate, current.Lhs.FixedPart(ctx)), pos)
+		}
+		lhs, _, ok := inferTypedescConstraint(t, current.Lhs, paramIndex, constraint, candidate, pos)
+		if !ok {
+			return semtypes.Never, true, false
+		}
+		rhs, _, ok := inferTypedescConstraint(t, current.Rhs, paramIndex, constraint, candidate, pos)
+		if !ok {
+			return semtypes.Never, true, false
+		}
+		if current.Kind == model.TypeOpUnion {
+			return semtypes.Intersect(lhs, rhs), true, true
+		}
+		return semtypes.Union(lhs, rhs), true, true
+	default:
+		t.internalError(fmt.Sprintf("unknown dependent return type op: %T", op), pos)
+		return semtypes.Never, false, false
+	}
+}
+
+func inferBinaryOperandCandidate(ctx semtypes.Context, kind model.BinaryTypeOpKind, candidate, fixed semtypes.SemType) semtypes.SemType {
+	if kind != model.TypeOpUnion {
+		return candidate
+	}
+	inferred := semtypes.Diff(candidate, fixed)
+	if semtypes.IsEmpty(ctx, inferred) {
+		return candidate
+	}
+	return inferred
+}
+
+func typeOpReferencesParam(op model.TypeOp, paramIndex int) bool {
+	switch current := op.(type) {
+	case *model.RefTypeOp:
+		return current.Index == paramIndex
+	case *model.ArrayTypeOp:
+		return typeOpReferencesParam(current.Element, paramIndex)
+	case *model.BinaryTypeOp:
+		return typeOpReferencesParam(current.Lhs, paramIndex) || typeOpReferencesParam(current.Rhs, paramIndex)
+	case *model.IdentityTypeOp:
+		return false
+	default:
+		return false
+	}
+}
+
+func arraySemType(ctx semtypes.Context, element semtypes.SemType, length int, isOpen bool) semtypes.SemType {
+	definition := semtypes.NewListDefinition()
+	if isOpen {
+		return definition.Define(ctx.Env(), nil, semtypes.ListRest(element))
+	}
+	return definition.Define(ctx.Env(), []semtypes.SemType{element}, semtypes.ListFixedLength(length))
 }
 
 func lowerNamedCallArg(t typeResolver, sig model.UntypedFunctionSignature, slots []lowerArgSlot, seenNames map[string]diagnostics.Location, expr *ast.BLangNamedArgsExpression) bool {


### PR DESCRIPTION
## Summary

- recognize typedesc parameter references inside array return descriptors
- preserve open, fixed, zero-length, and nested array operations through symbol serialization
- infer typedesc defaults through array, union, and intersection operation trees
- validate explicit and inferred calls through corpus, extern-runtime, and cross-module tests

## Testing

- `go test ./model/... ./semantics/... ./corpus ./corpus/extern/...`
- `go test ./...`
- commit hook: `make -j4 build lint`

Depends on #835

Closes #831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for dependently typed functions that infer and return open, fixed-size, zero-length, nested, union, and intersection-based arrays.
  - Extended dependent array return types across module boundaries, including nested fixed-size arrays.
  - Added XML filter expression resolution and improved readonly mapping-field mutation checks.

- **Bug Fixes**
  - Improved diagnostics for incompatible dependent array return types and invalid non-`typedesc` parameter references.
  - Fixed serialization and restoration of array type information, including nested array shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->