### PR TITLE
fix(semantics): give constants the readonly shape type

### DIFF
--- a/corpus/ast/subset8/08-const/readonly-list-v.txt
+++ b/corpus/ast/subset8/08-const/readonly-list-v.txt
@@ -1,0 +1,90 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (const A (
+    (array-type
+      (value-type byte) dimensions: 1 ([]))) (
+    (list-constructor-expr
+      (literal 1)
+      (literal 2))))
+  (const B (
+    (array-type
+      (value-type int) dimensions: 1 ([]))) (
+    (list-constructor-expr
+      (literal 3)
+      (literal 4))))
+  (const C () (
+    (list-constructor-expr
+      (list-constructor-expr
+        (literal 1)
+        (literal 2))
+      (list-constructor-expr
+        (literal 3)
+        (literal 4)))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (simple-var-ref A))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (value-type readonly)))))
+      (var-def
+        (variable r (type
+          (intersection-type
+            (value-type readonly)
+            (array-type
+              (value-type byte) dimensions: 1 ([])))) (expr
+          (simple-var-ref A))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref r))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (array-type
+              (value-type byte) dimensions: 1 ([
+              (literal 2)]))))))
+      (var-def
+        (variable b (type
+          (value-type any)) (expr
+          (simple-var-ref B))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref b)
+            (intersection-type
+              (value-type readonly)
+              (array-type
+                (value-type int) dimensions: 1 ([])))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref b)
+            (tuple-type
+              (finite-type
+                (literal 3))
+              (finite-type
+                (literal 4)))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref C)
+            (value-type readonly)))))
+      (var-def
+        (variable nested (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (simple-var-ref C))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (index-based-access
+              (simple-var-ref nested)
+              (literal 0))
+            (value-type readonly))))))))

--- a/corpus/ast/subset8/08-const/readonly-map-v.txt
+++ b/corpus/ast/subset8/08-const/readonly-map-v.txt
@@ -1,0 +1,72 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (const A (
+    (constrained-type
+      (builtin-ref-type map)
+      (value-type int))) (
+    (mapping-constructor-expr
+      (key-value
+        (literal a)
+        (literal 1)))))
+  (const B (
+    (constrained-type
+      (builtin-ref-type map)
+      (constrained-type
+        (builtin-ref-type map)
+        (value-type int)))) (
+    (mapping-constructor-expr
+      (key-value
+        (literal x)
+        (mapping-constructor-expr
+          (key-value
+            (literal y)
+            (literal 2)))))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (simple-var-ref A))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (value-type readonly)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (record-type
+              (field a
+                (value-type int)))))))
+      (var-def
+        (variable r (type
+          (intersection-type
+            (value-type readonly)
+            (constrained-type
+              (builtin-ref-type map)
+              (value-type int)))) (expr
+          (simple-var-ref A))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref r))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref B)
+            (value-type readonly)))))
+      (var-def
+        (variable m (type
+          (constrained-type
+            (builtin-ref-type map)
+            (value-type any))) (expr
+          (simple-var-ref B))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (index-based-access
+              (simple-var-ref m)
+              (literal x))
+            (value-type readonly))))))))

--- a/corpus/ast/subset8/08-const/readonly-record-v.txt
+++ b/corpus/ast/subset8/08-const/readonly-record-v.txt
@@ -1,0 +1,51 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (type-definition R
+    (record-type
+      (field x
+        (value-type int))
+      (field y
+        (value-type string))))
+  (const A (
+    (user-defined-type R)) (
+    (mapping-constructor-expr
+      (key-value
+        (literal x)
+        (literal 1))
+      (key-value
+        (literal y)
+        (literal two)))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (simple-var-ref A))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (value-type readonly)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (intersection-type
+              (value-type readonly)
+              (user-defined-type R))))))
+      (var-def
+        (variable r (type
+          (intersection-type
+            (value-type readonly)
+            (user-defined-type R))) (expr
+          (simple-var-ref A))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref r))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref A)
+            (user-defined-type R))))))))

