### PR TITLE
feat: support shorthand fields in mapping constructors

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -514,7 +514,6 @@ type (
 		bLangNodeBase
 		Key       *BLangMappingKey
 		ValueExpr BLangExpression
-		Readonly  bool
 	}
 
 	BLangMappingConstructorExpr struct {

--- a/corpus/ast/subset10/10-mapping/shorthand-const-v.txt
+++ b/corpus/ast/subset10/10-mapping/shorthand-const-v.txt
@@ -1,0 +1,20 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (const A (
+    (value-type int)) (
+    (literal 1)))
+  (const M (
+    (constrained-type
+      (builtin-ref-type map)
+      (value-type int))) (
+    (mapping-constructor-expr
+      (key-value
+        (literal A)
+        (simple-var-ref A)))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref M)))))))

--- a/corpus/ast/subset10/10-mapping/shorthand-contextual-v.txt
+++ b/corpus/ast/subset10/10-mapping/shorthand-contextual-v.txt
@@ -1,0 +1,60 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition Person
+    (record-type
+      (field name
+        (value-type string))
+      (field age
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable name (type
+          (value-type string)) (expr
+          (literal Ada))))
+      (var-def
+        (variable age (type
+          (value-type int)) (expr
+          (literal 36))))
+      (var-def
+        (variable p (type
+          (user-defined-type Person)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal age)
+              (simple-var-ref age))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref p))))
+      (var-def
+        (variable m (type
+          (constrained-type
+            (builtin-ref-type map)
+            (value-type int))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal age)
+              (simple-var-ref age))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref m))))
+      (assignment
+        (simple-var-ref m)
+        (mapping-constructor-expr
+          (key-value
+            (literal age)
+            (simple-var-ref age))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref m))))
+      (assignment
+        (simple-var-ref name)
+        (literal Bob))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref p)))))))

--- a/corpus/ast/subset10/10-mapping/shorthand-mixed-forms-v.txt
+++ b/corpus/ast/subset10/10-mapping/shorthand-mixed-forms-v.txt
@@ -1,0 +1,72 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition Person
+    (record-type
+      (field name
+        (value-type string))
+      (field age
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable name (type
+          (value-type string)) (expr
+          (literal Ada))))
+      (var-def
+        (variable age (type
+          (value-type int)) (expr
+          (literal 36))))
+      (var-def
+        (variable a (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal age)
+              (literal 40))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref a))))
+      (var-def
+        (variable b (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal age)
+              (literal 40))
+            (key-value
+              (literal name)
+              (simple-var-ref name))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref b))))
+      (var-def
+        (variable c (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal age)
+              (simple-var-ref age))
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal extra)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref c))))
+      (var-def
+        (variable p (type
+          (user-defined-type Person)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal age)
+              (literal 40))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref p)))))))

--- a/corpus/ast/subset10/10-mapping/shorthand-symbol-kinds-v.txt
+++ b/corpus/ast/subset10/10-mapping/shorthand-symbol-kinds-v.txt
@@ -1,0 +1,44 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition Foo
+    (value-type int))
+  (function helper () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (literal helper))))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable fn (type
+          (function-type () (
+            (value-type null)))) (expr
+          (simple-var-ref helper))))
+      (var-def
+        (variable f (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal fn)
+              (simple-var-ref fn))))))
+      (var-def
+        (variable g (expr
+          (field-based-access fn
+            (simple-var-ref f)))))
+      (expression-stmt
+        (invocation g ()))
+      (var-def
+        (variable t (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal Foo)
+              (simple-var-ref Foo))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (index-based-access
+              (simple-var-ref t)
+              (literal Foo))
+            (value-type typedesc))))))))

--- a/corpus/ast/subset10/10-mapping/shorthand-v.txt
+++ b/corpus/ast/subset10/10-mapping/shorthand-v.txt
@@ -1,0 +1,51 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (const GREETING (
+    (value-type string)) (
+    (literal hi)))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable name (type
+          (value-type string)) (expr
+          (literal Ada))))
+      (var-def
+        (variable age (type
+          (value-type int)) (expr
+          (literal 36))))
+      (var-def
+        (variable default (type
+          (value-type string)) (expr
+          (literal d))))
+      (var-def
+        (variable person (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal age)
+              (simple-var-ref age))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref person))))
+      (var-def
+        (variable c (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal GREETING)
+              (simple-var-ref GREETING))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref c))))
+      (var-def
+        (variable q (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal default)
+              (simple-var-ref default))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref q)))))))

