### PR TITLE
[Don't merge]: bisect frontend API commit for exec regression

### DIFF
--- a/ast/statements.go
+++ b/ast/statements.go
@@ -127,8 +127,9 @@ type (
 		// LockKey is the content-addressed identifier of the restricted
 		// variable, set by the lock analyzer. For a module-level isolated
 		// variable it has the form "org/pkg:varName"; for a non-immutable
-		// field of an isolated class accessed via self it has the form
-		// "org/pkg:ClassName.fieldName". Empty when the lock body has no
+		// field of an isolated class or service accessed via self it has the
+		// form "org/pkg:ClassName.fieldName" or
+		// "org/pkg:$service$N.fieldName". Empty when the lock body has no
 		// restricted variable (we treat this as a semantic error though
 		// spec doesn't).
 		LockKey string

--- a/birgen/bir_gen.go
+++ b/birgen/bir_gen.go
@@ -41,6 +41,7 @@ func birLoc(de *diagnostics.DiagnosticEnv, pos diagnostics.Location) bir.Locatio
 type packageContext struct {
 	CompilerContext *compilerctx.CompilerContext
 	packageID       *model.PackageID // Current package ID
+	sourcePrefix    string
 	birPkg          *bir.BIRPackage
 	typeCtx         semtypes.Context
 	// PR-TODO: extract them to memoized types struc
@@ -75,7 +76,16 @@ func (fn *functionContext) addBB() *bir.BIRBasicBlock {
 }
 
 func (fn *functionContext) loc(pos diagnostics.Location) bir.Location {
-	return birLoc(fn.pkgCtx.CompilerContext.DiagnosticEnv(), pos)
+	return fn.pkgCtx.loc(pos)
+}
+
+func (c *packageContext) loc(pos diagnostics.Location) bir.Location {
+	location := birLoc(c.CompilerContext.DiagnosticEnv(), pos)
+	if c.sourcePrefix == "" || bir.IsLocationEmpty(location) {
+		return location
+	}
+	return bir.NewLocation(c.sourcePrefix+location.FilePath(), location.StartLine(), location.EndLine(),
+		location.StartColumn(), location.EndColumn())
 }
 
 // context is one node of the lexical block tree. The whole tree (across
@@ -383,9 +393,14 @@ func newContext(compilerCtx *compilerctx.CompilerContext, packageID *model.Packa
 }
 
 func GenBir(ctx *compilerctx.CompilerContext, ast *ast.BLangPackage) *bir.BIRPackage {
+	return GenBirWithSourcePrefix(ctx, ast, "")
+}
+
+func GenBirWithSourcePrefix(ctx *compilerctx.CompilerContext, ast *ast.BLangPackage, sourcePrefix string) *bir.BIRPackage {
 	birPkg := &bir.BIRPackage{}
 	birPkg.PackageID = ast.PackageID
 	genCtx := newContext(ctx, ast.PackageID, birPkg)
+	genCtx.sourcePrefix = sourcePrefix
 	birPkg.GlobalVars = make(map[string]bir.BIRGlobalVariableDcl)
 	for _, globalVar := range ast.GlobalVars {
 		addGlobalVar(birPkg, transformGlobalVariableDcl(genCtx, globalVar))
@@ -450,7 +465,7 @@ func addGlobalVar(birPkg *bir.BIRPackage, dcl bir.BIRGlobalVariableDcl) {
 func transformGlobalVariableDcl(ctx *packageContext, ast *ast.BLangVariable) bir.BIRGlobalVariableDcl {
 	name := model.Name(ast.GetName().GetValue())
 	dcl := bir.BIRGlobalVariableDcl{}
-	dcl.Pos = birLoc(ctx.CompilerContext.DiagnosticEnv(), ast.GetPosition())
+	dcl.Pos = ctx.loc(ast.GetPosition())
 	dcl.Name = name
 	dcl.PkgID = ctx.packageID
 	dcl.Type = ctx.CompilerContext.SymbolType(ast.Symbol())

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -146,7 +146,11 @@ func printDiagnostic(fsys fs.FS, w io.Writer, d diagnostics.Diagnostic, noColors
 		de.EndLine(location), de.EndColumn(location),
 	)
 	printDiagnosticLocation(w, s, loc)
-	printSourceSnippet(w, s, loc, fsys, s.severityColor(d.DiagnosticInfo().Severity()))
+	if document := de.TextDocument(location); document != nil {
+		printSourceSnippetContent(w, s, loc, document.String(), s.severityColor(d.DiagnosticInfo().Severity()))
+	} else {
+		printSourceSnippet(w, s, loc, fsys, s.severityColor(d.DiagnosticInfo().Severity()))
+	}
 	_, _ = fmt.Fprintln(w)
 }
 
@@ -176,7 +180,11 @@ func printSourceSnippet(w io.Writer, s outputStyle, loc diagnosticLocation, fsys
 	if err != nil {
 		return
 	}
-	lines := strings.Split(string(content), "\n")
+	printSourceSnippetContent(w, s, loc, string(content), severityColor)
+}
+
+func printSourceSnippetContent(w io.Writer, s outputStyle, loc diagnosticLocation, content, severityColor string) {
+	lines := strings.Split(content, "\n")
 	if loc.startLine >= len(lines) {
 		return
 	}

--- a/context/env.go
+++ b/context/env.go
@@ -97,6 +97,7 @@ func (t *distinctTypeTracker) symbolRef(id int) (model.SymbolRef, bool) {
 type CompilerEnvironment struct {
 	anonTypeCount              map[*model.PackageID]int
 	anonFuncCount              map[*model.PackageID]int
+	anonCountMu                sync.Mutex
 	packageInterner            *model.PackageIDInterner
 	symbolSpaces               []*model.SymbolSpace
 	symbolSpacesMu             sync.RWMutex // we need this because desugaring add new init functions concurrently we shouldn't need this if the spaces are scoped to the module, may be we should do that?
@@ -374,12 +375,16 @@ const (
 )
 
 func (c *CompilerEnvironment) GetNextAnonymousFunctionKey(packageID *model.PackageID) string {
+	c.anonCountMu.Lock()
+	defer c.anonCountMu.Unlock()
 	nextValue := c.anonFuncCount[packageID]
 	c.anonFuncCount[packageID] = nextValue + 1
 	return anonPrefix + "Func$_" + strconv.Itoa(nextValue)
 }
 
 func (c *CompilerEnvironment) GetNextAnonymousTypeKey(packageID *model.PackageID) string {
+	c.anonCountMu.Lock()
+	defer c.anonCountMu.Unlock()
 	nextValue := c.anonTypeCount[packageID]
 	c.anonTypeCount[packageID] = nextValue + 1
 	if packageID != nil && model.ANNOTATIONS_PKG != packageID {

--- a/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-isolated-resource-remote-1-v.txt
@@ -47,7 +47,7 @@ class $service$0 {
 
   $remote$greet() -> string{
     bb0 {
-      lock-start "$anon/.:$service.514.1.foo" GOTO bb1;
+      lock-start "$anon/.:$service$0.foo" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 2
@@ -55,7 +55,7 @@ class $service$0 {
       %0 = (1, self)[%1];
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.514.1.foo" GOTO bb2;
+      lock-end "$anon/.:$service$0.foo" GOTO bb2;
     }
     bb2 {
       return;
@@ -77,7 +77,7 @@ class $service$0 {
   resource get hello $resource$get$0(string) -> string{
     bb0 {
       _ = name;
-      lock-start "$anon/.:$service.514.1.foo" GOTO bb1;
+      lock-start "$anon/.:$service$0.foo" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 4
@@ -87,7 +87,7 @@ class $service$0 {
       %0 = + %1 %2;
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.514.1.foo" GOTO bb2;
+      lock-end "$anon/.:$service$0.foo" GOTO bb2;
     }
     bb2 {
       return;

--- a/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
+++ b/corpus/bir/subset9/09-object/service-lock-field-1-v.txt
@@ -113,7 +113,7 @@ class $service$0 {
 
   get() -> int{
     bb0 {
-      lock-start "$anon/.:$service.524.0.count" GOTO bb1;
+      lock-start "$anon/.:$service$0.count" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 2
@@ -121,7 +121,7 @@ class $service$0 {
       %0 = (1, self)[%1];
       (1, %0) = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.524.0.count" GOTO bb2;
+      lock-end "$anon/.:$service$0.count" GOTO bb2;
     }
     bb2 {
       return;
@@ -133,7 +133,7 @@ class $service$0 {
 
   inc() -> nil{
     bb0 {
-      lock-start "$anon/.:$service.524.0.count" GOTO bb1;
+      lock-start "$anon/.:$service$0.count" GOTO bb1;
     }
     bb1 {
       PushScopeFrame 7
@@ -146,7 +146,7 @@ class $service$0 {
       %6 = ConstantLoad count
       (1, self)[%6] = %0;
       PopScopeFrame
-      lock-end "$anon/.:$service.524.0.count" GOTO bb2;
+      lock-end "$anon/.:$service$0.count" GOTO bb2;
     }
     bb2 {
       return;

--- a/desugar/desugar.go
+++ b/desugar/desugar.go
@@ -44,7 +44,7 @@ type desugaredNode[E ast.Node] struct {
 type packageContext struct {
 	compilerCtx            *context.CompilerContext
 	pkg                    *ast.BLangPackage
-	importedSymbols        map[string]model.ExportedSymbolSpace
+	importedSymbols        model.ImportedSymbolSpaces
 	importMu               sync.Mutex
 	addedImplicitImports   map[string]bool
 	defaultClosureOwnersMu sync.Mutex
@@ -56,7 +56,7 @@ type packageContext struct {
 
 var _ desugarContext = &packageContext{}
 
-func newPackageContext(compilerCtx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) *packageContext {
+func newPackageContext(compilerCtx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols model.ImportedSymbolSpaces) *packageContext {
 	return &packageContext{
 		compilerCtx:          compilerCtx,
 		pkg:                  pkg,
@@ -131,8 +131,7 @@ func inferredLambda(expr ast.BLangActionOrExpression) *ast.BLangLambdaFunction {
 }
 
 func (ctx *packageContext) getImportedSymbolSpace(pkgName string) (model.ExportedSymbolSpace, bool) {
-	space, ok := ctx.importedSymbols[pkgName]
-	return space, ok
+	return ctx.importedSymbols.ByModule("ballerina", pkgName)
 }
 
 func (ctx *packageContext) symbolType(symbol model.SymbolRef) semtypes.SemType {
@@ -1590,10 +1589,7 @@ func remapSymbolRefs(node ast.BLangNode, mapping map[model.SymbolRef]model.Symbo
 }
 
 // DesugarPackage returns a desugared package (may be new or same instance)
-func DesugarPackage(compilerCtx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) *ast.BLangPackage {
-	if importedSymbols == nil {
-		importedSymbols = make(map[string]model.ExportedSymbolSpace)
-	}
+func DesugarPackage(compilerCtx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols model.ImportedSymbolSpaces) *ast.BLangPackage {
 	pkgCtx := newPackageContext(compilerCtx, pkg, importedSymbols)
 
 	var wg sync.WaitGroup

--- a/model/symbol.go
+++ b/model/symbol.go
@@ -267,6 +267,8 @@ type (
 		AnnotationSpaces []*SymbolSpace
 	}
 
+	ImportedSymbolSpaces map[PackageIdentifier]ExportedSymbolSpace
+
 	BlockScopeBase struct {
 		Parent Scope
 		Main   *SymbolSpace
@@ -445,6 +447,19 @@ type (
 		fieldNames [][]string
 	}
 )
+
+func NewImportedSymbolSpaces() ImportedSymbolSpaces {
+	return make(ImportedSymbolSpaces)
+}
+
+func (spaces ImportedSymbolSpaces) ByModule(org, name string) (ExportedSymbolSpace, bool) {
+	for identifier, symbols := range spaces {
+		if identifier.Organization == org && identifier.Package == name {
+			return symbols, true
+		}
+	}
+	return ExportedSymbolSpace{}, false
+}
 
 func (ref SymbolRef) IsEmpty() bool {
 	return ref == SymbolRef{}

--- a/nodebuilder/mod.go
+++ b/nodebuilder/mod.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ballerina-nutcracker/ballerina/ast"
 	"github.com/ballerina-nutcracker/ballerina/context"
+	"github.com/ballerina-nutcracker/ballerina/model"
 	"github.com/ballerina-nutcracker/ballerina/st"
 	"github.com/ballerina-nutcracker/ballerina/tools/diagnostics"
 )
@@ -31,9 +32,27 @@ func GetCompilationUnit(cx *context.CompilerContext, syntaxTree *st.SyntaxTree) 
 	return compilationUnit.(*ast.BLangCompilationUnit)
 }
 
+func GetCompilationUnitForSource(cx *context.CompilerContext, syntaxTree *st.SyntaxTree,
+	packageID *model.PackageID,
+) *ast.BLangCompilationUnit {
+	builder := newNodeBuilderWithMode(cx, nodeBuilderModeStrict)
+	builder.PackageID = packageID
+	compilationUnit := builder.transformModulePart(syntaxTree.RootNode.(*st.ModulePart))
+	return compilationUnit.(*ast.BLangCompilationUnit)
+}
+
 // GetRecoveredCompilationUnit builds an AST while preserving malformed syntax as bad nodes.
 func GetRecoveredCompilationUnit(cx *context.CompilerContext, syntaxTree *st.SyntaxTree) *ast.BLangCompilationUnit {
 	builder := newRecoveringNodeBuilder(cx)
+	compilationUnit := builder.transformModulePart(syntaxTree.RootNode.(*st.ModulePart))
+	return compilationUnit.(*ast.BLangCompilationUnit)
+}
+
+func GetRecoveredCompilationUnitForSource(cx *context.CompilerContext, syntaxTree *st.SyntaxTree,
+	packageID *model.PackageID,
+) *ast.BLangCompilationUnit {
+	builder := newNodeBuilderWithMode(cx, nodeBuilderModeRecover)
+	builder.PackageID = packageID
 	compilationUnit := builder.transformModulePart(syntaxTree.RootNode.(*st.ModulePart))
 	return compilationUnit.(*ast.BLangCompilationUnit)
 }
@@ -80,6 +99,8 @@ func addCompilationUnitNodesToPackage(cx *context.CompilerContext, pkg *ast.BLan
 			pkg.XmlnsList = append(pkg.XmlnsList, node)
 		case *ast.BLangClassDefinition:
 			pkg.ClassDefinitions = append(pkg.ClassDefinitions, node)
+		case *ast.BLangBadTopLevelNode:
+			continue
 		default:
 			pos := compilationUnit.GetPosition()
 			if node != nil {

--- a/nodebuilder/node_builder.go
+++ b/nodebuilder/node_builder.go
@@ -35,8 +35,10 @@ import (
 
 type nodeBuilderMode uint8
 
+const nodeBuilderModeStrict nodeBuilderMode = 0
+
 const (
-	nodeBuilderModeStrict nodeBuilderMode = iota
+	nodeBuilderModeLegacy nodeBuilderMode = 1 << iota
 	nodeBuilderModeRecover
 )
 
@@ -68,11 +70,11 @@ func (n *nodeBuilder) unimplemented(message string, node st.Node) {
 }
 
 func newNodeBuilder(cx *context.CompilerContext) *nodeBuilder {
-	return newNodeBuilderWithMode(cx, nodeBuilderModeStrict)
+	return newNodeBuilderWithMode(cx, nodeBuilderModeLegacy)
 }
 
 func newRecoveringNodeBuilder(cx *context.CompilerContext) *nodeBuilder {
-	return newNodeBuilderWithMode(cx, nodeBuilderModeRecover)
+	return newNodeBuilderWithMode(cx, nodeBuilderModeLegacy|nodeBuilderModeRecover)
 }
 
 func newNodeBuilderWithMode(cx *context.CompilerContext, mode nodeBuilderMode) *nodeBuilder {
@@ -83,6 +85,10 @@ func newNodeBuilderWithMode(cx *context.CompilerContext, mode nodeBuilderMode) *
 	}
 	return nodeBuilder
 }
+
+func (n *nodeBuilder) recovering() bool { return n.mode&nodeBuilderModeRecover != 0 }
+
+func (n *nodeBuilder) legacy() bool { return n.mode&nodeBuilderModeLegacy != 0 }
 
 func (n *nodeBuilder) transformSyntaxNode(node st.Node) ast.BLangNode {
 	switch t := node.(type) {
@@ -576,7 +582,7 @@ func diagnosticMessage(diagnostic st.STNodeDiagnostic) string {
 
 func (n *nodeBuilder) getPosition(node st.Node) diagnostics.Location {
 	textRange := node.TextRange()
-	if n.mode == nodeBuilderModeRecover {
+	if n.recovering() {
 		textRange = node.TextRangeWithMinutiae()
 	}
 	return n.location(node, textRange)
@@ -827,7 +833,7 @@ func (n *nodeBuilder) createTypeNode(typeNode st.Node) ast.TypeDescriptor {
 	if err == nil {
 		return result
 	}
-	if n.mode != nodeBuilderModeRecover {
+	if !n.recovering() {
 		n.internalError(err.Error(), typeNode)
 	}
 	return n.badTypeNode(typeNode)
@@ -960,13 +966,13 @@ func setIdentifierValue(identifier ast.IdentifierNode, value string) {
 
 func (n *nodeBuilder) createIdentifierNodeFromToken(pos diagnostics.Location, token st.Token) ast.IdentifierNode {
 	if token == nil {
-		if n.mode != nodeBuilderModeRecover {
+		if !n.recovering() {
 			n.cx.InternalError("missing identifier token", pos)
 		}
 		return n.badIdentifier(token)
 	}
 	if token.IsMissing() || isUnsupportedIdentifierToken(token) {
-		if n.mode != nodeBuilderModeRecover {
+		if !n.recovering() {
 			n.cx.InternalError("invalid identifier", pos)
 		}
 		return n.badIdentifier(token)
@@ -1293,7 +1299,7 @@ func (n *nodeBuilder) transformModulePart(modulePartNode *st.ModulePart) ast.BLa
 	compilationUnit.SetPackageID(n.PackageID)
 	pos := n.getPosition(modulePartNode)
 
-	if modulePartNode.HasDiagnostics() {
+	if n.legacy() && modulePartNode.HasDiagnostics() {
 		n.syntaxError(modulePartNode)
 	}
 
@@ -1301,14 +1307,14 @@ func (n *nodeBuilder) transformModulePart(modulePartNode *st.ModulePart) ast.BLa
 	imports := modulePartNode.Imports()
 	for importDecl := range imports.Iterator() {
 		if importDecl.HasDiagnostics() {
-			if n.mode == nodeBuilderModeRecover {
+			if n.recovering() {
 				compilationUnit.AddTopLevelNode(n.badTopLevel(importDecl))
 			}
 			continue
 		}
 		node, err := n.transformImportTopLevel(importDecl)
 		if err != nil {
-			if n.mode != nodeBuilderModeRecover {
+			if !n.recovering() {
 				n.internalError(err.Error(), importDecl)
 			}
 			node = n.badTopLevel(importDecl)
@@ -1322,7 +1328,7 @@ func (n *nodeBuilder) transformModulePart(modulePartNode *st.ModulePart) ast.BLa
 		// Dispatch to transformSyntaxNode which handles all node types
 		var memberNode st.Node = member
 		if memberNode.HasDiagnostics() {
-			if n.mode != nodeBuilderModeRecover {
+			if !n.recovering() {
 				continue
 			}
 			if memberNode.Kind() != st.FUNCTION_DEFINITION {
@@ -1339,12 +1345,10 @@ func (n *nodeBuilder) transformModulePart(modulePartNode *st.ModulePart) ast.BLa
 	}
 
 	// Create diagnostic location
-	fileName := ""
+	var newLocation diagnostics.Location
 	if !diagnostics.IsLocationEmpty(pos) {
-		fileName = n.de().FileName(pos)
+		newLocation = diagnostics.NewLocation(n.de(), getFileName(modulePartNode), 0, 0)
 	}
-
-	newLocation := diagnostics.NewLocation(n.de(), fileName, 0, 0)
 	compilationUnit.SetPosition(newLocation)
 	compilationUnit.SetPackageID(n.PackageID)
 
@@ -1464,7 +1468,7 @@ func (n *nodeBuilder) transformTopLevel(node st.Node) (ast.TopLevelNode, error) 
 	if err == nil {
 		return result, nil
 	}
-	if n.mode == nodeBuilderModeRecover {
+	if n.recovering() {
 		return n.badTopLevel(node), nil
 	}
 	return nil, err
@@ -1890,7 +1894,7 @@ func (n *nodeBuilder) transformStatement(statement st.StatementNode) ast.Stateme
 	if err == nil {
 		return result
 	}
-	if n.mode != nodeBuilderModeRecover {
+	if !n.recovering() {
 		n.internalError(err.Error(), statement)
 	}
 	return n.badStmt(statement)
@@ -1917,7 +1921,7 @@ func (n *nodeBuilder) generateAndAddBLangStatements(statementNodes st.NodeList[s
 		if currentStatement == nil {
 			continue
 		}
-		if currentStatement.HasDiagnostics() && n.mode != nodeBuilderModeRecover {
+		if currentStatement.HasDiagnostics() && !n.recovering() {
 			continue
 		}
 		if currentStatement.Kind() == st.FORK_STATEMENT {
@@ -1987,7 +1991,7 @@ func (n *nodeBuilder) createExpression(expressionNode st.Node) ast.BLangExpressi
 	if err == nil {
 		return result
 	}
-	if n.mode != nodeBuilderModeRecover {
+	if !n.recovering() {
 		n.internalError(err.Error(), expressionNode)
 	}
 	return n.badExprOrAction(expressionNode)
@@ -2011,7 +2015,7 @@ func (n *nodeBuilder) createActionOrExpression(actionOrExpression st.Node) ast.B
 	if err == nil {
 		return result
 	}
-	if n.mode != nodeBuilderModeRecover {
+	if !n.recovering() {
 		n.internalError(err.Error(), actionOrExpression)
 	}
 	return n.badExprOrAction(actionOrExpression)
@@ -5814,7 +5818,7 @@ func createUserDefinedType(pos diagnostics.Location, pkgAlias ast.BLangIdentifie
 }
 
 func (n *nodeBuilder) getNextMissingNodeName(pkgID *model.PackageID, node st.Node) string {
-	if n.mode != nodeBuilderModeRecover {
+	if !n.recovering() {
 		n.internalError("missing type-name token", node)
 	}
 	return n.cx.GetNextAnonymousTypeKey(pkgID)

--- a/parser/corpus_parser_test.go
+++ b/parser/corpus_parser_test.go
@@ -19,6 +19,7 @@ package parser
 import (
 	"encoding/json"
 	"flag"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -174,9 +175,10 @@ func parseFile(t *testing.T, testCase test_util.TestCase) {
 	ctx := context.NewCompilerContext(env)
 	ctx.DiagnosticEnv().RegisterFile(testCase.InputPath, text.TextDocumentFromText(source))
 
-	lexer := newLexer(ctx, testCase.InputPath, reader)
+	debug := newDebugOutput(DebugOptions{}, io.Discard)
+	lexer := newLexer(ctx, testCase.InputPath, reader, debug)
 
-	tokenReader := createTokenReader(ctx, testCase.InputPath, lexer)
+	tokenReader := createTokenReader(ctx, testCase.InputPath, lexer, debug)
 
 	ballerinaParser := newBallerinaParserFromTokenReader(tokenReader)
 

--- a/parser/debug_options.go
+++ b/parser/debug_options.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"fmt"
+	"io"
+)
+
+type DebugOptions struct {
+	DumpTokens     bool
+	DumpSyntaxTree bool
+	TraceRecovery  bool
+}
+
+type debugOutput struct {
+	options DebugOptions
+	writer  io.Writer
+}
+
+func newDebugOutput(options DebugOptions, writer io.Writer) *debugOutput {
+	if writer == nil {
+		writer = io.Discard
+	}
+	return &debugOutput{options: options, writer: writer}
+}
+
+func (d *debugOutput) write(enabled bool, message func() string) {
+	if parserDebugBuild && enabled {
+		_, _ = fmt.Fprintln(d.writer, message())
+	}
+}

--- a/parser/debug_options_debug.go
+++ b/parser/debug_options_debug.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build debug
+
+package parser
+
+const parserDebugBuild = true

--- a/parser/debug_options_release.go
+++ b/parser/debug_options_release.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !debug
+
+package parser
+
+const parserDebugBuild = false

--- a/parser/debug_options_test.go
+++ b/parser/debug_options_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build debug
+
+package parser_test
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	compilercontext "github.com/ballerina-nutcracker/ballerina/context"
+	"github.com/ballerina-nutcracker/ballerina/parser"
+	"github.com/ballerina-nutcracker/ballerina/semtypes"
+)
+
+func TestConcurrentParsesUseIndependentDebugWriters(t *testing.T) {
+	type parseCase struct {
+		name, source string
+		output       bytes.Buffer
+	}
+	cases := []*parseCase{
+		{name: "alpha.bal", source: "function alphaOnly() {}"},
+		{name: "beta.bal", source: "function betaOnly() {}"},
+	}
+	var wg sync.WaitGroup
+	for _, test := range cases {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			env := compilercontext.NewCompilerEnvironment(semtypes.CreateTypeEnv(), false)
+			cx := compilercontext.NewCompilerContext(env)
+			_, err := parser.GetSyntaxTreeWithIdentity(cx, test.name, "identity:"+test.name, test.source,
+				parser.DebugOptions{DumpTokens: true, DumpSyntaxTree: true}, &test.output)
+			if err != nil {
+				t.Errorf("parse %s: %v", test.name, err)
+			}
+		}()
+	}
+	wg.Wait()
+	for index, test := range cases {
+		own := strings.TrimSuffix(test.name, ".bal") + "Only"
+		other := strings.TrimSuffix(cases[1-index].name, ".bal") + "Only"
+		output := test.output.String()
+		if !strings.Contains(output, own) {
+			t.Fatalf("debug output for %s lacks %q: %s", test.name, own, output)
+		}
+		if strings.Contains(output, other) {
+			t.Fatalf("debug output for %s contains concurrent parse token %q", test.name, other)
+		}
+	}
+}
+
+func TestZeroDebugOptionsWriteNothing(t *testing.T) {
+	env := compilercontext.NewCompilerEnvironment(semtypes.CreateTypeEnv(), false)
+	cx := compilercontext.NewCompilerContext(env)
+	var output bytes.Buffer
+	if _, err := parser.GetSyntaxTreeWithIdentity(cx, "main.bal", "identity:main", "function main() {}",
+		parser.DebugOptions{}, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("zero debug options wrote %q", output.String())
+	}
+}

--- a/parser/diagnostics_test.go
+++ b/parser/diagnostics_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser_test
+
+import (
+	"testing"
+
+	compilercontext "github.com/ballerina-nutcracker/ballerina/context"
+	"github.com/ballerina-nutcracker/ballerina/parser"
+	"github.com/ballerina-nutcracker/ballerina/semtypes"
+	"github.com/ballerina-nutcracker/ballerina/tools/diagnostics"
+)
+
+func TestSyntaxDiagnosticMetadataAndProperties(t *testing.T) {
+	env := compilercontext.NewCompilerEnvironment(semtypes.CreateTypeEnv(), false)
+	cx := compilercontext.NewCompilerContext(env)
+	tree, err := parser.GetSyntaxTree(cx, "main.bal", "public function main() { int x += 1; }")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for diagnostic := range tree.Diagnostics() {
+		info := diagnostic.DiagnosticInfo()
+		if info.Code() == "" || info.MessageFormat() == "" || info.Severity() == 0 {
+			t.Fatalf("incomplete diagnostic info: %#v", info)
+		}
+		properties := diagnostic.Properties()
+		if len(properties) == 0 || properties[0].Kind() != diagnostics.Collection {
+			t.Fatalf("unexpected diagnostic properties: %#v", properties)
+		}
+		return
+	}
+	t.Fatal("expected a syntax diagnostic")
+}

--- a/parser/documentation_lexer.go
+++ b/parser/documentation_lexer.go
@@ -31,8 +31,8 @@ type documentationLexer struct {
 	previousBacktickMode parserMode
 }
 
-func newDocumentationLexer(ctx *compilercontext.CompilerContext, fileName string, charReader text.CharReader, leadingTriviaList []st.STNode, diagnostics []st.STNodeDiagnostic) *documentationLexer {
-	lexer := newLexer(ctx, fileName, charReader)
+func newDocumentationLexer(ctx *compilercontext.CompilerContext, fileName string, charReader text.CharReader, leadingTriviaList []st.STNode, diagnostics []st.STNodeDiagnostic, debug *debugOutput) *documentationLexer {
+	lexer := newLexer(ctx, fileName, charReader, debug)
 	lexer.context.leadingTriviaList = leadingTriviaList
 	lexer.context.diagnostics = diagnostics
 	lexer.StartMode(parserModeDocLineStartHash)

--- a/parser/error_handler.go
+++ b/parser/error_handler.go
@@ -18,7 +18,6 @@ package parser
 
 import (
 	"fmt"
-	debugcommon "github.com/ballerina-nutcracker/ballerina/common"
 	"github.com/ballerina-nutcracker/ballerina/parser/common"
 	"github.com/ballerina-nutcracker/ballerina/st"
 	"runtime/debug"
@@ -26,8 +25,8 @@ import (
 	"strings"
 )
 
-func logRecoveredPanic(location string, recovered any) {
-	traceRecovery(func() string {
+func logRecoveredPanic(debugOutput *debugOutput, location string, recovered any) {
+	debugOutput.write(debugOutput.options.TraceRecovery, func() string {
 		stackTrace := debug.Stack()
 		return fmt.Sprintf("[parser] recovered panic in %s: %v\n[parser] stack trace:\n%s", location, recovered, stackTrace)
 	})
@@ -129,10 +128,6 @@ func formatResult(result *recoveryResult) string {
 func formatResultValue(result recoveryResult) string {
 	solutionStr := formatSolution(result.solution)
 	return fmt.Sprintf("matches:%d removeFixes:%d fixes:%d solution:%s", result.matches, result.removeFixes, len(result.fixes), solutionStr)
-}
-
-func traceRecovery(messageFn func() string) {
-	debugcommon.DebugWriteLazy(debugcommon.DEBUG_ERROR_RECOVERY, messageFn)
 }
 
 // ============================================================================
@@ -342,18 +337,23 @@ type abstractParserErrorHandlerMethods struct {
 	Self abstractParserErrorHandler
 }
 
+func (m *abstractParserErrorHandlerMethods) traceRecovery(messageFn func() string) {
+	debugOutput := m.Self.GetTokenReader().debug
+	debugOutput.write(debugOutput.options.TraceRecovery, messageFn)
+}
+
 func (m *abstractParserErrorHandlerMethods) internalError(message string) {
 	m.Self.GetTokenReader().internalError(message)
 }
 
 func (m *abstractParserErrorHandlerMethods) Recover(currentCtx common.ParserRuleContext, nextToken st.STToken, isCompletion bool) (result *solution) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(Recover start %s %s %s)",
 			formatParserRuleContext(currentCtx),
 			formatSTToken(nextToken),
 			formatBool(isCompletion))
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(Recover end (%s %s %s) %s)", formatParserRuleContext(currentCtx), formatSTToken(nextToken), formatBool(isCompletion), formatSolution(result))
 	})
 
@@ -377,13 +377,13 @@ func (m *abstractParserErrorHandlerMethods) Recover(currentCtx common.ParserRule
 	// Fail safe. This means we can't find a path to recover.
 	if isCompletion {
 		if m.Self.GetItterCount() == completionItterLimit {
-			traceRecovery(func() string {
+			m.traceRecovery(func() string {
 				return "fail safe reached"
 			})
 		}
 	} else {
 		if m.Self.GetItterCount() == resolutionItterLimit {
-			traceRecovery(func() string {
+			m.traceRecovery(func() string {
 				return "fail safe reached"
 			})
 		}
@@ -392,7 +392,7 @@ func (m *abstractParserErrorHandlerMethods) Recover(currentCtx common.ParserRule
 }
 
 func (m *abstractParserErrorHandlerMethods) getResolution(currentCtx common.ParserRuleContext, nextToken st.STToken) *solution {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(getResolution start %s %s)",
 			formatParserRuleContext(currentCtx),
 			formatSTToken(nextToken))
@@ -439,7 +439,7 @@ func (m *abstractParserErrorHandlerMethods) getCompletion(context common.ParserR
 		// TODO: check if we panic inside this method
 		defer func() {
 			if r := recover(); r != nil {
-				logRecoveredPanic("getCompletion", r)
+				logRecoveredPanic(m.Self.GetTokenReader().debug, "getCompletion", r)
 				if false {
 					m.internalError("assertion failed")
 					return
@@ -455,10 +455,10 @@ func (m *abstractParserErrorHandlerMethods) getCompletion(context common.ParserR
 }
 
 func (m *abstractParserErrorHandlerMethods) ConsumeInvalidToken() (result st.STToken) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return "(ConsumeInvalidToken start)"
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(ConsumeInvalidToken end %s)", formatSTToken(result))
 	})
 	return m.Self.GetTokenReader().Read()
@@ -489,17 +489,17 @@ func (m *abstractParserErrorHandlerMethods) getCtxStackSnapshot() []common.Parse
 }
 
 func (m *abstractParserErrorHandlerMethods) seekMatchStart(currentCtx common.ParserRuleContext) (bestMatch *recoveryResult) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchStart start %s)", formatParserRuleContext(currentCtx))
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchStart end (%s) %s)", formatParserRuleContext(currentCtx), formatResult(bestMatch))
 	})
 	tempCtxStack := m.Self.GetCtxStack()
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				logRecoveredPanic("seekMatchStart", r)
+				logRecoveredPanic(m.Self.GetTokenReader().debug, "seekMatchStart", r)
 				if false {
 					m.internalError("assertion failed")
 					return
@@ -516,10 +516,10 @@ func (m *abstractParserErrorHandlerMethods) seekMatchStart(currentCtx common.Par
 }
 
 func (m *abstractParserErrorHandlerMethods) seekMatchInSubTree(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, isEntryPoint bool) (result *recoveryResult) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchInSubTree start %s %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, formatBool(isEntryPoint))
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchInSubTree end (%s %d %d %s) %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, formatBool(isEntryPoint), formatResult(result))
 	})
 	tempCtxStack := m.Self.GetCtxStack()
@@ -530,44 +530,44 @@ func (m *abstractParserErrorHandlerMethods) seekMatchInSubTree(currentCtx common
 }
 
 func (m *abstractParserErrorHandlerMethods) StartContext(context common.ParserRuleContext) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(StartContext start %s)", formatParserRuleContext(context))
 	})
 	ctxStack := m.Self.GetCtxStack()
 	m.Self.SetCtxStack(append(ctxStack, context))
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(StartContext end (%s))", formatParserRuleContext(context))
 	})
 }
 
 func (m *abstractParserErrorHandlerMethods) EndContext() {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return "(EndContext start)"
 	})
 	ctxStack := m.Self.GetCtxStack()
 	m.Self.SetCtxStack(ctxStack[:len(ctxStack)-1])
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return "(EndContext end)"
 	})
 }
 
 func (m *abstractParserErrorHandlerMethods) SwitchContext(context common.ParserRuleContext) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(SwitchContext start %s)", formatParserRuleContext(context))
 	})
 	ctxStack := m.Self.GetCtxStack()
 	ctxStack = ctxStack[:len(ctxStack)-1]
 	m.Self.SetCtxStack(append(ctxStack, context))
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return "(SwitchContext end)"
 	})
 }
 
 func (m *abstractParserErrorHandlerMethods) GetParentContext() (result common.ParserRuleContext) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return "(GetParentContext start)"
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(GetParentContext end %s)", formatParserRuleContext(result))
 	})
 	ctxStack := m.Self.GetCtxStack()
@@ -575,10 +575,10 @@ func (m *abstractParserErrorHandlerMethods) GetParentContext() (result common.Pa
 }
 
 func (m *abstractParserErrorHandlerMethods) GetGrandParentContext() (result common.ParserRuleContext) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return "(GetGrandParentContext start)"
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(GetGrandParentContext end %s)", formatParserRuleContext(result))
 	})
 	ctxStack := m.Self.GetCtxStack()
@@ -592,10 +592,10 @@ func (m *abstractParserErrorHandlerMethods) GetGrandParentContext() (result comm
 }
 
 func (m *abstractParserErrorHandlerMethods) HasAncestorContext(context common.ParserRuleContext) (result bool) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(HasAncestorContext start %s)", formatParserRuleContext(context))
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(HasAncestorContext end (%s) %s)", formatParserRuleContext(context), formatBool(result))
 	})
 	ctxStack := m.Self.GetCtxStack()
@@ -603,20 +603,20 @@ func (m *abstractParserErrorHandlerMethods) HasAncestorContext(context common.Pa
 }
 
 func (m *abstractParserErrorHandlerMethods) GetContextStack() (result []common.ParserRuleContext) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return "(GetContextStack start)"
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(GetContextStack end %s)", formatContextStack(result))
 	})
 	return m.Self.GetCtxStack()
 }
 
 func (m *abstractParserErrorHandlerMethods) seekInAlternativesPaths(lookahead int, currentDepth int, currentMatches int, alternativeRules []common.ParserRuleContext, isEntryPoint bool) (result *recoveryResult) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(seekInAlternativesPaths start %d %d %d %s %s)", lookahead, currentDepth, currentMatches, formatContextStack(alternativeRules), formatBool(isEntryPoint))
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(seekInAlternativesPaths end (%d %d %d %s %s) %s)", lookahead, currentDepth, currentMatches, formatContextStack(alternativeRules), formatBool(isEntryPoint), formatResult(result))
 	})
 	results := make([][]*recoveryResult, lookaheadLimit)
@@ -629,7 +629,7 @@ func (m *abstractParserErrorHandlerMethods) seekInAlternativesPaths(lookahead in
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					logRecoveredPanic("seekInAlternativesPaths", r)
+					logRecoveredPanic(m.Self.GetTokenReader().debug, "seekInAlternativesPaths", r)
 					if false {
 						m.internalError("assertion failed")
 						return
@@ -692,10 +692,10 @@ func (m *abstractParserErrorHandlerMethods) hasFoundBestAlternative(result *reco
 }
 
 func (m *abstractParserErrorHandlerMethods) getFinalResult(currentMatches int, bestMatch *recoveryResult) (result *recoveryResult) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(getFinalResult start %d %s)", currentMatches, formatResult(bestMatch))
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(getFinalResult end (%d %s) %s)", currentMatches, formatResult(bestMatch), formatResult(result))
 	})
 	bestMatch.matches += currentMatches
@@ -703,10 +703,10 @@ func (m *abstractParserErrorHandlerMethods) getFinalResult(currentMatches int, b
 }
 
 func (m *abstractParserErrorHandlerMethods) fixAndContinue(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result *recoveryResult) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(fixAndContinue start %s %d %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint))
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(fixAndContinue end (%s %d %d %d %s) %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint), formatResult(result))
 	})
 	fixedPathResult := m.fixAndContinueCore(currentCtx, lookahead, currentDepth)
@@ -719,10 +719,10 @@ func (m *abstractParserErrorHandlerMethods) fixAndContinue(currentCtx common.Par
 }
 
 func (m *abstractParserErrorHandlerMethods) fixAndContinueCore(currentCtx common.ParserRuleContext, lookahead int, currentDepth int) (fixedPathResult *recoveryResult) {
-	traceRecovery(func() string {
+	m.traceRecovery(func() string {
 		return fmt.Sprintf("(fixAndContinueCore start %s %d %d)", formatParserRuleContext(currentCtx), lookahead, currentDepth)
 	})
-	defer traceRecovery(func() string {
+	defer m.traceRecovery(func() string {
 		return fmt.Sprintf("(fixAndContinueCore end (%s %d %d) %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, formatResult(fixedPathResult))
 	})
 	deletionResult := m.seekMatchInSubTree(currentCtx, lookahead+1, currentDepth+1, false)
@@ -1043,10 +1043,10 @@ func (b *ballerinaParserErrorHandler) isEndOfObjectTypeNode(nextLookahead int) b
 }
 
 func (b *ballerinaParserErrorHandler) SeekMatch(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, isEntryPoint bool) (result *recoveryResult) {
-	traceRecovery(func() string {
+	b.traceRecovery(func() string {
 		return fmt.Sprintf("(SeekMatch start %s %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, formatBool(isEntryPoint))
 	})
-	defer traceRecovery(func() string {
+	defer b.traceRecovery(func() string {
 		return fmt.Sprintf("(SeekMatch end (%s %d %d %s) %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, formatBool(isEntryPoint), formatResult(result))
 	})
 	var hasMatch bool
@@ -2123,10 +2123,10 @@ func (b *ballerinaParserErrorHandler) getShortestAlternative(currentCtx common.P
 }
 
 func (b *ballerinaParserErrorHandler) seekMatchInAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result recoveryResult) {
-	traceRecovery(func() string {
+	b.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchInAlternativePaths start %s %d %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint))
 	})
-	defer traceRecovery(func() string {
+	defer b.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchInAlternativePaths end (%s %d %d %d %s) %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint), formatResultValue(result))
 	})
 	var alternativeRules []common.ParserRuleContext
@@ -2375,10 +2375,10 @@ func (b *ballerinaParserErrorHandler) seekMatchInAlternativePaths(currentCtx com
 }
 
 func (b *ballerinaParserErrorHandler) seekMatchInStmtRelatedAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result recoveryResult) {
-	traceRecovery(func() string {
+	b.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchInStmtRelatedAlternativePaths start %s %d %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint))
 	})
-	defer traceRecovery(func() string {
+	defer b.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchInStmtRelatedAlternativePaths end (%s %d %d %d %s) %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint), formatResultValue(result))
 	})
 	var alternativeRules []common.ParserRuleContext
@@ -2565,10 +2565,10 @@ func (b *ballerinaParserErrorHandler) seekMatchInStmtRelatedAlternativePaths(cur
 }
 
 func (b *ballerinaParserErrorHandler) seekMatchInExprRelatedAlternativePaths(currentCtx common.ParserRuleContext, lookahead int, currentDepth int, matchingRulesCount int, isEntryPoint bool) (result recoveryResult) {
-	traceRecovery(func() string {
+	b.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchInExprRelatedAlternativePaths start %s %d %d %d %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint))
 	})
-	defer traceRecovery(func() string {
+	defer b.traceRecovery(func() string {
 		return fmt.Sprintf("(seekMatchInExprRelatedAlternativePaths end (%s %d %d %d %s) %s)", formatParserRuleContext(currentCtx), lookahead, currentDepth, matchingRulesCount, formatBool(isEntryPoint), formatResultValue(result))
 	})
 	var alternativeRules []common.ParserRuleContext

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -19,7 +19,6 @@ package parser
 import (
 	"unicode"
 
-	debugcommon "github.com/ballerina-nutcracker/ballerina/common"
 	compilercontext "github.com/ballerina-nutcracker/ballerina/context"
 	"github.com/ballerina-nutcracker/ballerina/parser/common"
 	"github.com/ballerina-nutcracker/ballerina/st"
@@ -48,6 +47,7 @@ type lexer struct {
 	context  lexerContext
 	ctx      *compilercontext.CompilerContext
 	location diagnostics.Location
+	debug    *debugOutput
 }
 
 type lexerContext struct {
@@ -57,12 +57,13 @@ type lexerContext struct {
 	diagnostics       []st.STNodeDiagnostic
 }
 
-func newLexer(ctx *compilercontext.CompilerContext, fileName string, reader text.CharReader) *lexer {
+func newLexer(ctx *compilercontext.CompilerContext, diagnosticIdentity string, reader text.CharReader, debug *debugOutput) *lexer {
 	return &lexer{
 		reader:   reader,
 		context:  lexerContext{},
 		ctx:      ctx,
-		location: diagnostics.NewLocation(ctx.DiagnosticEnv(), fileName, 0, 0),
+		location: diagnostics.NewLocationForIdentity(ctx.DiagnosticEnv(), diagnosticIdentity, 0, 0),
+		debug:    debug,
 	}
 }
 
@@ -121,7 +122,7 @@ func (l *lexer) NextToken() st.STToken {
 		token = st.AddSyntaxDiagnostics(token, l.context.diagnostics)
 		l.context.diagnostics = nil
 	}
-	debugcommon.DebugWriteLazy(debugcommon.DUMP_TOKENS, func() string { return st.ToSexpr(token) })
+	l.debug.write(l.debug.options.DumpTokens, func() string { return st.ToSexpr(token) })
 	return token
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -19,6 +19,7 @@ package parser
 
 import (
 	"errors"
+	"io"
 	"slices"
 	"strings"
 
@@ -604,13 +605,13 @@ func isDigit(c byte) bool {
 
 func (b *ballerinaParser) Parse() st.STNode {
 	ast := b.parseCompUnit()
-	debugcommon.DebugWriteLazy(debugcommon.DUMP_ST, func() string { return generateJSON(ast) })
+	b.tokenReader.debug.write(b.tokenReader.debug.options.DumpSyntaxTree, func() string { return generateJSON(ast) })
 	return ast
 }
 
 func (b *ballerinaParser) ParseImports() st.STNode {
 	ast := b.parseCompUnitImports()
-	debugcommon.DebugWriteLazy(debugcommon.DUMP_ST, func() string { return generateJSON(ast) })
+	b.tokenReader.debug.write(b.tokenReader.debug.options.DumpSyntaxTree, func() string { return generateJSON(ast) })
 	return ast
 }
 
@@ -8446,8 +8447,8 @@ func (b *ballerinaParser) parseTemplateContentAsXML() st.STNode {
 		nextToken = b.peek()
 	}
 	charReader := text.CharReaderFromText(xmlStringBuilder.String())
-	xl := newXMLLexer(b.tokenReader.ctx, b.tokenReader.fileName, charReader)
-	tr := createTokenReader(b.tokenReader.ctx, b.tokenReader.fileName, xl)
+	xl := newXMLLexer(b.tokenReader.ctx, b.tokenReader.fileName, charReader, b.tokenReader.debug)
+	tr := createTokenReader(b.tokenReader.ctx, b.tokenReader.fileName, xl, b.tokenReader.debug)
 	xp := newXMLParser(tr, expressions)
 	return xp.Parse()
 }
@@ -11450,8 +11451,8 @@ func (b *ballerinaParser) parseDocumentationString(documentationStringToken st.S
 	diagnostics := documentationStringToken.Diagnostics()
 
 	charReader := text.CharReaderFromText(documentationStringToken.Text())
-	documentationLexer := newDocumentationLexer(b.tokenReader.ctx, b.tokenReader.fileName, charReader, leadingTriviaList, diagnostics)
-	tokenReader := createTokenReader(b.tokenReader.ctx, b.tokenReader.fileName, documentationLexer)
+	documentationLexer := newDocumentationLexer(b.tokenReader.ctx, b.tokenReader.fileName, charReader, leadingTriviaList, diagnostics, b.tokenReader.debug)
+	tokenReader := createTokenReader(b.tokenReader.ctx, b.tokenReader.fileName, documentationLexer, b.tokenReader.debug)
 	documentationParser := newDocumentationParser(tokenReader)
 
 	return documentationParser.Parse()
@@ -14771,20 +14772,57 @@ func (b *ballerinaParser) isSpecialMethodName(token st.STToken) bool {
 // GetSyntaxTree parses content into a syntax tree, attributing it to fileName
 // (used for diagnostics and the syntax tree's text document).
 func GetSyntaxTree(ctx *context.CompilerContext, fileName string, content string) (*st.SyntaxTree, error) {
+	options := DebugOptions{
+		DumpTokens:     debugcommon.DebugEnabled(debugcommon.DUMP_TOKENS),
+		DumpSyntaxTree: debugcommon.DebugEnabled(debugcommon.DUMP_ST),
+		TraceRecovery:  debugcommon.DebugEnabled(debugcommon.DEBUG_ERROR_RECOVERY),
+	}
+	return getSyntaxTree(ctx, fileName, fileName, content, options, debugcommon.DebugWriter(), false)
+}
+
+func GetSyntaxTreeWithIdentity(
+	ctx *context.CompilerContext,
+	sourcePath string,
+	diagnosticIdentity string,
+	content string,
+	debug DebugOptions,
+	debugWriter io.Writer,
+) (*st.SyntaxTree, error) {
+	return getSyntaxTree(ctx, sourcePath, diagnosticIdentity, content, debug, debugWriter, true)
+}
+
+func getSyntaxTree(
+	ctx *context.CompilerContext,
+	sourcePath string,
+	diagnosticIdentity string,
+	content string,
+	options DebugOptions,
+	debugWriter io.Writer,
+	reportDiagnostics bool,
+) (*st.SyntaxTree, error) {
 	textDocument := text.TextDocumentFromText(content)
-	ctx.DiagnosticEnv().RegisterFile(fileName, textDocument)
+	ctx.DiagnosticEnv().RegisterFileIdentity(diagnosticIdentity, sourcePath, textDocument)
+	debug := newDebugOutput(options, debugWriter)
 	reader := text.CharReaderFromText(content)
-	lexer := newLexer(ctx, fileName, reader)
-	tokenReader := createTokenReader(ctx, fileName, lexer)
+	lexer := newLexer(ctx, diagnosticIdentity, reader, debug)
+	tokenReader := createTokenReader(ctx, diagnosticIdentity, lexer, debug)
 	ballerinaParser := newBallerinaParserFromTokenReader(tokenReader)
 	root := ballerinaParser.Parse()
 	rootNode, ok := root.(*st.STModulePart)
 	if !ok {
 		const message = "parser root is not an STModulePart"
-		ctx.InternalError(message, diagnostics.NewLocation(ctx.DiagnosticEnv(), fileName, 0, 0))
+		ctx.InternalError(message, diagnostics.NewLocationForIdentity(ctx.DiagnosticEnv(), diagnosticIdentity, 0, 0))
 		return nil, errors.New(message)
 	}
 	moduleNode := st.CreateUnlinkedFacade[*st.STModulePart, *st.ModulePart](rootNode)
-	syntaxTree := st.NewSyntaxTreeFromNodeTextDocument(moduleNode, textDocument, fileName, false)
+	syntaxTree := st.NewSyntaxTreeFromNodeTextDocument(moduleNode, textDocument, diagnosticIdentity, false)
+	if reportDiagnostics {
+		for diagnostic := range syntaxTree.Diagnostics() {
+			textRange := diagnostic.Location().TextRange()
+			location := diagnostics.NewLocationForIdentity(ctx.DiagnosticEnv(), diagnosticIdentity,
+				textRange.StartOffset, textRange.EndOffset)
+			ctx.SyntaxError(diagnostic.Message(), location)
+		}
+	}
 	return &syntaxTree, nil
 }

--- a/parser/tokenizer.go
+++ b/parser/tokenizer.go
@@ -34,17 +34,19 @@ type tokenReader struct {
 	ctx               *compilercontext.CompilerContext
 	fileName          string
 	location          diagnostics.Location
+	debug             *debugOutput
 }
 
-func createTokenReader(ctx *compilercontext.CompilerContext, fileName string, lexer tokenLexer) *tokenReader {
-	location := diagnostics.NewLocation(ctx.DiagnosticEnv(), fileName, 0, 0)
+func createTokenReader(ctx *compilercontext.CompilerContext, diagnosticIdentity string, lexer tokenLexer, debug *debugOutput) *tokenReader {
+	location := diagnostics.NewLocationForIdentity(ctx.DiagnosticEnv(), diagnosticIdentity, 0, 0)
 	return &tokenReader{
 		lexer:             lexer,
 		currentToken:      nil,
 		currentTokenIndex: 0,
 		ctx:               ctx,
-		fileName:          fileName,
+		fileName:          diagnosticIdentity,
 		location:          location,
+		debug:             debug,
 		tokenBuffer: tokenBuffer{
 			capacity:   20,
 			tokens:     make([]st.STToken, bufferSize),

--- a/parser/xml_lexer.go
+++ b/parser/xml_lexer.go
@@ -30,8 +30,8 @@ type xmlLexer struct {
 	*lexer
 }
 
-func newXMLLexer(ctx *compilercontext.CompilerContext, fileName string, reader text.CharReader) *xmlLexer {
-	inner := newLexer(ctx, fileName, reader)
+func newXMLLexer(ctx *compilercontext.CompilerContext, fileName string, reader text.CharReader, debug *debugOutput) *xmlLexer {
+	inner := newLexer(ctx, fileName, reader, debug)
 	inner.StartMode(parserModeXmlContent)
 	return &xmlLexer{lexer: inner}
 }

--- a/projects/module_context.go
+++ b/projects/module_context.go
@@ -59,7 +59,7 @@ type moduleContext struct {
 	bLangPkg        *ast.BLangPackage
 	bPackageSymbol  any // TODO(S3): BPackageSymbol once compiler symbol types are migrated
 	compilerCtx     *context.CompilerContext
-	importedSymbols map[string]model.ExportedSymbolSpace
+	importedSymbols model.ImportedSymbolSpaces
 	birPkg          *bir.BIRPackage
 }
 

--- a/semantics/internal/analysis/enclosing_class.go
+++ b/semantics/internal/analysis/enclosing_class.go
@@ -16,20 +16,23 @@
 
 package analysis
 
-import "github.com/ballerina-nutcracker/ballerina/ast"
+import (
+	"github.com/ballerina-nutcracker/ballerina/ast"
+	"github.com/ballerina-nutcracker/ballerina/context"
+	"github.com/ballerina-nutcracker/ballerina/tools/diagnostics"
+)
 
 // enclosingClassBody captures the subset of a class or service body that
 // semantic analysis (in particular lock validation and isolated-field
-// checks) needs when walking method bodies. Classes carry a className
-// derived from the user-supplied name; services have no name and instead
-// carry a per-service tag used to disambiguate field lock keys.
+// checks) needs when walking method bodies. Classes carry the user-supplied
+// name; services carry their deterministic compiler-generated symbol name.
 type enclosingClassBody struct {
-	// name is the user-supplied class name for class bodies, empty for
-	// service bodies (services have no name).
+	// name is the user-supplied class name or compiler-generated service name.
 	name     string
 	isolated bool
 	fields   []*ast.BLangVariable
 	initFn   *ast.BLangFunction
+	position diagnostics.Location
 }
 
 func enclosingFromClass(c *ast.BLangClassDefinition) *enclosingClassBody {
@@ -38,13 +41,16 @@ func enclosingFromClass(c *ast.BLangClassDefinition) *enclosingClassBody {
 		isolated: c.IsIsolated(),
 		fields:   c.Fields,
 		initFn:   c.InitFunction,
+		position: c.GetPosition(),
 	}
 }
 
-func enclosingFromService(s *ast.BLangService) *enclosingClassBody {
+func enclosingFromService(ctx *context.CompilerContext, s *ast.BLangService) *enclosingClassBody {
 	return &enclosingClassBody{
+		name:     ctx.SymbolName(s.Symbol()),
 		isolated: s.IsIsolated(),
 		fields:   s.Fields,
 		initFn:   s.InitFunction,
+		position: s.GetPosition(),
 	}
 }

--- a/semantics/internal/analysis/lock_analyzer.go
+++ b/semantics/internal/analysis/lock_analyzer.go
@@ -119,7 +119,7 @@ func selfFieldLockEntry(a analyzer, access *ast.BLangFieldBaseAccess) (string, m
 			return "", model.SymbolRef{}, false
 		}
 		pkg := a.ctx().SymbolPackage(field.Symbol())
-		return classBodyFieldLockKey(pkg, cls, field.Symbol(), fieldName), field.Symbol(), true
+		return classFieldLockKey(pkg, cls.name, fieldName), field.Symbol(), true
 	}
 	return "", model.SymbolRef{}, false
 }
@@ -130,17 +130,6 @@ func moduleVarLockKey(pkg model.PackageIdentifier, name string) string {
 
 func classFieldLockKey(pkg model.PackageIdentifier, className, fieldName string) string {
 	return pkg.Organization + "/" + pkg.Package + ":" + className + "." + fieldName
-}
-
-// classBodyFieldLockKey returns a per-field lock key for either a class or a
-// service. For classes it uses the class's module-level name; for services
-// (which have no name) it derives a unique key from the field's SymbolRef,
-// which is already unique within the package.
-func classBodyFieldLockKey(pkg model.PackageIdentifier, cls *enclosingClassBody, fieldRef model.SymbolRef, fieldName string) string {
-	if cls.name != "" {
-		return classFieldLockKey(pkg, cls.name, fieldName)
-	}
-	return fmt.Sprintf("%s/%s:$service.%d.%d.%s", pkg.Organization, pkg.Package, fieldRef.SpaceIndex, fieldRef.Index, fieldName)
 }
 
 // validateLockStmt determines the restricted variable and validate semantics of a lock statment.

--- a/semantics/internal/analysis/semantic_analyzer.go
+++ b/semantics/internal/analysis/semantic_analyzer.go
@@ -55,7 +55,7 @@ type (
 		// TODO: move the constant resolution to type resolver as well so that we can run semantic analyzer in parallel as well
 		pkg              *ast.BLangPackage
 		importedPkgs     map[string]*ast.BLangImportPackage
-		importedSymbols  map[string]model.ExportedSymbolSpace
+		importedSymbols  model.ImportedSymbolSpaces
 		moduleVarMetaMap map[model.SymbolRef]varDeclMetadata
 	}
 	constantAnalyzer struct {
@@ -338,21 +338,18 @@ func newSemanticAnalyzer(ctx *context.CompilerContext) *semanticAnalyzer {
 		compilerCtx:      ctx,
 		typeCtx:          semtypes.ContextFrom(ctx.GetTypeEnv()),
 		importedPkgs:     make(map[string]*ast.BLangImportPackage),
-		importedSymbols:  make(map[string]model.ExportedSymbolSpace),
+		importedSymbols:  model.NewImportedSymbolSpaces(),
 		moduleVarMetaMap: make(map[model.SymbolRef]varDeclMetadata),
 	}
 }
 
-func Analyze(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
+func Analyze(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols model.ImportedSymbolSpaces) {
 	analyzer := newSemanticAnalyzer(ctx)
 	analyzer.analyze(pkg, importedSymbols)
 }
 
-func (sa *semanticAnalyzer) analyze(pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
+func (sa *semanticAnalyzer) analyze(pkg *ast.BLangPackage, importedSymbols model.ImportedSymbolSpaces) {
 	sa.pkg = pkg
-	if importedSymbols == nil {
-		importedSymbols = make(map[string]model.ExportedSymbolSpace)
-	}
 	sa.importedSymbols = importedSymbols
 	sa.moduleVarMetaMap = sa.buildModuleVarMetadata()
 	sa.validateModuleLevelIsolatedDecls(pkg)
@@ -1915,7 +1912,7 @@ func visitInner[A analyzer](a A, node ast.BLangNode) ast.Visitor {
 		}
 		validateServiceListenerTypes(a, n)
 		analyzeClassLikeDefn(a, n.Fields, n.InitFunction, n.Methods, n.ResourceMethods, n.Inclusions,
-			n.InclusionPositions, n.IsIsolated(), enclosingFromService(n))
+			n.InclusionPositions, n.IsIsolated(), enclosingFromService(a.ctx(), n))
 		return nil
 	default:
 		return a

--- a/semantics/internal/symbols/symbol_resolver.go
+++ b/semantics/internal/symbols/symbol_resolver.go
@@ -588,7 +588,7 @@ func Resolve(
 	implicitImports map[string]model.ExportedSymbolSpace,
 	publicSymbols map[PackageIdentifier]model.ExportedSymbolSpace,
 	defaultOrg string,
-) (model.Scope, model.ExportedSymbolSpace, map[string]model.ExportedSymbolSpace) {
+) (model.Scope, model.ExportedSymbolSpace, model.ImportedSymbolSpaces) {
 	cuImportsList := bindImports(cx, compilationUnits, implicitImports, publicSymbols, defaultOrg)
 	moduleResolver := newModuleSymbolResolver(cx, pkgID)
 	injectOpaqueSymbols(pkgID, moduleResolver)
@@ -603,7 +603,12 @@ func Resolve(
 		resolver.allocateTopLevelSymbols(cuImportsList[i].compilationUnit)
 	}
 
-	importedSymbols := make(map[string]model.ExportedSymbolSpace)
+	importedSymbols := model.NewImportedSymbolSpaces()
+	for _, imported := range implicitImports {
+		if len(imported.MainSpaces) > 0 {
+			importedSymbols[imported.MainSpaces[0].Pkg] = imported
+		}
+	}
 	for i, cuImports := range cuImportsList {
 		cu := cuImports.compilationUnit
 		resolver := cuResolvers[i]
@@ -611,7 +616,11 @@ func Resolve(
 		ast.Walk(resolver, cu)
 		reportUnusedImports(resolver, compilationUnitImports(cu))
 		reportUnusedVariables(cx, resolver.getUnused())
-		maps.Copy(importedSymbols, cuImports.imports)
+		for _, imported := range cuImports.imports {
+			if len(imported.MainSpaces) > 0 {
+				importedSymbols[imported.MainSpaces[0].Pkg] = imported
+			}
+		}
 	}
 
 	mainSpaces := make([]*model.SymbolSpace, 0, len(cuResolvers)+1)
@@ -1137,7 +1146,14 @@ func bindImports(
 	result := make([]compilationUnitImportsWithSymbols, len(compilationUnits))
 	for i, cu := range compilationUnits {
 		imports := make(map[string]model.ExportedSymbolSpace)
+		aliases := make(map[string]bool)
 		for _, imp := range compilationUnitImports(cu) {
+			alias := imp.Alias.GetValue()
+			if aliases[alias] {
+				ctx.SemanticError(fmt.Sprintf("import alias '%s' already defined", alias), imp.GetPosition())
+				continue
+			}
+			aliases[alias] = true
 			resolveExternalImport(ctx, &imp, defaultOrg, publicSymbols, imports)
 		}
 		maps.Copy(imports, implicitImports)

--- a/semantics/internal/types/type_resolver.go
+++ b/semantics/internal/types/type_resolver.go
@@ -139,7 +139,7 @@ const (
 type packageTypeResolver struct {
 	ctx             *context.CompilerContext
 	tyCtx           semtypes.Context
-	importedSymbols map[string]model.ExportedSymbolSpace
+	importedSymbols model.ImportedSymbolSpaces
 	pkg             *ast.BLangPackage
 	implicitImports map[string]ast.BLangImportPackage
 	// capturedNarrowedVars tracks base symbols of narrowed variables captured across
@@ -347,8 +347,7 @@ func (t *packageTypeResolver) lookupClassMethodSymbol(receiverTy semtypes.SemTyp
 }
 
 func (t *packageTypeResolver) lookupImportedSymbols(name string) (model.ExportedSymbolSpace, bool) {
-	s, ok := t.importedSymbols[name]
-	return s, ok
+	return t.importedSymbols.ByModule("ballerina", name)
 }
 
 func (t *packageTypeResolver) addImplicitImport(name string, imp ast.BLangImportPackage) {
@@ -584,7 +583,7 @@ func (f *functionTypeResolver) nextMonoFnName(origName string) string {
 	return fmt.Sprintf("$mono$%s$%d", origName, idx)
 }
 
-func newPackageTypeResolver(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace, moduleScope model.Scope) *packageTypeResolver {
+func newPackageTypeResolver(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols model.ImportedSymbolSpaces, moduleScope model.Scope) *packageTypeResolver {
 	return &packageTypeResolver{
 		ctx:                    ctx,
 		tyCtx:                  semtypes.ContextFrom(ctx.GetTypeEnv()),
@@ -693,12 +692,12 @@ func (t *packageTypeResolver) ensureResolved(ref model.SymbolRef, depth int) boo
 }
 
 // ResolvePublicNodeTypes resolves types of public symbols. After this dependencies can use the ExportedSymbolSpace for this package.
-func ResolvePublicNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
+func ResolvePublicNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols model.ImportedSymbolSpaces) {
 	t := newPackageTypeResolver(ctx, pkg, importedSymbols, pkg.Scope)
 	t.resolveTopLevelTypes(pkg)
 }
 
-func populateMappingAtomMaps(t typeResolver, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
+func populateMappingAtomMaps(t typeResolver, pkg *ast.BLangPackage, importedSymbols model.ImportedSymbolSpaces) {
 	for i := range pkg.TypeDefinitions {
 		defn := pkg.TypeDefinitions[i]
 		semType := t.symbolType(defn.Symbol())
@@ -750,7 +749,7 @@ func populateMappingAtomMaps(t typeResolver, pkg *ast.BLangPackage, importedSymb
 }
 
 // ResolvePrivateNodesTypes resolves the types private nodes within the package. Then can be executed concurrently
-func ResolvePrivateNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols map[string]model.ExportedSymbolSpace) {
+func ResolvePrivateNodes(ctx *context.CompilerContext, pkg *ast.BLangPackage, importedSymbols model.ImportedSymbolSpaces) {
 	p := newPackageTypeResolver(ctx, pkg, importedSymbols, pkg.Scope)
 	populateClassSymbolByType(p, pkg)
 	populateMappingAtomMaps(p, pkg, importedSymbols)

--- a/semantics/internal/types/type_resolver_query_test.go
+++ b/semantics/internal/types/type_resolver_query_test.go
@@ -759,7 +759,7 @@ func TestResolveQueryExprMapConstructTypeOnConflictError(t *testing.T) {
 func newTestQueryResolver() (*packageTypeResolver, *context.CompilerContext) {
 	env := context.NewCompilerEnvironment(semtypes.CreateTypeEnv(), false)
 	cx := context.NewCompilerContext(env)
-	return newPackageTypeResolver(cx, &ast.BLangPackage{}, nil, nil), cx
+	return newPackageTypeResolver(cx, &ast.BLangPackage{}, model.NewImportedSymbolSpaces(), nil), cx
 }
 
 func assertDiagnosticContains(t *testing.T, cx *context.CompilerContext, substr string) {

--- a/semantics/semantics.go
+++ b/semantics/semantics.go
@@ -48,7 +48,7 @@ func ResolveSymbols(
 	implicitImports map[string]model.ExportedSymbolSpace,
 	publicSymbols map[PackageIdentifier]model.ExportedSymbolSpace,
 	defaultOrg string,
-) (model.Scope, model.ExportedSymbolSpace, map[string]model.ExportedSymbolSpace) {
+) (model.Scope, model.ExportedSymbolSpace, model.ImportedSymbolSpaces) {
 	internalPublicSymbols := make(map[symbols.PackageIdentifier]model.ExportedSymbolSpace, len(publicSymbols))
 	for id, symbolSpace := range publicSymbols {
 		internalPublicSymbols[symbols.PackageIdentifier{OrgName: id.OrgName, ModuleName: id.ModuleName}] = symbolSpace
@@ -60,7 +60,7 @@ func ResolveSymbols(
 func ResolvePublicNodeTypes(
 	ctx *context.CompilerContext,
 	pkg *ast.BLangPackage,
-	importedSymbols map[string]model.ExportedSymbolSpace,
+	importedSymbols model.ImportedSymbolSpaces,
 ) {
 	semantictypes.ResolvePublicNodes(ctx, pkg, importedSymbols)
 }
@@ -69,7 +69,7 @@ func ResolvePublicNodeTypes(
 func ResolvePrivateNodesTypes(
 	ctx *context.CompilerContext,
 	pkg *ast.BLangPackage,
-	importedSymbols map[string]model.ExportedSymbolSpace,
+	importedSymbols model.ImportedSymbolSpaces,
 ) {
 	semantictypes.ResolvePrivateNodes(ctx, pkg, importedSymbols)
 }
@@ -78,7 +78,7 @@ func ResolvePrivateNodesTypes(
 func AnalyzeSemantics(
 	ctx *context.CompilerContext,
 	pkg *ast.BLangPackage,
-	importedSymbols map[string]model.ExportedSymbolSpace,
+	importedSymbols model.ImportedSymbolSpaces,
 ) {
 	analysis.Analyze(ctx, pkg, importedSymbols)
 }

--- a/st/node.go
+++ b/st/node.go
@@ -20,6 +20,8 @@ package st
 
 import (
 	"iter"
+	"reflect"
+	"strings"
 
 	"github.com/ballerina-nutcracker/ballerina/tools/diagnostics"
 )
@@ -128,11 +130,54 @@ func (sd *SyntaxDiagnostic) DiagnosticInfo() DiagnosticInfo {
 	return *sd.diagnosticInfo
 }
 
+func (sd *SyntaxDiagnostic) Message() string {
+	return strings.ReplaceAll(strings.TrimPrefix(sd.nodeDiagnostic.DiagnosticCode().MessageKey(), "error."), ".", " ")
+}
+
+func (sd *SyntaxDiagnostic) Properties() []DiagnosticProperty[any] {
+	args := sd.nodeDiagnostic.Args()
+	properties := make([]DiagnosticProperty[any], len(args))
+	for index, value := range args {
+		properties[index] = syntaxDiagnosticProperty{kind: diagnosticPropertyKind(value), value: value}
+	}
+	return properties
+}
+
+type syntaxDiagnosticProperty struct {
+	kind  diagnostics.DiagnosticPropertyKind
+	value any
+}
+
+func (p syntaxDiagnosticProperty) Kind() diagnostics.DiagnosticPropertyKind { return p.kind }
+func (p syntaxDiagnosticProperty) Value() any                               { return p.value }
+
+func diagnosticPropertyKind(value any) diagnostics.DiagnosticPropertyKind {
+	switch value.(type) {
+	case string:
+		return diagnostics.String
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return diagnostics.Numeric
+	}
+	if value != nil {
+		switch reflect.TypeOf(value).Kind() {
+		case reflect.Array, reflect.Slice, reflect.Map:
+			return diagnostics.Collection
+		default:
+			return diagnostics.Other
+		}
+	}
+	return diagnostics.Other
+}
+
 type DiagnosticInfo struct {
 	code          string
 	messageFormat string
 	severity      DiagnosticSeverity
 }
+
+func (di DiagnosticInfo) Code() string                 { return di.code }
+func (di DiagnosticInfo) MessageFormat() string        { return di.messageFormat }
+func (di DiagnosticInfo) Severity() DiagnosticSeverity { return di.severity }
 
 type DiagnosticSeverity uint8
 
@@ -242,7 +287,13 @@ func (n *NodeBase) Location() NodeLocation {
 }
 
 func (n *NodeBase) Diagnostics() iter.Seq[Diagnostic] {
-	panic("Diagnostics() should be implemented by child types")
+	return func(yield func(Diagnostic) bool) {
+		for _, diagnostic := range n.internalNode.Diagnostics() {
+			if !yield(createSyntaxDiagnostic(diagnostic, n)) {
+				return
+			}
+		}
+	}
 }
 
 func (n *NonTerminalNodeBase) Diagnostics() iter.Seq[Diagnostic] {
@@ -250,7 +301,10 @@ func (n *NonTerminalNodeBase) Diagnostics() iter.Seq[Diagnostic] {
 		if !n.internalNode.HasDiagnostics() {
 			return
 		}
-		for _, ch := range n.Children() {
+		for ch := range n.ChildNodes() {
+			if ch == nil {
+				continue
+			}
 			for diagnostic := range ch.Diagnostics() {
 				if !yield(diagnostic) {
 					return
@@ -258,19 +312,18 @@ func (n *NonTerminalNodeBase) Diagnostics() iter.Seq[Diagnostic] {
 			}
 		}
 		for _, diagnostic := range n.internalNode.Diagnostics() {
-			if !yield(createSyntaxDiagnostic(diagnostic)) {
+			if !yield(createSyntaxDiagnostic(diagnostic, n)) {
 				return
 			}
 		}
 	}
 }
 
-func createSyntaxDiagnostic(diagnostic STNodeDiagnostic) Diagnostic {
-	panic("not implemented")
-}
-
-func (n *NonTerminalNodeBase) Children() []Node {
-	panic("Children() should be implemented by child types")
+func createSyntaxDiagnostic(diagnostic STNodeDiagnostic, node Node) Diagnostic {
+	return &SyntaxDiagnostic{
+		nodeDiagnostic: diagnostic,
+		location:       NodeLocation{node: node},
+	}
 }
 
 func (n *NodeBase) HasDiagnostics() bool {

--- a/st/st_node.go
+++ b/st/st_node.go
@@ -966,6 +966,10 @@ func (s STNodeDiagnostic) DiagnosticCode() diagnostics.DiagnosticCode {
 	return s.code
 }
 
+func (s STNodeDiagnostic) Args() []any {
+	return append([]any(nil), s.args...)
+}
+
 // Modification methods
 func Replace(current STNode, target STNode, replacement STNode) STNode {
 	// TODO: this is doing value comparison which is super expensive, need to think of a better way to do this

--- a/st/syntax_tree.go
+++ b/st/syntax_tree.go
@@ -62,8 +62,37 @@ func (s *SyntaxTree) ReplaceNode(target Node, replacement Node) SyntaxTree {
 }
 
 func (s *SyntaxTree) Diagnostics() iter.Seq[Diagnostic] {
-	// migrated from SyntaxTree.java:105:5
-	return s.RootNode.Diagnostics()
+	return func(yield func(Diagnostic) bool) {
+		for _, node := range innermostDiagnosticNodes(s.RootNode) {
+			deepest := FindDeepestDiagnosticSTNode(node.InternalNode())
+			if deepest == nil {
+				continue
+			}
+			for _, diagnostic := range deepest.Diagnostics() {
+				if !yield(createSyntaxDiagnostic(diagnostic, node)) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func innermostDiagnosticNodes(node Node) []Node {
+	if node == nil || !node.HasDiagnostics() {
+		return nil
+	}
+	var result []Node
+	if nonTerminal, ok := node.(NonTerminalNode); ok {
+		for child := range nonTerminal.ChildNodes() {
+			if child != nil && child.HasDiagnostics() {
+				result = append(result, innermostDiagnosticNodes(child)...)
+			}
+		}
+	}
+	if len(result) > 0 {
+		return result
+	}
+	return []Node{node}
 }
 
 func (s *SyntaxTree) HasDiagnostics() bool {

--- a/tools/diagnostics/diagnostic_env.go
+++ b/tools/diagnostics/diagnostic_env.go
@@ -48,34 +48,41 @@ const (
 // It maps file names to integer indices for compact storage in Location.
 // Thread-safe via RWMutex since it is shared across compilation phases.
 type DiagnosticEnv struct {
-	mu          sync.RWMutex
-	fileNames   []string
-	nameToIndex map[string]int
-	docs        []text.TextDocument
+	mu              sync.RWMutex
+	fileNames       []string
+	identityToIndex map[string]int
+	docs            []text.TextDocument
 }
 
 // NewDiagnosticEnv creates an empty DiagnosticEnv.
 func NewDiagnosticEnv() *DiagnosticEnv {
 	return &DiagnosticEnv{
-		nameToIndex: make(map[string]int),
+		identityToIndex: make(map[string]int),
 	}
 }
 
 // RegisterFile adds or updates a file in the environment.
 // Assigns 1-based indices so zero-value Location (fileIndex=0) is unknown.
 func (de *DiagnosticEnv) RegisterFile(fileName string, doc text.TextDocument) {
+	de.RegisterFileIdentity(fileName, fileName, doc)
+}
+
+// RegisterFileIdentity adds or updates a file using an internal lookup identity
+// that may differ from the file name shown to users.
+func (de *DiagnosticEnv) RegisterFileIdentity(identity string, displayName string, doc text.TextDocument) {
 	de.mu.Lock()
 	defer de.mu.Unlock()
-	if idx, ok := de.nameToIndex[fileName]; ok {
+	if idx, ok := de.identityToIndex[identity]; ok {
 		// Keep the stable index used by existing locations while replacing the
 		// document after an incremental source update.
+		de.fileNames[idx-1] = displayName
 		de.docs[idx-1] = doc
 		return
 	}
-	de.fileNames = append(de.fileNames, fileName)
+	de.fileNames = append(de.fileNames, displayName)
 	de.docs = append(de.docs, doc)
 	idx := len(de.fileNames)
-	de.nameToIndex[fileName] = idx
+	de.identityToIndex[identity] = idx
 }
 
 // FileIndex returns the index for a previously registered file name.
@@ -84,11 +91,16 @@ func (de *DiagnosticEnv) RegisterFile(fileName string, doc text.TextDocument) {
 func (de *DiagnosticEnv) FileIndex(fileName string) int {
 	de.mu.RLock()
 	defer de.mu.RUnlock()
-	idx, ok := de.nameToIndex[fileName]
+	idx, ok := de.identityToIndex[fileName]
 	if !ok {
 		panic(fmt.Sprintf("diagnostics: file not registered: %q", fileName))
 	}
 	return idx
+}
+
+// TextDocument returns the registered source document for loc.
+func (de *DiagnosticEnv) TextDocument(loc Location) text.TextDocument {
+	return de.requireDoc(loc, "TextDocument")
 }
 
 // FileName returns the file name for a Location.

--- a/tools/diagnostics/diagnostic_env_test.go
+++ b/tools/diagnostics/diagnostic_env_test.go
@@ -75,3 +75,21 @@ func TestRegisterFile_DifferentContentUpdatesDocument(t *testing.T) {
 		t.Errorf("StartLine after update = %d, want 1", got)
 	}
 }
+
+func TestRegisterFileIdentitySeparatesLookupAndDisplayName(t *testing.T) {
+	de := NewDiagnosticEnv()
+	de.RegisterFileIdentity("opaque", "first.bal", text.TextDocumentFromText("first"))
+	index := de.FileIndex("opaque")
+	location := NewLocationForIdentity(de, "opaque", 0, 6)
+	de.RegisterFileIdentity("opaque", "second.bal", text.TextDocumentFromText("second"))
+
+	if got := de.FileIndex("opaque"); got != index {
+		t.Fatalf("FileIndex after replacement = %d, want %d", got, index)
+	}
+	if got := de.FileName(location); got != "second.bal" {
+		t.Errorf("FileName after replacement = %q, want second.bal", got)
+	}
+	if got := de.TextDocument(location).String(); got != "second" {
+		t.Errorf("TextDocument after replacement = %q, want second", got)
+	}
+}

--- a/tools/diagnostics/location.go
+++ b/tools/diagnostics/location.go
@@ -31,8 +31,13 @@ type Location struct {
 // to an integer index for compact storage. The file must already be
 // registered via DiagnosticEnv.RegisterFile.
 func NewLocation(de *DiagnosticEnv, fileName string, startOffset, endOffset int) Location {
+	return NewLocationForIdentity(de, fileName, startOffset, endOffset)
+}
+
+// NewLocationForIdentity creates a location using a registered internal file identity.
+func NewLocationForIdentity(de *DiagnosticEnv, identity string, startOffset, endOffset int) Location {
 	return Location{
-		fileIndex:   de.FileIndex(fileName),
+		fileIndex:   de.FileIndex(identity),
 		startOffset: startOffset,
 		endOffset:   endOffset,
 	}


### PR DESCRIPTION
## Not for merge

Bisect step for the execution-benchmark regression on #875. **Please don't merge** — it exists only to produce one benchmark comment.

This branch is `main` plus **exactly one commit**, `refactor(frontend): expose explicit compilation APIs` (`e38cfb080`), whose parent is current `main` (`bb5298bba`). Single variable, no cherry-pick.

### Why

After the rebase, #875 is just two commits. The regression is reproducible across four independent CI runs (two before the rebase, two after):

| Case | pre r1 | pre r2 | rebase1 | rebase2 | mean | noise range |
|---|---|---|---|---|---|---|
| 08-bench/sieve | 1.529 | 1.606 | 1.493 | 1.496 | 1.531 | 0.961–1.177 |
| 08-bench/closure2 | 1.497 | 1.511 | 1.443 | 1.488 | 1.485 | 0.970–1.019 |
| 08-bench/closure1 | 1.374 | 1.354 | 1.291 | 1.357 | 1.344 | 0.980–1.029 |
| 07-bench/2 | 1.156 | 1.176 | 1.161 | 1.148 | 1.160 | 0.975–1.026 |
| 09-bench/huge-project | 0.650 | 0.651 | 0.689 | 0.613 | 0.651 | 0.974–1.020 |

Noise ranges are per-case, from the benchmark tables of 13 unrelated PRs. The 09-bench win is the intended front-end gain and reproduces locally at 1.48–1.52×.

What makes the regressions strange: the affected cases are execution-dominated (compilation is under 5% of their runtime; sieve is ~97% interpretation), yet the PR changes **zero lines** in `runtime/`, `values/`, `bir/`, `semtypes/`, `lib/` and `decimal/`, and `--dump-bir` is byte-identical for all four. The same program runs on the same interpreter. Three of the four are also the suite's only hot-loop closure benchmarks.

Already ruled out by experiment: worse codegen (BIR diff), langlib changes, runtime construction, retained compiler heap (`gctrace` identical), GC/GOMAXPROCS tuning (absent from the diff), extra OS threads (`schedtrace`: 18 both), core count (GOMAXPROCS 1/2/4/12), measurement artifact (a second run reproduced everything), and **binary code layout** — #878 added 1200 inert never-executed functions reproducing the identical 64-byte alignment flip on the identical interpreter functions, and came back flat (closure1 1.009, closure2 1.021, sieve 0.980).

It also does not reproduce on darwin/arm64 at any core count: against this same pair, sieve 0.965, closure2 0.983, 07-bench/2 0.894 — HEAD equal or faster.

This commit touches no interpreter code either (mostly `parser`, `st`, `semantics`, `tools/diagnostics`), so on the face of it it should be flat.

### How to read the result

- **Regressions appear here** → the cause is in this frontend API refactor, which would be genuinely surprising and narrows the search to 36 files.
- **Flat** → the cause is `feat(driver): replace project-based run compilation`, which is where concurrent per-module compilation lives. That points at the execution phase inheriting a differently-allocated heap, and the follow-up is to measure `AnonHugePages` from `/proc/self/smaps_rollup` and the type-env size at `rt.Init` on linux.

The `Lint PR` title check will fail on the `[Don't merge]` prefix, same as on #875. The commit itself is unmodified from #875, so `Validate Commit Messages` should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable parser diagnostics for token dumps, syntax-tree output, and recovery tracing.
  * Added parser support for custom source identities and debug output destinations.
  * Added strict and recovery-based compilation options for source processing.
  * Diagnostic environments can now separate internal file identities from displayed filenames.

* **Bug Fixes**
  * Improved source snippets in diagnostics by using in-memory document content when available.
  * Duplicate import aliases are now reported consistently.
  * Improved handling of invalid top-level syntax during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->