--- a/corpus/ast/subset8/08-const/readonly-tuple-v.txt
+++ b/corpus/ast/subset8/08-const/readonly-tuple-v.txt
@@ -1,0 +1,68 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (const A (
+    (tuple-type
+      (value-type int)
+      (value-type string))) (
+    (list-constructor-expr
+      (literal 1)
+      (literal two))))
+  (const B (
+    (tuple-type
+      (value-type int) (rest
+        (value-type int)))) (
+    (list-constructor-expr
+      (literal 1)
+      (literal 2)
+      (literal 3))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (simple-var-ref A))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (value-type readonly)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (tuple-type
+              (finite-type
+                (literal 1))
+              (finite-type
+                (literal two)))))))
+      (var-def
+        (variable r (type
+          (intersection-type
+            (value-type readonly)
+            (tuple-type
+              (value-type int)
+              (value-type string)))) (expr
+          (simple-var-ref A))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref r))))
+      (var-def
+        (variable b (type
+          (value-type any)) (expr
+          (simple-var-ref B))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref b)
+            (value-type readonly)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref b)
+            (intersection-type
+              (value-type readonly)
+              (tuple-type
+                (value-type int) (rest
+                  (value-type int)))))))))))

--- a/corpus/bal/subset8/08-const/readonly-list-v.bal
+++ b/corpus/bal/subset8/08-const/readonly-list-v.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// @productions module-const-decl array-type-descriptor list-constructor-expr type-test-expr
+import ballerina/io;
+
+const byte[] A = [1, 2];
+const int[] B = [3, 4];
+const C = [[1, 2], [3, 4]];
+
+public function main() {
+    any a = A;
+    io:println(a is readonly); // @output true
+    readonly & byte[] r = A;
+    io:println(r); // @output [1,2]
+    io:println(a is byte[2]); // @output true
+    any b = B;
+    io:println(b is readonly & int[]); // @output true
+    io:println(b is [3, 4]); // @output true
+    io:println(C is readonly); // @output true
+    any[] nested = C;
+    io:println(nested[0] is readonly); // @output true
+}

--- a/corpus/bal/subset8/08-const/readonly-map-v.bal
+++ b/corpus/bal/subset8/08-const/readonly-map-v.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// @productions module-const-decl map-type-descriptor mapping-constructor-expr type-test-expr
+import ballerina/io;
+
+const map<int> A = {"a": 1};
+const map<map<int>> B = {"x": {"y": 2}};
+
+public function main() {
+    any a = A;
+    io:println(a is readonly); // @output true
+    io:println(a is record {| int a; |}); // @output true
+    readonly & map<int> r = A;
+    io:println(r); // @output {"a":1}
+    io:println(B is readonly); // @output true
+    map<any> m = B;
+    io:println(m["x"] is readonly); // @output true
+}

--- a/corpus/bal/subset8/08-const/readonly-record-v.bal
+++ b/corpus/bal/subset8/08-const/readonly-record-v.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// @productions module-const-decl record-type-descriptor mapping-constructor-expr type-test-expr
+import ballerina/io;
+
+type R record {|
+    int x;
+    string y;
+|};
+
+const R A = {x: 1, y: "two"};
+
+public function main() {
+    any a = A;
+    io:println(a is readonly); // @output true
+    io:println(a is readonly & R); // @output true
+    readonly & R r = A;
+    io:println(r); // @output {"x":1,"y":"two"}
+    io:println(A is R); // @output true
+}

--- a/corpus/bal/subset8/08-const/readonly-tuple-v.bal
+++ b/corpus/bal/subset8/08-const/readonly-tuple-v.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// @productions module-const-decl tuple-type-descriptor list-constructor-expr type-test-expr
+import ballerina/io;
+
+const [int, string] A = [1, "two"];
+const [int, int...] B = [1, 2, 3];
+
+public function main() {
+    any a = A;
+    io:println(a is readonly); // @output true
+    io:println(a is [1, "two"]); // @output true
+    readonly & [int, string] r = A;
+    io:println(r); // @output [1,"two"]
+    any b = B;
+    io:println(b is readonly); // @output true
+    io:println(b is readonly & [int, int...]); // @output true
+}