--- a/corpus/bal/subset10/10-mapping/duplicate-explicit-shorthand-e.bal
+++ b/corpus/bal/subset10/10-mapping/duplicate-explicit-shorthand-e.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+public function main() {
+    string name = "Ada";
+    var x = {name: "b", name}; // @error
+    _ = x;
+}

--- a/corpus/bal/subset10/10-mapping/duplicate-quoted-shorthand-e.bal
+++ b/corpus/bal/subset10/10-mapping/duplicate-quoted-shorthand-e.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+public function main() {
+    string name = "Ada";
+    var x = {'name, name}; // @error
+    _ = x;
+}

--- a/corpus/bal/subset10/10-mapping/duplicate-shorthand-e.bal
+++ b/corpus/bal/subset10/10-mapping/duplicate-shorthand-e.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+public function main() {
+    string name = "Ada";
+    var x = {name, name}; // @error
+    _ = x;
+}

--- a/corpus/bal/subset10/10-mapping/duplicate-shorthand-explicit-e.bal
+++ b/corpus/bal/subset10/10-mapping/duplicate-shorthand-explicit-e.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+public function main() {
+    string name = "Ada";
+    var x = {name, name: "b"}; // @error
+    _ = x;
+}

--- a/corpus/bal/subset10/10-mapping/duplicate-shorthand-string-key-e.bal
+++ b/corpus/bal/subset10/10-mapping/duplicate-shorthand-string-key-e.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+public function main() {
+    string name = "Ada";
+    var x = {name, "name": "b"}; // @error
+    _ = x;
+}

--- a/corpus/bal/subset10/10-mapping/readonly-field-fv.bal
+++ b/corpus/bal/subset10/10-mapping/readonly-field-fv.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io;
+
+public function main() {
+    var x = {readonly age: 36}; // @error future: readonly mapping constructor field
+    io:println(x); // @output {"age":36}
+}

--- a/corpus/bal/subset10/10-mapping/readonly-shorthand-fv.bal
+++ b/corpus/bal/subset10/10-mapping/readonly-shorthand-fv.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io;
+
+public function main() {
+    int age = 36;
+    var x = {readonly age}; // @error future: readonly mapping constructor field
+    io:println(x); // @output {"age":36}
+}

--- a/corpus/bal/subset10/10-mapping/readonly-string-key-fv.bal
+++ b/corpus/bal/subset10/10-mapping/readonly-string-key-fv.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io;
+
+public function main() {
+    var x = {readonly "foo": 1}; // @error future: readonly mapping constructor field
+    io:println(x); // @output {"foo":1}
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-const-v.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-const-v.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io;
+
+const int A = 1;
+
+const map<int> M = {A};
+
+public function main() {
+    io:println(M); // @output {"A":1}
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-contextual-mismatch-e.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-contextual-mismatch-e.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+public function main() {
+    string name = "Ada";
+    map<int> m = {name}; // @error
+    _ = m;
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-contextual-v.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-contextual-v.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io;
+
+type Person record {|
+    string name;
+    int age;
+|};
+
+public function main() {
+    string name = "Ada";
+    int age = 36;
+    Person p = {name, age};
+    io:println(p); // @output {"name":"Ada","age":36}
+    map<int> m = {age};
+    io:println(m); // @output {"age":36}
+    m = {age};
+    io:println(m); // @output {"age":36}
+    name = "Bob";
+    io:println(p); // @output {"name":"Ada","age":36}
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-mixed-forms-v.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-mixed-forms-v.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io;
+
+type Person record {|
+    string name;
+    int age;
+|};
+
+public function main() {
+    string name = "Ada";
+    int age = 36;
+    var a = {name, age: 40};
+    io:println(a); // @output {"name":"Ada","age":40}
+    var b = {age: 40, name};
+    io:println(b); // @output {"age":40,"name":"Ada"}
+    var c = {age, name, "extra": 1};
+    io:println(c); // @output {"age":36,"name":"Ada","extra":1}
+    Person p = {name, age: 40};
+    io:println(p); // @output {"name":"Ada","age":40}
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-rest-field-e.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-rest-field-e.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+type Config record {|
+    int x;
+    anydata...;
+|};
+
+public function main() {
+    int y = 2;
+    Config c = {x: 1, y}; // @error
+    _ = c;
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-stmt-start-e.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-stmt-start-e.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+public function main() {
+    string name = "Ada";
+    int age = 36;
+    {name, age}.length(); // @error
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-symbol-kinds-v.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-symbol-kinds-v.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io;
+
+type Foo int;
+
+function helper() {
+    io:println("helper"); // @output helper
+}
+
+public function main() {
+    function () fn = helper;
+    var f = {fn};
+    var g = f.fn;
+    g();
+    var t = {Foo};
+    io:println(t["Foo"] is typedesc); // @output true
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-undefined-e.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-undefined-e.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+public function main() {
+    var x = {missing}; // @error
+    _ = x;
+}

--- a/corpus/bal/subset10/10-mapping/shorthand-v.bal
+++ b/corpus/bal/subset10/10-mapping/shorthand-v.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/io;
+
+const string GREETING = "hi";
+
+public function main() {
+    string name = "Ada";
+    int age = 36;
+    string 'default = "d";
+    var person = {name, age};
+    io:println(person); // @output {"name":"Ada","age":36}
+    var c = {GREETING};
+    io:println(c); // @output {"GREETING":"hi"}
+    var q = {'default};
+    io:println(q); // @output {"default":"d"}
+}

--- a/corpus/bir/subset10/10-mapping/shorthand-const-v.txt
+++ b/corpus/bir/subset10/10-mapping/shorthand-const-v.txt
@@ -1,0 +1,10 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad {"A":1}
+    %2 = println(%1) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}

--- a/corpus/bir/subset10/10-mapping/shorthand-contextual-v.txt
+++ b/corpus/bir/subset10/10-mapping/shorthand-contextual-v.txt
@@ -1,0 +1,34 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad Ada
+    name = %1;
+    %3 = ConstantLoad 36
+    age = %3;
+    %5 = ConstantLoad name
+    %6 = ConstantLoad age
+    %7 = newMap {| age: int, name: string, never... |}{%5=name, %6=age}
+    p = %7;
+    %9 = println(p) -> bb1;
+  }
+  bb1 {
+    %10 = ConstantLoad age
+    %11 = newMap {| int... |}{%10=age}
+    m = %11;
+    %13 = println(m) -> bb2;
+  }
+  bb2 {
+    %14 = ConstantLoad age
+    %15 = newMap {| int... |}{%14=age}
+    m = %15;
+    %16 = println(m) -> bb3;
+  }
+  bb3 {
+    %17 = ConstantLoad Bob
+    name = %17;
+    %18 = println(p) -> bb4;
+  }
+  bb4 {
+    return;
+  }
+}

--- a/corpus/bir/subset10/10-mapping/shorthand-mixed-forms-v.txt
+++ b/corpus/bir/subset10/10-mapping/shorthand-mixed-forms-v.txt
@@ -1,0 +1,43 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad Ada
+    name = %1;
+    %3 = ConstantLoad 36
+    age = %3;
+    %5 = ConstantLoad name
+    %6 = ConstantLoad age
+    %7 = ConstantLoad 40
+    %8 = newMap {| age: int, name: string, never... |}{%5=name, %6=%7}
+    a = %8;
+    %10 = println(a) -> bb1;
+  }
+  bb1 {
+    %11 = ConstantLoad age
+    %12 = ConstantLoad 40
+    %13 = ConstantLoad name
+    %14 = newMap {| age: int, name: string, never... |}{%11=%12, %13=name}
+    b = %14;
+    %16 = println(b) -> bb2;
+  }
+  bb2 {
+    %17 = ConstantLoad age
+    %18 = ConstantLoad name
+    %19 = ConstantLoad extra
+    %20 = ConstantLoad 1
+    %21 = newMap {| age: int, extra: int, name: string, never... |}{%17=age, %18=name, %19=%20}
+    c = %21;
+    %23 = println(c) -> bb3;
+  }
+  bb3 {
+    %24 = ConstantLoad name
+    %25 = ConstantLoad age
+    %26 = ConstantLoad 40
+    %27 = newMap {| age: int, name: string, never... |}{%24=name, %25=%26}
+    p = %27;
+    %29 = println(p) -> bb4;
+  }
+  bb4 {
+    return;
+  }
+}

--- a/corpus/bir/subset10/10-mapping/shorthand-symbol-kinds-v.txt
+++ b/corpus/bir/subset10/10-mapping/shorthand-symbol-kinds-v.txt
@@ -1,0 +1,37 @@
+module $anon.. v 0.0.0;
+helper() -> nil{
+  bb0 {
+    %1 = ConstantLoad helper
+    %2 = println(%1) -> bb1;
+  }
+  bb1 {
+    return;
+  }
+}
+main() -> nil{
+  bb0 {
+    %1 = fp $anon/.:helper
+    fn = %1;
+    %3 = ConstantLoad fn
+    %4 = newMap {| fn: function() returns nil, never... |}{%3=fn}
+    f = %4;
+    %7 = ConstantLoad fn
+    %6 = f[%7];
+    g = %6;
+    %9 = g() -> bb1;
+  }
+  bb1 {
+    %10 = ConstantLoad Foo
+    %11 = ConstantLoad typedesc
+    %12 = newMap {| Foo: typedesc<int>, never... |}{%10=%11}
+    t = %12;
+    %15 = ConstantLoad Foo
+    %14 = t[%15];
+    %16 = %14 is typedesc
+    %17 = %16;
+    %18 = println(%17) -> bb2;
+  }
+  bb2 {
+    return;
+  }
+}

--- a/corpus/bir/subset10/10-mapping/shorthand-v.txt
+++ b/corpus/bir/subset10/10-mapping/shorthand-v.txt
@@ -1,0 +1,32 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad Ada
+    name = %1;
+    %3 = ConstantLoad 36
+    age = %3;
+    %5 = ConstantLoad d
+    default = %5;
+    %7 = ConstantLoad name
+    %8 = ConstantLoad age
+    %9 = newMap {| age: int, name: string, never... |}{%7=name, %8=age}
+    person = %9;
+    %11 = println(person) -> bb1;
+  }
+  bb1 {
+    %12 = ConstantLoad GREETING
+    %13 = ConstantLoad hi
+    %14 = newMap {| GREETING: string, never... |}{%12=%13}
+    c = %14;
+    %16 = println(c) -> bb2;
+  }
+  bb2 {
+    %17 = ConstantLoad default
+    %18 = newMap {| default: string, never... |}{%17=default}
+    q = %18;
+    %20 = println(q) -> bb3;
+  }
+  bb3 {
+    return;
+  }
+}

--- a/corpus/cfg/subset10/10-mapping/shorthand-const-v.txt
+++ b/corpus/cfg/subset10/10-mapping/shorthand-const-v.txt
@@ -1,0 +1,7 @@
+(main
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref M))))
+  )
+)

