### PR TITLE
ci: benchmark PRs with Go 1.27.1

### DIFF
--- a/.github/workflows/benchmark-pr-http-prepare.yml
+++ b/.github/workflows/benchmark-pr-http-prepare.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.27.1"
 
       - name: Install wrk
         run: |

--- a/.github/workflows/benchmark-pr-memory-prepare.yml
+++ b/.github/workflows/benchmark-pr-memory-prepare.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.27.1"
 
       - name: Install benchmark dependencies
         run: |

--- a/.github/workflows/benchmark-pr-time-prepare.yml
+++ b/.github/workflows/benchmark-pr-time-prepare.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.27.1"
 
       - name: Install benchmark dependencies
         run: |


### PR DESCRIPTION
Experimental benchmark control. Do not merge.

Bottom PR in stack #886. It pins the PR time, memory, and HTTP benchmark workflows to Go 1.27.1 without changing product code.

The benchmark harness builds both origin/main and HEAD with the workflow toolchain. This PR therefore provides a same-source control under Go 1.27.1 and measures runner noise. Its absolute origin/main timings may be compared cautiously with earlier Go 1.26.7 runs, but that cross-run comparison is not a paired toolchain benchmark.