--- a/corpus/bir/subset8/08-const/readonly-list-v.txt
+++ b/corpus/bir/subset8/08-const/readonly-list-v.txt
@@ -1,0 +1,50 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad [1,2]
+    a = %1;
+    %3 = a is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %4 = %3;
+    %5 = println(%4) -> bb1;
+  }
+  bb1 {
+    %6 = ConstantLoad [1,2]
+    r = %6;
+    %8 = println(r) -> bb2;
+  }
+  bb2 {
+    %9 = a is [int:Unsigned8, int:Unsigned8, never...]
+    %10 = %9;
+    %11 = println(%10) -> bb3;
+  }
+  bb3 {
+    %12 = ConstantLoad [3,4]
+    b = %12;
+    %14 = b is readonly&[int...]
+    %15 = %14;
+    %16 = println(%15) -> bb4;
+  }
+  bb4 {
+    %17 = b is [3, 4, never...]
+    %18 = %17;
+    %19 = println(%18) -> bb5;
+  }
+  bb5 {
+    %20 = ConstantLoad [[1,2],[3,4]]
+    %21 = %20 is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %22 = %21;
+    %23 = println(%22) -> bb6;
+  }
+  bb6 {
+    %24 = ConstantLoad [[1,2],[3,4]]
+    nested = %24;
+    %27 = ConstantLoad 0
+    %26 = nested[%27];
+    %28 = %26 is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %29 = %28;
+    %30 = println(%29) -> bb7;
+  }
+  bb7 {
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-const/readonly-map-v.txt
+++ b/corpus/bir/subset8/08-const/readonly-map-v.txt
@@ -1,0 +1,38 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad {"a":1}
+    a = %1;
+    %3 = a is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %4 = %3;
+    %5 = println(%4) -> bb1;
+  }
+  bb1 {
+    %6 = a is {| a: int, never... |}
+    %7 = %6;
+    %8 = println(%7) -> bb2;
+  }
+  bb2 {
+    %9 = ConstantLoad {"a":1}
+    r = %9;
+    %11 = println(r) -> bb3;
+  }
+  bb3 {
+    %12 = ConstantLoad {"x":{"y":2}}
+    %13 = %12 is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %14 = %13;
+    %15 = println(%14) -> bb4;
+  }
+  bb4 {
+    %16 = ConstantLoad {"x":{"y":2}}
+    m = %16;
+    %19 = ConstantLoad x
+    %18 = m[%19];
+    %20 = %18 is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %21 = %20;
+    %22 = println(%21) -> bb5;
+  }
+  bb5 {
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-const/readonly-record-v.txt
+++ b/corpus/bir/subset8/08-const/readonly-record-v.txt
@@ -1,0 +1,29 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad {"x":1,"y":"two"}
+    a = %1;
+    %3 = a is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %4 = %3;
+    %5 = println(%4) -> bb1;
+  }
+  bb1 {
+    %6 = a is readonly&{| x: int, y: string, never... |}
+    %7 = %6;
+    %8 = println(%7) -> bb2;
+  }
+  bb2 {
+    %9 = ConstantLoad {"x":1,"y":"two"}
+    r = %9;
+    %11 = println(r) -> bb3;
+  }
+  bb3 {
+    %12 = ConstantLoad {"x":1,"y":"two"}
+    %13 = %12 is {| x: int, y: string, never... |}
+    %14 = %13;
+    %15 = println(%14) -> bb4;
+  }
+  bb4 {
+    return;
+  }
+}

--- a/corpus/bir/subset8/08-const/readonly-tuple-v.txt
+++ b/corpus/bir/subset8/08-const/readonly-tuple-v.txt
@@ -1,0 +1,35 @@
+module $anon.. v 0.0.0;
+main() -> nil{
+  bb0 {
+    %1 = ConstantLoad [1,"two"]
+    a = %1;
+    %3 = a is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %4 = %3;
+    %5 = println(%4) -> bb1;
+  }
+  bb1 {
+    %6 = a is [1, "two", never...]
+    %7 = %6;
+    %8 = println(%7) -> bb2;
+  }
+  bb2 {
+    %9 = ConstantLoad [1,"two"]
+    r = %9;
+    %11 = println(r) -> bb3;
+  }
+  bb3 {
+    %12 = ConstantLoad [1,2,3]
+    b = %12;
+    %14 = b is nil|boolean|int|float|decimal|string|error|typedesc|handle|function|regexp|readonly|readonly|table|xml<xml:Text|xml:Element|xml:Comment|xml:ProcessingInstruction>|readonly
+    %15 = %14;
+    %16 = println(%15) -> bb4;
+  }
+  bb4 {
+    %17 = b is readonly&[int, int...]
+    %18 = %17;
+    %19 = println(%18) -> bb5;
+  }
+  bb5 {
+    return;
+  }
+}