--- a/corpus/cfg/subset10/10-mapping/shorthand-contextual-v.txt
+++ b/corpus/cfg/subset10/10-mapping/shorthand-contextual-v.txt
@@ -1,0 +1,52 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable name (type
+        (value-type string)) (expr
+        (literal Ada))))
+    (var-def
+      (variable age (type
+        (value-type int)) (expr
+        (literal 36))))
+    (var-def
+      (variable p (type
+        (user-defined-type Person)) (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal name)
+            (simple-var-ref name))
+          (key-value
+            (literal age)
+            (simple-var-ref age))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref p))))
+    (var-def
+      (variable m (type
+        (constrained-type
+          (builtin-ref-type map)
+          (value-type int))) (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal age)
+            (simple-var-ref age))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref m))))
+    (assignment
+      (simple-var-ref m)
+      (mapping-constructor-expr
+        (key-value
+          (literal age)
+          (simple-var-ref age))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref m))))
+    (assignment
+      (simple-var-ref name)
+      (literal Bob))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref p))))
+  )
+)

--- a/corpus/cfg/subset10/10-mapping/shorthand-mixed-forms-v.txt
+++ b/corpus/cfg/subset10/10-mapping/shorthand-mixed-forms-v.txt
@@ -1,0 +1,64 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable name (type
+        (value-type string)) (expr
+        (literal Ada))))
+    (var-def
+      (variable age (type
+        (value-type int)) (expr
+        (literal 36))))
+    (var-def
+      (variable a (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal name)
+            (simple-var-ref name))
+          (key-value
+            (literal age)
+            (literal 40))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref a))))
+    (var-def
+      (variable b (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal age)
+            (literal 40))
+          (key-value
+            (literal name)
+            (simple-var-ref name))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref b))))
+    (var-def
+      (variable c (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal age)
+            (simple-var-ref age))
+          (key-value
+            (literal name)
+            (simple-var-ref name))
+          (key-value
+            (literal extra)
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref c))))
+    (var-def
+      (variable p (type
+        (user-defined-type Person)) (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal name)
+            (simple-var-ref name))
+          (key-value
+            (literal age)
+            (literal 40))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref p))))
+  )
+)

