### PR TITLE
refactor(codec): remove BIR and symbol pool versions

### DIFF
--- a/bir/codec/SPEC.md
+++ b/bir/codec/SPEC.md
@@ -8,8 +8,6 @@ The BIR binary file has the following structure:
 +------------------+
 | Magic (4 bytes)  | 0xBA 0x10 0xC0 0xDE
 +------------------+
-| Version (4 bytes)| int32 (currently 82)
-+------------------+
 | Constant Pool    | See Constant Pool Format
 +------------------+
 | Package Data     | See Package Structure

--- a/bir/codec/deserializer.go
+++ b/bir/codec/deserializer.go
@@ -58,13 +58,6 @@ func (br *birReader) readPackage() (pkg *bir.BIRPackage, err error) {
 		panic(fmt.Sprintf("invalid BIR magic: %x", magic))
 	}
 
-	var version int32
-	br.read(&version)
-
-	if version != BIR_VERSION {
-		panic(fmt.Sprintf("unsupported BIR version: %d", version))
-	}
-
 	br.readTypePool()
 	br.readConstantPool()
 

--- a/bir/codec/serializer.go
+++ b/bir/codec/serializer.go
@@ -29,10 +29,7 @@ import (
 	"github.com/ballerina-nutcracker/ballerina/values"
 )
 
-const (
-	BIR_MAGIC   = "\xba\x10\xc0\xde"
-	BIR_VERSION = 84
-)
+const BIR_MAGIC = "\xba\x10\xc0\xde"
 
 type birWriter struct {
 	cp           *ConstantPool
@@ -70,8 +67,6 @@ func (bw *birWriter) serialize(pkg *bir.BIRPackage) (result []byte, err error) {
 	if err != nil {
 		panic(fmt.Sprintf("writing BIR magic: %v", err))
 	}
-
-	write(buf, int32(BIR_VERSION))
 
 	tpBytes := semtypes.MarshalTypePool(bw.tp, bw.env).Bytes()
 	write(buf, int64(len(tpBytes)))

--- a/model/symbolpool/deserializer.go
+++ b/model/symbolpool/deserializer.go
@@ -62,12 +62,6 @@ func (sr *symbolReader) deserialize() (result model.ExportedSymbolSpace, err err
 		panic(fmt.Sprintf("invalid symbol magic: %x", magic))
 	}
 
-	var version int32
-	read(sr.r, &version)
-	if version != symVersion {
-		panic(fmt.Sprintf("unsupported symbol version: %d", version))
-	}
-
 	var tpSize int64
 	read(sr.r, &tpSize)
 	tpBytes := make([]byte, tpSize)

--- a/model/symbolpool/serializer.go
+++ b/model/symbolpool/serializer.go
@@ -27,10 +27,7 @@ import (
 	"github.com/ballerina-nutcracker/ballerina/values"
 )
 
-const (
-	symMagic   = "\x53\x59\x4d\x42"
-	symVersion = 10
-)
+const symMagic = "\x53\x59\x4d\x42"
 
 const (
 	symTagType uint8 = iota
@@ -128,9 +125,6 @@ func (sw *symbolWriter) serialize(exported model.ExportedSymbolSpace) ([]byte, e
 	buf := &bytes.Buffer{}
 	if _, err := buf.Write([]byte(symMagic)); err != nil {
 		return nil, fmt.Errorf("writing magic: %v", err)
-	}
-	if err := write(buf, int32(symVersion)); err != nil {
-		return nil, err
 	}
 	tpBytes := tpEncoding.Bytes()
 	if err := write(buf, int64(len(tpBytes))); err != nil {


### PR DESCRIPTION
## Summary
- remove version fields from serialized BIR data
- remove version fields from serialized symbol pools

## Testing
- `go test ./...`

Closes #908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated serialized BIR and symbol data formats to omit embedded version metadata.
  * Updated data readers to process content directly after the format identifier without version checks.
  * Updated the BIR format specification to reflect the revised file structure.
  * Existing serialized data that depends on the removed version field may require regeneration or compatibility review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->