--- a/corpus/cfg/subset8/08-const/readonly-list-v.txt
+++ b/corpus/cfg/subset8/08-const/readonly-list-v.txt
@@ -1,0 +1,68 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (value-type any)) (expr
+        (simple-var-ref A))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref a)
+          (value-type readonly)))))
+    (var-def
+      (variable r (type
+        (intersection-type
+          (value-type readonly)
+          (array-type
+            (value-type byte) dimensions: 1 ([])))) (expr
+        (simple-var-ref A))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref r))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref a)
+          (array-type
+            (value-type byte) dimensions: 1 ([
+            (literal 2)]))))))
+    (var-def
+      (variable b (type
+        (value-type any)) (expr
+        (simple-var-ref B))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref b)
+          (intersection-type
+            (value-type readonly)
+            (array-type
+              (value-type int) dimensions: 1 ([])))))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref b)
+          (tuple-type
+            (finite-type
+              (literal 3))
+            (finite-type
+              (literal 4)))))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref C)
+          (value-type readonly)))))
+    (var-def
+      (variable nested (type
+        (array-type
+          (value-type any) dimensions: 1 ([]))) (expr
+        (simple-var-ref C))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (index-based-access
+            (simple-var-ref nested)
+            (literal 0))
+          (value-type readonly)))))
+  )
+)

--- a/corpus/cfg/subset8/08-const/readonly-map-v.txt
+++ b/corpus/cfg/subset8/08-const/readonly-map-v.txt
@@ -1,0 +1,49 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (value-type any)) (expr
+        (simple-var-ref A))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref a)
+          (value-type readonly)))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref a)
+          (record-type
+            (field a
+              (value-type int)))))))
+    (var-def
+      (variable r (type
+        (intersection-type
+          (value-type readonly)
+          (constrained-type
+            (builtin-ref-type map)
+            (value-type int)))) (expr
+        (simple-var-ref A))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref r))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref B)
+          (value-type readonly)))))
+    (var-def
+      (variable m (type
+        (constrained-type
+          (builtin-ref-type map)
+          (value-type any))) (expr
+        (simple-var-ref B))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (index-based-access
+            (simple-var-ref m)
+            (literal x))
+          (value-type readonly)))))
+  )
+)

--- a/corpus/cfg/subset8/08-const/readonly-record-v.txt
+++ b/corpus/cfg/subset8/08-const/readonly-record-v.txt
@@ -1,0 +1,34 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (value-type any)) (expr
+        (simple-var-ref A))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref a)
+          (value-type readonly)))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref a)
+          (intersection-type
+            (value-type readonly)
+            (user-defined-type R))))))
+    (var-def
+      (variable r (type
+        (intersection-type
+          (value-type readonly)
+          (user-defined-type R))) (expr
+        (simple-var-ref A))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref r))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref A)
+          (user-defined-type R)))))
+  )
+)

--- a/corpus/cfg/subset8/08-const/readonly-tuple-v.txt
+++ b/corpus/cfg/subset8/08-const/readonly-tuple-v.txt
@@ -1,0 +1,51 @@
+(main
+  (bb0 () ()
+    (var-def
+      (variable a (type
+        (value-type any)) (expr
+        (simple-var-ref A))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref a)
+          (value-type readonly)))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref a)
+          (tuple-type
+            (finite-type
+              (literal 1))
+            (finite-type
+              (literal two)))))))
+    (var-def
+      (variable r (type
+        (intersection-type
+          (value-type readonly)
+          (tuple-type
+            (value-type int)
+            (value-type string)))) (expr
+        (simple-var-ref A))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref r))))
+    (var-def
+      (variable b (type
+        (value-type any)) (expr
+        (simple-var-ref B))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref b)
+          (value-type readonly)))))
+    (expression-stmt
+      (invocation io println (
+        (type-test-expr is
+          (simple-var-ref b)
+          (intersection-type
+            (value-type readonly)
+            (tuple-type
+              (value-type int) (rest
+                (value-type int))))))))
+  )
+)