--- a/corpus/cfg/subset10/10-mapping/shorthand-symbol-kinds-v.txt
+++ b/corpus/cfg/subset10/10-mapping/shorthand-symbol-kinds-v.txt
@@ -1,0 +1,41 @@
+(helper
+  (bb0 () ()
+    (expression-stmt
+      (invocation io println (
+        (literal helper))))
+  )
+)
+(main
+  (bb0 () ()
+    (var-def
+      (variable fn (type
+        (function-type () (
+          (value-type null)))) (expr
+        (simple-var-ref helper))))
+    (var-def
+      (variable f (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal fn)
+            (simple-var-ref fn))))))
+    (var-def
+      (variable g (expr
+        (field-based-access fn
+          (simple-var-ref f)))))
+    (expression-stmt
+      (invocation g ()))
+    (var-def
+      (variable t (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal Foo)
+            (simple-var-ref Foo))))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (index-based-access
+            (simple-var-ref t)
+            (literal Foo))
+          (value-type typedesc)))))
+  )
+)

--- a/corpus/cfg/subset10/10-mapping/shorthand-v.txt
+++ b/corpus/cfg/subset10/10-mapping/shorthand-v.txt
@@ -1,0 +1,46 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable name (type
+        (value-type string)) (expr
+        (literal Ada))))
+    (var-def
+      (variable age (type
+        (value-type int)) (expr
+        (literal 36))))
+    (var-def
+      (variable default (type
+        (value-type string)) (expr
+        (literal d))))
+    (var-def
+      (variable person (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal name)
+            (simple-var-ref name))
+          (key-value
+            (literal age)
+            (simple-var-ref age))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref person))))
+    (var-def
+      (variable c (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal GREETING)
+            (simple-var-ref GREETING))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref c))))
+    (var-def
+      (variable q (expr
+        (mapping-constructor-expr
+          (key-value
+            (literal default)
+            (simple-var-ref default))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref q))))
+  )
+)

