### PR TITLE
ci: benchmark PRs with Go 1.27.1

### DIFF
--- a/.github/workflows/benchmark-pr-http-prepare.yml
+++ b/.github/workflows/benchmark-pr-http-prepare.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.27.1"
 
       - name: Install wrk
         run: |

--- a/.github/workflows/benchmark-pr-memory-prepare.yml
+++ b/.github/workflows/benchmark-pr-memory-prepare.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.27.1"
 
       - name: Install benchmark dependencies
         run: |

--- a/.github/workflows/benchmark-pr-time-prepare.yml
+++ b/.github/workflows/benchmark-pr-time-prepare.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.27.1"
 
       - name: Install benchmark dependencies
         run: |


### PR DESCRIPTION
Experimental benchmark control. Do not merge.

Pins the PR time, memory, and HTTP benchmark workflows to Go 1.27.1 without changing product code.

The benchmark harness builds both origin/main and HEAD with the workflow toolchain, so this PR primarily measures same-source run-to-run noise under Go 1.27.1. Its absolute origin/main timings can be compared cautiously with the earlier Go 1.26.7 runs; that cross-run comparison is not a paired toolchain benchmark.

This is the bottom PR in the PR #875 Go 1.27.1 experiment stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go version used by HTTP, memory, and time benchmark workflows to 1.27.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->