--- a/corpus/desugared/subset8/08-const/readonly-list-v.txt
+++ b/corpus/desugared/subset8/08-const/readonly-list-v.txt
@@ -1,0 +1,69 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (literal [1,2]))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (value-type readonly)))))
+      (var-def
+        (variable r (type
+          (intersection-type
+            (value-type readonly)
+            (array-type
+              (value-type byte) dimensions: 1 ([])))) (expr
+          (literal [1,2]))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref r))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (array-type
+              (value-type byte) dimensions: 1 ([
+              (literal 2)]))))))
+      (var-def
+        (variable b (type
+          (value-type any)) (expr
+          (literal [3,4]))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref b)
+            (intersection-type
+              (value-type readonly)
+              (array-type
+                (value-type int) dimensions: 1 ([])))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref b)
+            (tuple-type
+              (finite-type
+                (literal 3))
+              (finite-type
+                (literal 4)))))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (literal [[1,2],[3,4]])
+            (value-type readonly)))))
+      (var-def
+        (variable nested (type
+          (array-type
+            (value-type any) dimensions: 1 ([]))) (expr
+          (literal [[1,2],[3,4]]))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (index-based-access
+              (simple-var-ref nested)
+              (literal 0))
+            (value-type readonly))))))))

--- a/corpus/desugared/subset8/08-const/readonly-map-v.txt
+++ b/corpus/desugared/subset8/08-const/readonly-map-v.txt
@@ -1,0 +1,50 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (literal {"a":1}))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (value-type readonly)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (record-type
+              (field a
+                (value-type int)))))))
+      (var-def
+        (variable r (type
+          (intersection-type
+            (value-type readonly)
+            (constrained-type
+              (builtin-ref-type map)
+              (value-type int)))) (expr
+          (literal {"a":1}))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref r))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (literal {"x":{"y":2}})
+            (value-type readonly)))))
+      (var-def
+        (variable m (type
+          (constrained-type
+            (builtin-ref-type map)
+            (value-type any))) (expr
+          (literal {"x":{"y":2}}))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (index-based-access
+              (simple-var-ref m)
+              (literal x))
+            (value-type readonly))))))))

--- a/corpus/desugared/subset8/08-const/readonly-record-v.txt
+++ b/corpus/desugared/subset8/08-const/readonly-record-v.txt
@@ -1,0 +1,41 @@
+(package
+  (import-package ballerina io (as io))
+  (type-definition R
+    (record-type
+      (field x
+        (value-type int))
+      (field y
+        (value-type string))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (literal {"x":1,"y":"two"}))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (value-type readonly)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (intersection-type
+              (value-type readonly)
+              (user-defined-type R))))))
+      (var-def
+        (variable r (type
+          (intersection-type
+            (value-type readonly)
+            (user-defined-type R))) (expr
+          (literal {"x":1,"y":"two"}))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref r))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (literal {"x":1,"y":"two"})
+            (user-defined-type R))))))))

--- a/corpus/desugared/subset8/08-const/readonly-tuple-v.txt
+++ b/corpus/desugared/subset8/08-const/readonly-tuple-v.txt
@@ -1,0 +1,52 @@
+(package
+  (import-package ballerina io (as io))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable a (type
+          (value-type any)) (expr
+          (literal [1,"two"]))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (value-type readonly)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref a)
+            (tuple-type
+              (finite-type
+                (literal 1))
+              (finite-type
+                (literal two)))))))
+      (var-def
+        (variable r (type
+          (intersection-type
+            (value-type readonly)
+            (tuple-type
+              (value-type int)
+              (value-type string)))) (expr
+          (literal [1,"two"]))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref r))))
+      (var-def
+        (variable b (type
+          (value-type any)) (expr
+          (literal [1,2,3]))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref b)
+            (value-type readonly)))))
+      (expression-stmt
+        (invocation io println (
+          (type-test-expr is
+            (simple-var-ref b)
+            (intersection-type
+              (value-type readonly)
+              (tuple-type
+                (value-type int) (rest
+                  (value-type int)))))))))))

--- a/corpus/integration/subset8/08-const/readonly-list-v.txtar
+++ b/corpus/integration/subset8/08-const/readonly-list-v.txtar
@@ -1,0 +1,9 @@
+-- stdout --
+true
+[1,2]
+true
+true
+true
+true
+true
+-- stderr --