--- a/corpus/desugared/subset10/10-mapping/shorthand-const-v.txt
+++ b/corpus/desugared/subset10/10-mapping/shorthand-const-v.txt
@@ -1,0 +1,8 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (literal {"A":1})))))))

--- a/corpus/desugared/subset10/10-mapping/shorthand-contextual-v.txt
+++ b/corpus/desugared/subset10/10-mapping/shorthand-contextual-v.txt
@@ -1,0 +1,59 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition Person
+    (record-type
+      (field name
+        (value-type string))
+      (field age
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable name (type
+          (value-type string)) (expr
+          (literal Ada))))
+      (var-def
+        (variable age (type
+          (value-type int)) (expr
+          (literal 36))))
+      (var-def
+        (variable p (type
+          (user-defined-type Person)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal age)
+              (simple-var-ref age))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref p))))
+      (var-def
+        (variable m (type
+          (constrained-type
+            (builtin-ref-type map)
+            (value-type int))) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal age)
+              (simple-var-ref age))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref m))))
+      (assignment
+        (simple-var-ref m)
+        (mapping-constructor-expr
+          (key-value
+            (literal age)
+            (simple-var-ref age))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref m))))
+      (assignment
+        (simple-var-ref name)
+        (literal Bob))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref p)))))))

--- a/corpus/desugared/subset10/10-mapping/shorthand-mixed-forms-v.txt
+++ b/corpus/desugared/subset10/10-mapping/shorthand-mixed-forms-v.txt
@@ -1,0 +1,71 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition Person
+    (record-type
+      (field name
+        (value-type string))
+      (field age
+        (value-type int))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable name (type
+          (value-type string)) (expr
+          (literal Ada))))
+      (var-def
+        (variable age (type
+          (value-type int)) (expr
+          (literal 36))))
+      (var-def
+        (variable a (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal age)
+              (literal 40))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref a))))
+      (var-def
+        (variable b (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal age)
+              (literal 40))
+            (key-value
+              (literal name)
+              (simple-var-ref name))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref b))))
+      (var-def
+        (variable c (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal age)
+              (simple-var-ref age))
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal extra)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref c))))
+      (var-def
+        (variable p (type
+          (user-defined-type Person)) (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal age)
+              (literal 40))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref p)))))))

--- a/corpus/desugared/subset10/10-mapping/shorthand-symbol-kinds-v.txt
+++ b/corpus/desugared/subset10/10-mapping/shorthand-symbol-kinds-v.txt
@@ -1,0 +1,44 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition Foo
+    (value-type int))
+  (function helper () (
+    (value-type null))
+    (block-function-body
+      (expression-stmt
+        (invocation io println (
+          (literal helper))))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable fn (type
+          (function-type () (
+            (value-type null)))) (expr
+          (simple-var-ref helper))))
+      (var-def
+        (variable f (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal fn)
+              (simple-var-ref fn))))))
+      (var-def
+        (variable g (expr
+          (index-based-access
+            (simple-var-ref f)
+            (literal fn)))))
+      (expression-stmt
+        (invocation g ()))
+      (var-def
+        (variable t (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal Foo)
+              (simple-var-ref Foo))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (index-based-access
+              (simple-var-ref t)
+              (literal Foo))
+            (value-type typedesc))))))))