--- a/corpus/integration/subset8/08-const/readonly-map-v.txtar
+++ b/corpus/integration/subset8/08-const/readonly-map-v.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+true
+true
+{"a":1}
+true
+true
+-- stderr --

--- a/corpus/integration/subset8/08-const/readonly-record-v.txtar
+++ b/corpus/integration/subset8/08-const/readonly-record-v.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+true
+true
+{"x":1,"y":"two"}
+true
+-- stderr --

--- a/corpus/integration/subset8/08-const/readonly-tuple-v.txtar
+++ b/corpus/integration/subset8/08-const/readonly-tuple-v.txtar
@@ -1,0 +1,7 @@
+-- stdout --
+true
+true
+[1,"two"]
+true
+true
+-- stderr --

--- a/semantics/internal/types/constant_evaluator.go
+++ b/semantics/internal/types/constant_evaluator.go
@@ -132,12 +132,48 @@ func (e *constantExpressionEvaluator) evaluateMappingConstructor(expr *ast.BLang
 		entries = append(entries, values.MapEntry{Key: key, Value: value})
 	}
 
-	ty := expr.GetDeterminedType()
-	atomic := semtypes.ToMappingAtomicType(e.resolver.typeContext(), ty)
-	if atomic == nil {
-		return nil, fmt.Errorf("constant mapping type is not atomic")
+	ty, atomic, err := readonlyMappingShapeType(e.resolver, entries)
+	if err != nil {
+		return nil, err
 	}
 	return values.NewMap(ty, atomic, true, entries), nil
+}
+
+// The type of a constant is the intersection of readonly and the singleton type
+// containing just the shape of its value (spec §8.8). readonlyListShapeType and
+// readonlyMappingShapeType build that type from the evaluated members, so it is
+// a single list or mapping atom rather than an intersection: both the BIR
+// deserializer and the inherent type checks on the value require an atomic type.
+func readonlyListShapeType(t typeResolver, members []values.BalValue) (semtypes.SemType,
+	*semtypes.ListAtomicType, error,
+) {
+	memberTypes := make([]semtypes.SemType, len(members))
+	for i, member := range members {
+		memberTypes[i] = values.SemTypeForValue(member)
+	}
+	ld := semtypes.NewListDefinition()
+	ty := ld.Define(t.typeEnv(), memberTypes, semtypes.ListMutability(semtypes.CellMutabilityNone))
+	atomic := semtypes.ToListAtomicType(t.typeEnv(), ty)
+	if atomic == nil {
+		return semtypes.SemType{}, nil, fmt.Errorf("constant list type is not atomic")
+	}
+	return ty, atomic, nil
+}
+
+func readonlyMappingShapeType(t typeResolver, entries []values.MapEntry) (semtypes.SemType,
+	*semtypes.MappingAtomicType, error,
+) {
+	fields := make([]semtypes.Field, 0, len(entries))
+	for _, entry := range entries {
+		fields = append(fields, semtypes.FieldFrom(entry.Key, values.SemTypeForValue(entry.Value), true, false))
+	}
+	md := semtypes.NewMappingDefinition()
+	ty := md.Define(t.typeEnv(), fields, semtypes.Never, semtypes.MappingMutability(semtypes.CellMutabilityNone))
+	atomic := semtypes.ToMappingAtomicType(t.typeContext(), ty)
+	if atomic == nil {
+		return semtypes.SemType{}, nil, fmt.Errorf("constant mapping type is not atomic")
+	}
+	return ty, atomic, nil
 }
 
 func constantMappingKey(key *ast.BLangMappingKey) (string, bool) {
@@ -181,8 +217,11 @@ func (e *constantExpressionEvaluator) evaluateListConstructor(expr *ast.BLangLis
 		}
 		initial = append(initial, filler())
 	}