--- a/corpus/desugared/subset10/10-mapping/shorthand-v.txt
+++ b/corpus/desugared/subset10/10-mapping/shorthand-v.txt
@@ -1,0 +1,47 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable name (type
+          (value-type string)) (expr
+          (literal Ada))))
+      (var-def
+        (variable age (type
+          (value-type int)) (expr
+          (literal 36))))
+      (var-def
+        (variable default (type
+          (value-type string)) (expr
+          (literal d))))
+      (var-def
+        (variable person (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal name)
+              (simple-var-ref name))
+            (key-value
+              (literal age)
+              (simple-var-ref age))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref person))))
+      (var-def
+        (variable c (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal GREETING)
+              (literal hi))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref c))))
+      (var-def
+        (variable q (expr
+          (mapping-constructor-expr
+            (key-value
+              (literal default)
+              (simple-var-ref default))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref q)))))))

--- a/corpus/integration/subset10/10-mapping/duplicate-explicit-shorthand-e.txtar
+++ b/corpus/integration/subset10/10-mapping/duplicate-explicit-shorthand-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: duplicate key 'name' in mapping constructor
+  --> duplicate-explicit-shorthand-e.bal:20:25
+   |
+20 |     var x = {name: "b", name}; // @error
+   |                         ^^^^