-	restFiller, _ := values.FillerFactoryFor(e.resolver.typeContext(), expr.AtomicType.Rest())
-	return values.NewList(expr.GetDeterminedType(), &expr.AtomicType, true, restFiller, len(initial), initial), nil
+	ty, atomic, err := readonlyListShapeType(e.resolver, initial)
+	if err != nil {
+		return nil, err
+	}
+	return values.NewList(ty, atomic, true, nil, len(initial), initial), nil
 }
 
 func (e *constantExpressionEvaluator) evaluateUnaryExpression(expr *ast.BLangUnaryExpr) (values.BalValue, error) {

--- a/semantics/internal/types/type_resolver.go
+++ b/semantics/internal/types/type_resolver.go
@@ -7860,8 +7860,15 @@ func resolveConstant(t typeResolver, constant *ast.BLangVariable) bool {
 		sym.SetConstantValue(value)
 	}
 
-	// TODO: I am not sure if this is strictly correct given expression type would have changed based on the contextually expected type in things like structure constructor expressions.
+	// The type of a constant is the intersection of readonly and the singleton
+	// type containing just the shape of its value (spec §8.8). The evaluated
+	// value carries that type, so taking it from there keeps the symbol type and
+	// the value in agreement. exprTy is the fallback for a constant whose value
+	// could not be evaluated; that is always a reported error.
 	expectedType := exprTy
+	if err == nil {
+		expectedType = values.SemTypeForValue(value)
+	}
 	setExpectedType(constant, expectedType)
 	symbol := constant.Symbol()
 	t.setSymbolType(symbol, expectedType)


### PR DESCRIPTION
## Purpose

Resolves #891.

Spec §8.8: *"The type of the constant is the intersection of `readonly` and the singleton type containing just the shape of the value named by the constant."* For a constant of a structured type we gave it neither the `readonly` intersection nor the singleton — the constant got the initializer's plain mutable type. The value itself was already readonly at runtime (mutating through an alias panics), only its type disagreed.

That showed up as:

- `CL is readonly` → `false` for `const byte[] CL = [1, 2];`
- `readonly & byte[] r = CL;` → `error[SEMANTIC_ERROR]: incompatible type: expected readonly&[int:Unsigned8...], got [int:Unsigned8...]`, so a const byte array could not be passed where `io:Block` is expected
- `CL is byte[2]` → `false`; the type was not the singleton either

This is the first of a stacked set of PRs; the byte-array-literal work (#869) sits on top of it and inherits both defects.

## Approach

Two sites, matching the two defects in the issue.

**`semantics/internal/types/constant_evaluator.go`** — the constant evaluator hardcoded `isReadonly = true` on the value while taking its `SemType` from resolution, which builds it with the default `CellMutabilityLimited`. So `values.List`/`values.Map` carried readonly-ness two ways that disagreed, and `x is readonly` (which reads the semtype) said `false`.

`readonlyListShapeType` / `readonlyMappingShapeType` now build the type from the *evaluated members* with `CellMutabilityNone`, so it is the readonly singleton shape type. They define it as a single list or mapping atom rather than an intersection, because both the BIR deserializer and the inherent type checks on the value require an atomic type.

**`semantics/internal/types/type_resolver.go`** — `resolveConstant` set the symbol type to the initializer's type verbatim (the site of the pre-existing `// TODO: I am not sure if this is strictly correct...`). It now takes the symbol type from the evaluated value, so the symbol type and the value's inherent type are the same type by construction. `exprTy` remains the fallback for a constant whose value could not be evaluated — always an already-reported error.

## Automation tests

Four corpus cases under `corpus/bal/subset8/08-const/`, covering the repros in the issue plus the combinations that the shared shape-type path could break:

- `readonly-list-v.bal` — `const byte[]`, `const int[]`, inferred nested `const`; `is readonly`, `readonly & byte[]` assignment, singleton `is byte[2]`, and that a nested member is readonly too
- `readonly-tuple-v.bal` — `[int, string]` and a rest-typed `[int, int...]`
- `readonly-map-v.bal` — `map<int>`, nested `map<map<int>>`, and that the map constant matches a closed record type
- `readonly-record-v.bal` — a record-typed constant against `R`, `readonly & R`

`make build`, `make vet` and the full test suite pass.

## Security checks

- Followed secure coding standards: yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Documentation

N/A — bug fix bringing constant typing in line with the existing spec, no user-facing doc change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved constant evaluation for readonly lists, maps, records, and tuples.
  - Constant values now preserve accurate readonly type information, including nested collections and inferred shapes.
  - Improved handling of constant type resolution when evaluating collection literals.

- **Tests**
  - Added coverage validating readonly checks, type assignments, nested values, and expected output for constant collection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->