--- a/corpus/integration/subset10/10-mapping/duplicate-quoted-shorthand-e.txtar
+++ b/corpus/integration/subset10/10-mapping/duplicate-quoted-shorthand-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: duplicate key 'name' in mapping constructor
+  --> duplicate-quoted-shorthand-e.bal:20:21
+   |
+20 |     var x = {'name, name}; // @error
+   |                     ^^^^

--- a/corpus/integration/subset10/10-mapping/duplicate-shorthand-e.txtar
+++ b/corpus/integration/subset10/10-mapping/duplicate-shorthand-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: duplicate key 'name' in mapping constructor
+  --> duplicate-shorthand-e.bal:20:20
+   |
+20 |     var x = {name, name}; // @error
+   |                    ^^^^

--- a/corpus/integration/subset10/10-mapping/duplicate-shorthand-explicit-e.txtar
+++ b/corpus/integration/subset10/10-mapping/duplicate-shorthand-explicit-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: duplicate key 'name' in mapping constructor
+  --> duplicate-shorthand-explicit-e.bal:20:20
+   |
+20 |     var x = {name, name: "b"}; // @error
+   |                    ^^^^

--- a/corpus/integration/subset10/10-mapping/duplicate-shorthand-string-key-e.txtar
+++ b/corpus/integration/subset10/10-mapping/duplicate-shorthand-string-key-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: duplicate key 'name' in mapping constructor
+  --> duplicate-shorthand-string-key-e.bal:20:20
+   |
+20 |     var x = {name, "name": "b"}; // @error
+   |                    ^^^^^^

--- a/corpus/integration/subset10/10-mapping/readonly-field-fv.txtar
+++ b/corpus/integration/subset10/10-mapping/readonly-field-fv.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+fatal[UNIMPLEMENTED_ERROR]: readonly mapping constructor field not implemented
+  --> readonly-field-fv.bal:21:14
+   |
+21 |     var x = {readonly age: 36}; // @error future: readonly mapping constructor field
+   |              ^^^^^^^^

--- a/corpus/integration/subset10/10-mapping/readonly-shorthand-fv.txtar
+++ b/corpus/integration/subset10/10-mapping/readonly-shorthand-fv.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+fatal[UNIMPLEMENTED_ERROR]: readonly mapping constructor field not implemented
+  --> readonly-shorthand-fv.bal:22:14
+   |
+22 |     var x = {readonly age}; // @error future: readonly mapping constructor field
+   |              ^^^^^^^^

--- a/corpus/integration/subset10/10-mapping/readonly-string-key-fv.txtar
+++ b/corpus/integration/subset10/10-mapping/readonly-string-key-fv.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+fatal[UNIMPLEMENTED_ERROR]: readonly mapping constructor field not implemented
+  --> readonly-string-key-fv.bal:21:14
+   |
+21 |     var x = {readonly "foo": 1}; // @error future: readonly mapping constructor field
+   |              ^^^^^^^^

--- a/corpus/integration/subset10/10-mapping/shorthand-const-v.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-const-v.txtar
@@ -1,0 +1,3 @@
+-- stdout --
+{"A":1}
+-- stderr --

--- a/corpus/integration/subset10/10-mapping/shorthand-contextual-mismatch-e.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-contextual-mismatch-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: incompatible type: expected int, got string
+  --> shorthand-contextual-mismatch-e.bal:20:19
+   |
+20 |     map<int> m = {name}; // @error
+   |                   ^^^^

--- a/corpus/integration/subset10/10-mapping/shorthand-contextual-v.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-contextual-v.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+{"name":"Ada","age":36}
+{"age":36}
+{"age":36}
+{"name":"Ada","age":36}
+-- stderr --

--- a/corpus/integration/subset10/10-mapping/shorthand-mixed-forms-v.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-mixed-forms-v.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+{"name":"Ada","age":40}
+{"age":40,"name":"Ada"}
+{"age":36,"name":"Ada","extra":1}
+{"name":"Ada","age":40}
+-- stderr --

--- a/corpus/integration/subset10/10-mapping/shorthand-rest-field-e.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-rest-field-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: identifier 'y' cannot be used as a key for a rest field; use a string literal instead
+  --> shorthand-rest-field-e.bal:25:23
+   |
+25 |     Config c = {x: 1, y}; // @error
+   |                       ^

--- a/corpus/integration/subset10/10-mapping/shorthand-stmt-start-e.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-stmt-start-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: expression value must be assigned
+  --> shorthand-stmt-start-e.bal:21:5
+   |
+21 |     {name, age}.length(); // @error
+   |     ^^^^^^^^^^^^^^^^^^^^

--- a/corpus/integration/subset10/10-mapping/shorthand-symbol-kinds-v.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-symbol-kinds-v.txtar
@@ -1,0 +1,4 @@
+-- stdout --
+helper
+true
+-- stderr --

--- a/corpus/integration/subset10/10-mapping/shorthand-undefined-e.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-undefined-e.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: Unknown symbol: missing
+  --> shorthand-undefined-e.bal:19:14
+   |
+19 |     var x = {missing}; // @error
+   |              ^^^^^^^

--- a/corpus/integration/subset10/10-mapping/shorthand-v.txtar
+++ b/corpus/integration/subset10/10-mapping/shorthand-v.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+{"name":"Ada","age":36}
+{"GREETING":"hi"}
+{"default":"d"}
+-- stderr --

--- a/nodebuilder/node_builder.go
+++ b/nodebuilder/node_builder.go
@@ -2273,9 +2273,17 @@ func (n *nodeBuilder) transformMappingConstructorExpression(mappingConstructorBL
 			mappingConstructor.Fields = append(mappingConstructor.Fields, keyValueField)
 		case st.SPECIFIC_FIELD:
 			specificField := field.(*st.SpecificFieldNode)
-			if specificField.ValueExpr() == nil {
-				n.unimplemented("mapping constructor var-name field not implemented", specificField)
+			if specificField.ReadonlyKeyword() != nil {
+				n.unimplemented("readonly mapping constructor field not implemented",
+					specificField.ReadonlyKeyword())
 				return n.badExprOrAction(mappingConstructorBLangExpression)
+			}
+			valueExpr := specificField.ValueExpr()
+			var value ast.BLangExpression
+			if valueExpr == nil {
+				value = n.createExpression(specificField.FieldName())
+			} else {
+				value = n.createExpression(valueExpr)
 			}
 			_, isStringLit := specificField.FieldName().(*st.BasicLiteralNode)
 			keyKind := ast.MappingKeyIdentifier
@@ -2289,8 +2297,7 @@ func (n *nodeBuilder) transformMappingConstructorExpression(mappingConstructorBL
 			key.SetPosition(n.getPosition(specificField.FieldName()))
 			keyValueField := &ast.BLangMappingKeyValueField{
 				Key:       key,
-				ValueExpr: n.createExpression(specificField.ValueExpr()),
-				Readonly:  specificField.ReadonlyKeyword() != nil,
+				ValueExpr: value,
 			}
 			keyValueField.SetPosition(n.getPosition(specificField))
 			mappingConstructor.Fields = append(mappingConstructor.Fields, keyValueField)


### PR DESCRIPTION
## Purpose

The shorthand `{name}` form parses fine, but the node builder bailed out with
`UNIMPLEMENTED_ERROR: mapping constructor var-name field not implemented`, so shorthand
fields could not be compiled even though the equivalent explicit fields worked.

Fixes #859

## Approach

The specification defines `{name}` as exactly equivalent to `{name: name}`, so the fix is a
total expansion in the node builder — no parser, semantics, desugar or BIR work is needed.

- **Expand the shorthand.** In the `st.SPECIFIC_FIELD` branch of
  `transformMappingConstructorExpression`, a field with `ValueExpr() == nil` now takes its
  value from `n.createExpression(specificField.FieldName())`.
  `createActionOrExpressionInner` already turns a bare `IDENTIFIER_TOKEN` into a
  `*ast.BLangVarRef` positioned on the token, so no helper is added and no var-ref is built
  by hand. The key side is untouched: `createSpecificFieldNameLiteral` already produces the
  identifier-key literal, and both sides run through `createBLangNameReference`, so the
  quoted-identifier prefix is stripped consistently (`{'default}` → key `"default"`).
- **Nothing downstream can tell the forms apart.** After the node builder a shorthand field
  is an ordinary `*ast.BLangMappingKeyValueField`, so symbol resolution, contextual record
  and `map<T>` construction, duplicate-key detection, const evaluation, CFG, desugar and
  BIR generation all apply unchanged.
- **Reject the per-field `readonly` prefix** with an `UNIMPLEMENTED_ERROR` positioned on the
  keyword. See the behaviour change below.
- **Drop the write-only `Readonly` field** from `ast.BLangMappingKeyValueField`. It was
  assigned in the node builder and read by no stage; the BIR-level `IsReadonly` on `NewMap`
  comes from the whole-mapping read-only bit, not from this field.

## Behaviour change

`{readonly x: 1}` and `{readonly "k": 1}` compile today with the modifier **silently
discarded** — the read-only bit is never set, so the runtime value is wrong. Both now report
`fatal[UNIMPLEMENTED_ERROR]: readonly mapping constructor field not implemented`. This turns
two currently-"working" programs into compile errors, deliberately: making the gap loud is
better than producing wrong runtime behaviour. Implementing the semantics is #876, and the
three `-fv` tests below are written in their eventual `-v` shape so that issue promotes them
by renaming the file and regenerating the golden.

`{_}` now reports `INTERNAL_ERROR: invalid identifier` instead of the var-name error,
matching what `{_: 1}` already reports today. That `_`-as-a-key problem predates this change
and affects both spellings equally, so it is left alone rather than special-cased for the
shorthand form.

## Checklist
- [x] Read the [Contributing Guide](CONTRIBUTING.md)
- [x] Added or updated [corpus tests](AGENTS.md#corpus-tests)

## Tests

16 corpus tests in a new `corpus/bal/subset10/10-mapping/`:

- **5 valid** — `shorthand-v` (the issue's program, plus a const and a quoted identifier),
  `shorthand-mixed-forms-v` (shorthand interleaved with explicit and string-literal-key
  fields in both orders, and a contextual record), `shorthand-contextual-v` (record, `map<int>`,
  reassignment, and construction-time value capture), `shorthand-const-v` (the only test
  reaching `evaluateMappingConstructor`), `shorthand-symbol-kinds-v` (a function-valued and a
  typedesc-valued field).
- **8 error** — undefined symbol; the rest-field key rule; a duplicate-key matrix covering
  every pairing of field forms, both key kinds, and the quoted/unquoted spellings of one
  identifier; and `shorthand-stmt-start-e`, which is the only test reaching the two
  statement-start producers of the shorthand shape (`parseIdentifierRhsInStmtStartingBrace`
  and `parseMappingFieldRhs`).
- **3 future** — one per `readonly` spelling, each asserting the error lands on the keyword.

Every `-v` program was also run under jBallerina and produces **byte-identical stdout** to
its golden; every `-e` program's diagnostic **position matches jBallerina exactly**; and all
three `-fv` programs compile and run under jBallerina printing exactly their `@output`
markers.

## Remarks

- Spread fields (`{...base}`) remain unimplemented (#858), so the parent issue #856's
  motivating example `{...base, count}` still will not compile.
- Mapping binding patterns (`{name, age} = person`) take the assignment path and are
  unaffected — they still stop at `binding-pattern assignment is not implemented`.
- `doc/lang/` is not updated: subset10 has no subset doc yet, and the stale spread-field
  bullet in `subset8.md`/`subset9.md` is #858's to remove.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for shorthand fields in mapping constructors, including contextual values, constants, mixed explicit/shorthand forms, functions, and typedescs.
  - Mapping fields without explicit values now use their field names as value expressions.

- **Bug Fixes**
  - Duplicate mapping keys are reported consistently across shorthand, quoted, string, and explicit forms.
  - Invalid shorthand usage produces clearer compiler diagnostics.
  - Readonly mapping constructor fields are explicitly reported as unsupported.

- **Tests**
  - Added comprehensive coverage for valid shorthand mappings and invalid mapping-constructor cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->