### PR TITLE
feat: testerina poc

### DIFF
--- a/INTENT.md
+++ b/INTENT.md
@@ -1,0 +1,61 @@
+# Test framework design
+
+## Requirements
+
+- We will initially support a simplified subset of `ballerina/test` to validate the design
+  - No special packages -> no special visibility rules
+  - Only `enable`, `before` and `after` configurations
+  - Support filtering (jBallerina: `--tests fn1,fn2` with `module:fn` and `*` wildcards)
+  - No support for mocking
+  - Support only `assertFail` in testerina
+    ```ballerina
+    function assertFail(string msg) returns never
+    ```
+
+## Design
+- Test function will be annotated with `Config` annotation that can be attached to functions
+```ballerina
+// ballerina/test lib
+type TestConfig record {|
+  boolean enable = true
+  function() returns ((any|error)) before?
+  function() returns ((any|error)) after?
+|};
+
+public annotation TestConfig Config on function;
+```
+- We will introduce a new command `test` (similar to `build` and `run`). When you run `bal test` this will use a additional compiler plugin (in addition to what we normally include for `run` and `build`) when a module import `ballerina/test`
+  - Ideally I would like this keep the definition of this in a separate package but I don't think this can be in the declaration of `ballerina/test` (we don't want project api to depend on libararies) perhaps a separate `testarina` module?
+  - For normal `run`, `build` we treat the annotation as no-op 
+
+- This compiler plugin reads all these annoatiations and build a `TestPlan` struct which is roughly
+```go
+type TestPlan struct {
+  ModuleTests map[ModuleKey][]TestFunction // ModuleKey is org/module, the runtime lookup identity
+}
+
+type FunctionRef struct {
+  Org, Module, Name string // empty means nothing; before/after may live in another module
+}
+
+type TestFunction struct {
+  Name string
+  Enabled bool
+  Before FunctionRef
+  After FunctionRef
+}
+```
+
+- After we have build these struct (ideally I would like to keep this in the CLI side so I assume allocate the struct wrap it in the compiler plugin and pass it in to project api) we continue until we have loaded all the BIR packages to runtime (I think we can engage the compiler plugin just before desuger). CLI should get the runtime at this point so it can manually start executing functions
+
+- It should then do `init` fallowed by start `listening` in a non-blocking manner
+  - So any services that tests may depend on are up
+
+- Then it builds an execution graph for tests: an ordered list of steps (modules in topological order, tests in source order, filtered by `--tests`), each step being before -> test -> after. Flat list for now; becomes a DAG when `dependsOn` is added
+
+- Then we start executing each test showing the status in a nice form (use something like bubletee if needed)
+  - I think current runtime API's give you what you need to implement this but we need to seperate the test data, execution graph and execution (last on top of current API)
+  - Show progress updating and at the end only show test failures
+
+- I imagine PAL needs to give a way to indicate testFailure that `assertFail` implementation can use
+  - And CLI given it creates the PAL and inject a call back via PAL to detect test failures

--- a/cli/cmd/bal.go
+++ b/cli/cmd/bal.go
@@ -52,6 +52,7 @@ func main() {
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(packCmd)
 	rootCmd.AddCommand(buildCmd)
+	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(pushCmd)
 	rootCmd.AddCommand(versionCmd)
 

--- a/cli/cmd/test.go
+++ b/cli/cmd/test.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ballerina-nutcracker/ballerina/bir"
+	"github.com/ballerina-nutcracker/ballerina/cli/internal/nativeexec"
+	"github.com/ballerina-nutcracker/ballerina/cli/internal/testerina"
+	debugcommon "github.com/ballerina-nutcracker/ballerina/common"
+	"github.com/ballerina-nutcracker/ballerina/compilerplugin"
+	_ "github.com/ballerina-nutcracker/ballerina/lib/rt"
+	"github.com/ballerina-nutcracker/ballerina/platform/palnative"
+	"github.com/ballerina-nutcracker/ballerina/projects"
+	"github.com/ballerina-nutcracker/ballerina/runtime"
+	"github.com/ballerina-nutcracker/ballerina/semtypes"
+	"github.com/ballerina-nutcracker/ballerina/tools/diagnostics"
+
+	"github.com/spf13/cobra"
+)
+
+type testOptions struct {
+	tests            string
+	list             bool
+	dumpTokens       bool
+	dumpST           bool
+	dumpAST          bool
+	dumpRecoveredAST bool
+	dumpCFG          bool
+	dumpBIR          bool
+	traceRecovery    bool
+	stats            bool
+	statsOneline     bool
+	logFile          string
+	format           string
+}
+
+var testCmd = createTestCmd()
+
+func createTestCmd() *cobra.Command {
+	opts := &testOptions{}
+	cmd := &cobra.Command{
+		Use:   "test [<package-dir> | .]",
+		Short: "Compile the current package and run its tests",
+		Long: `	Compile the current Ballerina package and run its tests.
+
+	Every function annotated with '@test:Config' in the current package is
+	executed against a live runtime, in module dependency order and in source
+	order within each module.
+
+	As in 'bal run', module initialization runs first: each module's 'init()'
+	is invoked and the root module's 'main()' runs if it declares one.
+
+	Use --tests to run a subset of the tests and --list to print the tests
+	that would run without running them.
+
+	Note: Testing individual '.bal' files of a package is not allowed.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTests(cmd, args, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.tests, "tests", "", "Comma-separated test filters ([<module>:]<name>, '*' wildcard)")
+	cmd.Flags().BoolVar(&opts.list, "list", false, "List the tests that would run and exit")
+	cmd.Flags().BoolVar(&opts.dumpTokens, "dump-tokens", false, "Dump lexer tokens")
+	cmd.Flags().BoolVar(&opts.dumpST, "dump-st", false, "Dump syntax tree")
+	cmd.Flags().BoolVar(&opts.dumpAST, "dump-ast", false, "Dump abstract syntax tree")
+	cmd.Flags().BoolVar(&opts.dumpRecoveredAST, "dump-recovered-ast", false, "Dump recovered abstract syntax tree")
+	cmd.Flags().BoolVar(&opts.dumpCFG, "dump-cfg", false, "Dump control flow graph")
+	cmd.Flags().BoolVar(&opts.dumpBIR, "dump-bir", false, "Dump Ballerina Intermediate Representation")
+	cmd.Flags().BoolVar(&opts.traceRecovery, "trace-recovery", false, "Enable error recovery tracing")
+	cmd.Flags().BoolVar(&opts.stats, "stats", false, "Print per-stage compilation timing statistics")
+	cmd.Flags().BoolVar(&opts.statsOneline, "stats-oneline", false, "Print per-stage compilation timing totals only")
+	cmd.Flags().StringVar(&opts.logFile, "log-file", "", "Write debug output to specified file")
+	cmd.Flags().StringVar(&opts.format, "format", "", "Output format for dump operations (dot)")
+	return cmd
+}
+
+func testError(format string, args ...any) error {
+	return usageError("test [<package-dir> | .]", format, args...)
+}
+
+func runTests(cmd *cobra.Command, args []string, opts *testOptions) error {
+	stderr := cmd.ErrOrStderr()
+
+	filter, err := testerina.ParseFilter(opts.tests)
+	if err != nil {
+		return testError("%w", err)
+	}
+
+	buildOpts := projects.NewBuildOptionsBuilder().
+		WithDumpAST(opts.dumpAST).
+		WithDumpRecoveredAST(opts.dumpRecoveredAST).
+		WithDumpBIR(opts.dumpBIR).
+		WithDumpCFG(opts.dumpCFG).
+		WithDumpCFGFormat(projects.ParseCFGFormat(opts.format)).
+		WithDumpTokens(opts.dumpTokens).
+		WithDumpST(opts.dumpST).
+		WithTraceRecovery(opts.traceRecovery).
+		WithStats(opts.stats || opts.statsOneline).
+		Build()
+
+	debugFlags := uint16(0)
+	if buildOpts.DumpTokens() {
+		debugFlags |= debugcommon.DUMP_TOKENS
+	}
+	if buildOpts.DumpST() {
+		debugFlags |= debugcommon.DUMP_ST
+	}
+	if buildOpts.TraceRecovery() {
+		debugFlags |= debugcommon.DEBUG_ERROR_RECOVERY
+	}
+	if debugFlags != 0 {
+		if opts.logFile != "" {
+			logWriter, err := os.Create(opts.logFile)
+			if err != nil {
+				return testError("error creating log file %s: %w", opts.logFile, err)
+			}
+			defer func() { _ = logWriter.Close() }()
+			debugcommon.InitDebug(debugFlags, logWriter)
+		} else {
+			debugcommon.InitDebug(debugFlags, stderr)
+		}
+	}
+
+	path := "."
+	if len(args) > 0 {
+		path = args[0]
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return testError("%w", err)
+	}
+	if !info.IsDir() {
+		return testError("cannot test a single source file; 'bal test' requires a package")
+	}
+	absBaseDir, err := filepath.Abs(path)
+	if err != nil {
+		return testError("%w", err)
+	}
+
+	workspaceRoot := findWorkspaceRoot(absBaseDir)
+	fsys := os.DirFS(path)
+	loadPath := "."
+	if workspaceRoot != "" {
+		fsys = os.DirFS(workspaceRoot)
+	}
+
+	ballerinaEnvPath, err := getBallerinaEnvPath()
+	if err != nil {
+		return testError("%w", err)
+	}
+
+	collector := testerina.NewCollector()
+	result, err := projects.Load(fsys, loadPath, projects.ProjectLoadConfig{
+		BallerinaEnvFs:  os.DirFS(ballerinaEnvPath),
+		BuildOptions:    &buildOpts,
+		CompilerPlugins: []compilerplugin.InjectedPlugin{collector.Plugin()},
+	})
+	if err != nil {
+		return testError("%w", err)
+	}
+	if result.Diagnostics().HasErrors() {
+		printDiagnostics(fsys, stderr, result.Diagnostics(), !isTerminal(), diagnostics.NewDiagnosticEnv())
+		return fmt.Errorf("project loading contains errors")
+	}
+
+	project, err := testProject(result.Project(), workspaceRoot, absBaseDir)
+	if err != nil {
+		return err
+	}
+	pkg := project.CurrentPackage()
+
+	if !nativeexec.InNativeMode() {
+		if err := execWithNativeRunner(pkg, project, absBaseDir); err != nil {
+			return testError("%w", err)
+		}
+	}
+
+	birPkgs, err := compilePackageForTests(cmd, fsys, pkg, project.Environment().TypeEnv(), opts)
+	if err != nil {
+		return err
+	}
+
+	schedule := testerina.NewSchedule(collector.Plan(rootModuleOrder(pkg)), filter)
+	if opts.list {
+		printTestList(cmd.OutOrStdout(), schedule)
+		return nil
+	}
+	return executeSchedule(cmd, project.Environment(), birPkgs, schedule)
+}
+
+// testProject narrows a loaded workspace to the member package under test.
+func testProject(project projects.Project, workspaceRoot, absBaseDir string) (projects.Project, error) {
+	if project.Kind() != projects.ProjectKindWorkspace {
+		return project, nil
+	}
+	workspace, ok := project.(*projects.WorkspaceProject)
+	if !ok {
+		return nil, testError("internal error: expected WorkspaceProject")
+	}
+	if workspaceRoot == "" || absBaseDir == workspaceRoot {
+		return nil, testError(
+			"cannot test a workspace project directly. Use 'bal test <package-path>' to test a specific package within the workspace")
+	}
+	buildProject := findBuildProjectByPath(workspace, workspaceRoot, absBaseDir)
+	if buildProject == nil {
+		return nil, testError("no package found at path %s within workspace %s", absBaseDir, workspaceRoot)
+	}
+	return buildProject, nil
+}
+
+func compilePackageForTests(
+	cmd *cobra.Command, fsys fs.FS, pkg *projects.Package, tyEnv semtypes.Env, opts *testOptions,
+) ([]*bir.BIRPackage, error) {
+	stderr := cmd.ErrOrStderr()
+	compilation := pkg.Compilation()
+	compilationDiags := compilation.DiagnosticResult()
+	if compilationDiags.DiagnosticCount() > 0 {
+		printDiagnostics(fsys, stderr, compilationDiags, !isTerminal(), compilation.DiagnosticEnv())
+	}
+	if compilationDiags.HasErrors() {
+		return nil, fmt.Errorf("compilation contains errors")
+	}
+
+	backend := projects.NewBallerinaBackend(compilation)
+	if backend.DiagnosticResult().HasErrors() {
+		printDiagnostics(fsys, stderr, backend.DiagnosticResult(), !isTerminal(), compilation.DiagnosticEnv())
+		return nil, fmt.Errorf("BIR generation failed")
+	}
+	birPkgs := backend.BIRPackages()
+	if len(birPkgs) == 0 {
+		return nil, fmt.Errorf("BIR generation failed: no BIR package produced")
+	}
+
+	if opts.statsOneline {
+		_, _ = fmt.Fprint(stderr, compilation.StatsReportOneline())
+	} else if opts.stats {
+		_, _ = fmt.Fprint(stderr, compilation.StatsReport())
+	}
+	if opts.dumpBIR {
+		dumpRootPackageBIR(stderr, pkg, tyEnv, birPkgs)
+	}
+	return birPkgs, nil
+}
+
+// dumpRootPackageBIR prints the BIR of the root package's own modules, as run
+// does; dependency packages are left out.
+func dumpRootPackageBIR(w io.Writer, pkg *projects.Package, tyEnv semtypes.Env, birPkgs []*bir.BIRPackage) {
+	prettyPrinter := bir.PrettyPrinter{}
+	tyCtx := semtypes.ContextFrom(tyEnv)
+	rootOrgName := pkg.PackageOrg().Value()
+	rootPkgName := pkg.PackageName().Value()
+	for _, birPkg := range birPkgs {
+		if birPkg.PackageID.OrgName.Value() != rootOrgName || birPkg.PackageID.PkgName.Value() != rootPkgName {
+			continue
+		}
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "==================BEGIN BIR==================")
+		_, _ = fmt.Fprintln(w, strings.TrimSpace(prettyPrinter.Print(tyCtx, *birPkg)))
+		_, _ = fmt.Fprintln(w, "===================END BIR===================")
+	}
+}
+
+// rootModuleOrder returns the root package's modules in topological order.
+func rootModuleOrder(pkg *projects.Package) []testerina.ModuleKey {
+	rootDescriptor := pkg.Descriptor()
+	var order []testerina.ModuleKey
+	for _, module := range pkg.Compilation().Resolution().ModuleDependencyGraph().ToTopologicallySortedList() {
+		if !module.PackageDescriptor().Equals(rootDescriptor) {
+			continue
+		}
+		order = append(order, testerina.ModuleKey{
+			Org: module.Org().Value(), Module: module.Name().String(),
+		})
+	}
+	return order
+}
+
+func printTestList(w io.Writer, schedule testerina.Schedule) {
+	for _, step := range schedule.Steps {
+		_, _ = fmt.Fprint(w, step.Label())
+		if !step.Test.Enabled {
+			_, _ = fmt.Fprint(w, " (disabled)")
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+}
+
+// executeSchedule initializes the runtime with the test PAL overrides installed
+// and runs the schedule against it.
+func executeSchedule(
+	cmd *cobra.Command, env *projects.Environment, birPkgs []*bir.BIRPackage, schedule testerina.Schedule,
+) error {
+	platform, cleanupSignals := palnative.NewPlatform()
+	defer cleanupSignals()
+
+	// The runner must exist before NewRuntime: extern.InitEnv copies
+	// pal.Platform by value, so every override has to be in place first.
+	runner := testerina.NewRunner(platform, platform.Signals.Signals, env.TypeEnv())
+	rt := runtime.NewRuntime(runner.Platform(), env.TypeEnv())
+
+	for _, birPkg := range birPkgs {
+		if err := rt.Init(*birPkg); err != nil {
+			// Runtime errors carry their own stack-trace-like format; printing
+			// them verbatim keeps them readable.
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err)
+			cmd.SilenceErrors = true
+			rt.Listen()
+			runner.Shutdown(rt)
+			return err
+		}
+	}
+	rt.Listen()
+	runner.Start(rt)
+
+	reporter := testerina.NewPlainReporter(cmd.OutOrStdout())
+	if isTerminal() {
+		reporter = testerina.NewTTYReporter(cmd.OutOrStdout())
+	}
+	summary := runner.Run(schedule, reporter)
+	// Graceful-stop handlers only run inside Shutdown, so a failure they report
+	// lands after Run's own snapshot.
+	runner.Shutdown(rt)
+	summary.RunFailures = runner.RunFailures()
+	reporter.End(summary)
+
+	if summary.Failed() {
+		cmd.SilenceErrors = true
+		return fmt.Errorf("tests failed")
+	}
+	return nil
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,27 +5,28 @@ go 1.27
 toolchain go1.27.1
 
 require (
+	github.com/ballerina-nutcracker/ballerina/ast v0.7.0
 	github.com/ballerina-nutcracker/ballerina/bir v0.7.0
 	github.com/ballerina-nutcracker/ballerina/common v0.7.0
+	github.com/ballerina-nutcracker/ballerina/compilerplugin v0.7.0
 	github.com/ballerina-nutcracker/ballerina/context v0.7.0
 	github.com/ballerina-nutcracker/ballerina/lib v0.7.0
+	github.com/ballerina-nutcracker/ballerina/model v0.7.0
 	github.com/ballerina-nutcracker/ballerina/platform v0.7.0
 	github.com/ballerina-nutcracker/ballerina/projects v0.7.0
 	github.com/ballerina-nutcracker/ballerina/runtime v0.7.0
 	github.com/ballerina-nutcracker/ballerina/semtypes v0.7.0
 	github.com/ballerina-nutcracker/ballerina/tools v0.7.0
+	github.com/ballerina-nutcracker/ballerina/values v0.7.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.43.0
 )
 
 require (
-	github.com/ballerina-nutcracker/ballerina/ast v0.7.0 // indirect
 	github.com/ballerina-nutcracker/ballerina/decimal v0.7.0 // indirect
 	github.com/ballerina-nutcracker/ballerina/desugar v0.7.0 // indirect
-	github.com/ballerina-nutcracker/ballerina/model v0.7.0 // indirect
 	github.com/ballerina-nutcracker/ballerina/parser v0.7.0 // indirect
 	github.com/ballerina-nutcracker/ballerina/semantics v0.7.0 // indirect
-	github.com/ballerina-nutcracker/ballerina/values v0.7.0 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/cli/internal/testerina/collector.go
+++ b/cli/internal/testerina/collector.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testerina
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/ballerina-nutcracker/ballerina/ast"
+	"github.com/ballerina-nutcracker/ballerina/compilerplugin"
+	compilercontext "github.com/ballerina-nutcracker/ballerina/context"
+	"github.com/ballerina-nutcracker/ballerina/model"
+	"github.com/ballerina-nutcracker/ballerina/values"
+)
+
+const (
+	testOrg        = "ballerina"
+	testModule     = "test"
+	configAnnName  = "Config"
+	enableField    = "enable"
+	beforeField    = "before"
+	afterField     = "after"
+	mainFunction   = "main"
+	initFunction   = "init"
+	configAnnLabel = "@test:Config"
+)
+
+// Collector owns the injected compiler plugin and accumulates the tests
+// discovered in each module it runs on.
+type Collector struct {
+	mu      sync.Mutex
+	modules map[ModuleKey]ModuleTests
+}
+
+func NewCollector() *Collector {
+	return &Collector{modules: make(map[ModuleKey]ModuleTests)}
+}
+
+// Plugin returns the compiler plugin the CLI injects into the compilation.
+func (c *Collector) Plugin() compilerplugin.InjectedPlugin {
+	return compilerplugin.InjectedPlugin{
+		Provider: compilerplugin.Provider{Org: testOrg, Package: testModule},
+		Plugin: compilerplugin.CompilerPlugin{
+			After:              compilerplugin.AfterSemantics,
+			PackageTransformer: c.collect,
+		},
+	}
+}
+
+// Plan returns the collected tests with modules in order, dropping modules
+// with no tests and sorting each module's tests into source order.
+func (c *Collector) Plan(order []ModuleKey) TestPlan {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	plan := TestPlan{}
+	for _, key := range order {
+		tests, ok := c.modules[key]
+		if !ok || len(tests.Tests) == 0 {
+			continue
+		}
+		slices.SortFunc(tests.Tests, func(a, b TestFunction) int {
+			if a.Position.FileIndex() != b.Position.FileIndex() {
+				return a.Position.FileIndex() - b.Position.FileIndex()
+			}
+			return a.Position.StartOffset() - b.Position.StartOffset()
+		})
+		plan.Modules = append(plan.Modules, tests)
+	}
+	return plan
+}
+
+// collect runs as the injected plugin's package transformer. It is called once
+// per qualifying module, concurrently with the other modules.
+func (c *Collector) collect(
+	compilerCtx *compilercontext.CompilerContext,
+	_ model.ExportedSymbolSpace,
+	pkg *ast.BLangPackage,
+) (*ast.BLangPackage, error) {
+	key := ModuleKey{Org: pkg.PackageID.OrgName.Value(), Module: pkg.PackageID.PkgName.Value()}
+	var tests []TestFunction
+	for _, fn := range pkg.Functions {
+		attachment, ok := configAnnotation(compilerCtx, fn)
+		if !ok {
+			continue
+		}
+		test, ok := testFunctionFrom(compilerCtx, fn, attachment)
+		if !ok {
+			continue
+		}
+		tests = append(tests, test)
+	}
+	if len(tests) > 0 {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		existing := c.modules[key]
+		existing.Key = key
+		existing.Tests = append(existing.Tests, tests...)
+		c.modules[key] = existing
+	}
+	return pkg, nil
+}
+
+func configAnnotation(
+	compilerCtx *compilercontext.CompilerContext, fn *ast.BLangFunction,
+) (ast.BLangAnnotationAttachment, bool) {
+	for _, attachment := range fn.GetAnnotationAttachments() {
+		if !ast.SymbolIsSet(&attachment) {
+			continue
+		}
+		pkg := compilerCtx.SymbolPackage(attachment.Symbol())
+		if pkg.Organization == testOrg && pkg.Package == testModule &&
+			compilerCtx.SymbolName(attachment.Symbol()) == configAnnName {
+			return attachment, true
+		}
+	}
+	return ast.BLangAnnotationAttachment{}, false
+}
+
+func testFunctionFrom(
+	compilerCtx *compilercontext.CompilerContext,
+	fn *ast.BLangFunction,
+	attachment ast.BLangAnnotationAttachment,
+) (TestFunction, bool) {
+	name := fn.GetName().GetValue()
+	if !validTestSignature(compilerCtx, fn, name) {
+		return TestFunction{}, false
+	}
+	test := TestFunction{Name: name, Enabled: true, Position: fn.GetPosition()}
+	fields, ok := configFields(compilerCtx, attachment)
+	if !ok {
+		return TestFunction{}, false
+	}
+	for _, field := range fields {
+		switch field.name {
+		case enableField:
+			enabled, ok := boolFieldValue(compilerCtx, attachment, field)
+			if !ok {
+				return TestFunction{}, false
+			}
+			test.Enabled = enabled
+		case beforeField:
+			ref, ok := functionFieldValue(compilerCtx, field)
+			if !ok {
+				return TestFunction{}, false
+			}
+			test.Before = ref
+		case afterField:
+			ref, ok := functionFieldValue(compilerCtx, field)
+			if !ok {
+				return TestFunction{}, false
+			}
+			test.After = ref
+		}
+	}
+	return test, true
+}
+
+func validTestSignature(
+	compilerCtx *compilercontext.CompilerContext, fn *ast.BLangFunction, name string,
+) bool {
+	// Defaultable params live in RequiredParams (flagged by IsDefaultableParam),
+	// so this rejects required, defaultable and rest parameters alike.
+	if len(fn.RequiredParams) != 0 || fn.RestParam != nil {
+		compilerCtx.SemanticError(
+			configAnnLabel+" function '"+name+"' must not have parameters", fn.GetPosition())
+		return false
+	}
+	if name == mainFunction || name == initFunction {
+		compilerCtx.SemanticError(
+			configAnnLabel+" cannot be applied to '"+name+"'", fn.GetPosition())
+		return false
+	}
+	return true
+}
+
+// configField is one `key: value` entry of the annotation, sourced either from
+// the attachment AST or from the evaluated constant value.
+type configField struct {
+	name string
+	expr ast.BLangExpression
+}
+
+// configFields returns the fields written in the attachment. The attachment
+// expression is not desugared at this stage, so a mapping constructor is the
+// only shape a `@test:Config { ... }` attachment can take.
+func configFields(
+	compilerCtx *compilercontext.CompilerContext, attachment ast.BLangAnnotationAttachment,
+) ([]configField, bool) {
+	if attachment.Expr == nil {
+		return nil, true
+	}
+	mapping, ok := attachment.Expr.(*ast.BLangMappingConstructorExpr)
+	if !ok {
+		compilerCtx.SemanticError(
+			configAnnLabel+" must be a mapping constructor", attachment.GetPosition())
+		return nil, false
+	}
+	fields := make([]configField, 0, len(mapping.Fields))
+	for _, field := range mapping.Fields {
+		keyValue, ok := field.(*ast.BLangMappingKeyValueField)
+		if !ok {
+			continue
+		}
+		name, ok := fieldName(keyValue)
+		if !ok {
+			continue
+		}
+		fields = append(fields, configField{name: name, expr: keyValue.ValueExpr})
+	}
+	return fields, true
+}
+
+func fieldName(field *ast.BLangMappingKeyValueField) (string, bool) {
+	if field.Key == nil || field.Key.Kind == ast.MappingKeyComputed {
+		return "", false
+	}
+	literal, ok := field.Key.Expr.(*ast.BLangLiteral)
+	if ok {
+		value, ok := literal.Value.(string)
+		return value, ok
+	}
+	if ref, ok := field.Key.Expr.(*ast.BLangVarRef); ok {
+		return ref.VariableName.GetValue(), true
+	}
+	return "", false
+}
+
+// boolFieldValue reads `enable`. The attachment AST carries the written
+// expression; a fully constant attachment additionally has an evaluated value,
+// which is consulted when the expression itself is not a literal.
+func boolFieldValue(
+	compilerCtx *compilercontext.CompilerContext,
+	attachment ast.BLangAnnotationAttachment,
+	field configField,
+) (bool, bool) {
+	if literal, ok := field.expr.(*ast.BLangLiteral); ok {
+		if value, ok := literal.Value.(bool); ok {
+			return value, true
+		}
+	}
+	if evaluated, ok := attachment.AnnotationValue.(*values.Map); ok && evaluated != nil {
+		if value, ok := evaluated.Get(field.name); ok {
+			if enabled, ok := value.(bool); ok {
+				return enabled, true
+			}
+		}
+	}
+	compilerCtx.SemanticError(
+		configAnnLabel+" '"+enableField+"' must be a boolean literal", field.expr.GetPosition())
+	return false, false
+}
+
+// functionFieldValue reads `before`/`after`, which must name a top-level
+// function. Visibility is already enforced by the type checker.
+func functionFieldValue(
+	compilerCtx *compilercontext.CompilerContext, field configField,
+) (FunctionRef, bool) {
+	ref, ok := field.expr.(*ast.BLangVarRef)
+	if ok && ast.SymbolIsSet(ref) && compilerCtx.SymbolKind(ref.Symbol()) == model.SymbolKindFunction {
+		pkg := compilerCtx.SymbolPackage(ref.Symbol())
+		return FunctionRef{
+			Org:    pkg.Organization,
+			Module: pkg.Package,
+			Name:   compilerCtx.SymbolName(ref.Symbol()),
+		}, true
+	}
+	compilerCtx.SemanticError(
+		configAnnLabel+" '"+field.name+"' must reference a function", field.expr.GetPosition())
+	return FunctionRef{}, false
+}

--- a/cli/internal/testerina/plan.go
+++ b/cli/internal/testerina/plan.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package testerina discovers and executes `@test:Config` functions.
+package testerina
+
+import (
+	"strings"
+
+	"github.com/ballerina-nutcracker/ballerina/tools/diagnostics"
+)
+
+// ModuleKey identifies a module by the org and the full dotted module name the
+// runtime dispatches on (e.g. `foo.sub`).
+type ModuleKey struct {
+	Org    string
+	Module string
+}
+
+// displayName is the name used for filtering and reporting: the submodule name
+// alone. Root-package modules are always `<pkgName>` or `<pkgName>.<rest>`, so
+// the default module keeps the package name and a submodule drops it.
+func (k ModuleKey) displayName() string {
+	if _, rest, found := strings.Cut(k.Module, "."); found {
+		return rest
+	}
+	return k.Module
+}
+
+// FunctionRef names a top-level function. The zero value means "none".
+type FunctionRef struct {
+	Org    string
+	Module string
+	Name   string
+}
+
+func (f FunctionRef) IsZero() bool {
+	return f == FunctionRef{}
+}
+
+// TestFunction is one discovered `@test:Config` function.
+type TestFunction struct {
+	Name     string
+	Enabled  bool
+	Before   FunctionRef
+	After    FunctionRef
+	Position diagnostics.Location
+}
+
+// ModuleTests holds the tests discovered in a single module, in source order.
+type ModuleTests struct {
+	Key   ModuleKey
+	Tests []TestFunction
+}
+
+// TestPlan holds every discovered test, with modules in the root package's
+// topological module order.
+type TestPlan struct {
+	Modules []ModuleTests
+}

--- a/cli/internal/testerina/reporter.go
+++ b/cli/internal/testerina/reporter.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testerina
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Reporter renders test progress and the final summary.
+type Reporter interface {
+	Begin(total int)
+	Report(Result)
+	End(Summary)
+}
+
+func NewPlainReporter(w io.Writer) Reporter {
+	return &plainReporter{reporterBase: reporterBase{w: w}}
+}
+
+func NewTTYReporter(w io.Writer) Reporter {
+	return &ttyReporter{reporterBase: reporterBase{w: w}}
+}
+
+// reporterBase holds the state and summary rendering both reporters share.
+type reporterBase struct {
+	w     io.Writer
+	total int
+}
+
+func (r *reporterBase) Begin(total int) {
+	r.total = total
+}
+
+func (r *reporterBase) End(summary Summary) {
+	var passed, failed, errored, skipped int
+	for _, result := range summary.Results {
+		switch result.Outcome {
+		case Passed:
+			passed++
+		case Failed:
+			failed++
+		case Errored:
+			errored++
+		case Skipped:
+			skipped++
+		}
+		if result.Outcome == Failed || result.Outcome == Errored {
+			r.printFailure(result)
+		}
+	}
+	if len(summary.RunFailures) > 0 {
+		_, _ = fmt.Fprintf(r.w, "%s\n", stepLabel(Step{}))
+		for _, message := range summary.RunFailures {
+			r.printIndented(message)
+		}
+	}
+	_, _ = fmt.Fprintf(r.w, "%d passing, %d failing, %d errored, %d skipped\n",
+		passed, failed, errored, skipped)
+}
+
+func (r *reporterBase) printFailure(result Result) {
+	_, _ = fmt.Fprintf(r.w, "%s\n", stepLabel(result.Step))
+	for _, message := range result.Messages {
+		r.printIndented(message)
+	}
+	r.printIndented(string(result.Stdout))
+}
+
+func (r *reporterBase) printIndented(text string) {
+	if text == "" {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
+		if line == "" {
+			_, _ = fmt.Fprintln(r.w)
+			continue
+		}
+		_, _ = fmt.Fprintf(r.w, "    %s\n", line)
+	}
+}
+
+func stepLabel(step Step) string {
+	if step.Test.Name == "" {
+		return "<run>"
+	}
+	return step.Label()
+}
+
+func outcomeLabel(outcome Outcome) string {
+	switch outcome {
+	case Passed:
+		return "PASS"
+	case Failed:
+		return "FAIL"
+	case Errored:
+		return "ERROR"
+	default:
+		return "SKIP"
+	}
+}
+
+// plainReporter prints one line per result; used when stdout is not a terminal.
+type plainReporter struct {
+	reporterBase
+}
+
+func (r *plainReporter) Report(result Result) {
+	_, _ = fmt.Fprintf(r.w, "%s %s\n", outcomeLabel(result.Outcome), stepLabel(result.Step))
+}
+
+// ttyReporter rewrites a single progress line in place.
+type ttyReporter struct {
+	reporterBase
+	done, passed, failed, errored, skipped int
+}
+
+func (r *ttyReporter) Report(result Result) {
+	r.done++
+	switch result.Outcome {
+	case Passed:
+		r.passed++
+	case Failed:
+		r.failed++
+	case Errored:
+		r.errored++
+	case Skipped:
+		r.skipped++
+	}
+	_, _ = fmt.Fprintf(r.w, "\rRunning %d/%d  passed %d  failed %d  errored %d  skipped %d",
+		r.done, r.total, r.passed, r.failed, r.errored, r.skipped)
+}
+
+func (r *ttyReporter) End(summary Summary) {
+	if r.done > 0 {
+		_, _ = fmt.Fprintln(r.w)
+	}
+	r.reporterBase.End(summary)
+}

--- a/cli/internal/testerina/reporter_test.go
+++ b/cli/internal/testerina/reporter_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testerina
+
+import (
+	"bytes"
+	"testing"
+)
+
+// The corpus harness runs bal over pipes, so it only ever exercises the plain
+// reporter; the TTY progress line has to be covered here.
+func TestTTYReporterRewritesOneProgressLine(t *testing.T) {
+	module := ModuleKey{Org: "acme", Module: "app"}
+	results := []Result{
+		{Step: Step{Module: module, Test: TestFunction{Name: "testOne"}}, Outcome: Passed},
+		{
+			Step:     Step{Module: module, Test: TestFunction{Name: "testTwo"}},
+			Outcome:  Failed,
+			Messages: []string{"boom"},
+			Stdout:   []byte("captured\n\nafter a blank line\n"),
+		},
+		{Step: Step{Module: module, Test: TestFunction{Name: "testThree"}}, Outcome: Errored, Messages: []string{"x"}},
+		{Step: Step{Module: module, Test: TestFunction{Name: "testFour"}}, Outcome: Skipped},
+	}
+
+	var buf bytes.Buffer
+	reporter := NewTTYReporter(&buf)
+	reporter.Begin(len(results))
+	for _, result := range results {
+		reporter.Report(result)
+	}
+	reporter.End(Summary{Results: results})
+
+	want := "\rRunning 1/4  passed 1  failed 0  errored 0  skipped 0" +
+		"\rRunning 2/4  passed 1  failed 1  errored 0  skipped 0" +
+		"\rRunning 3/4  passed 1  failed 1  errored 1  skipped 0" +
+		"\rRunning 4/4  passed 1  failed 1  errored 1  skipped 1" +
+		"\n" +
+		"app:testTwo\n    boom\n    captured\n\n    after a blank line\n" +
+		"app:testThree\n    x\n" +
+		"1 passing, 1 failing, 1 errored, 1 skipped\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("tty reporter output:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestPlainReporterPrintsOneLinePerResult(t *testing.T) {
+	module := ModuleKey{Org: "acme", Module: "app.sub"}
+	results := []Result{
+		{Step: Step{Module: module, Test: TestFunction{Name: "testOne"}}, Outcome: Passed},
+		{Step: Step{Module: module, Test: TestFunction{Name: "testTwo"}}, Outcome: Skipped},
+	}
+
+	var buf bytes.Buffer
+	reporter := NewPlainReporter(&buf)
+	reporter.Begin(len(results))
+	for _, result := range results {
+		reporter.Report(result)
+	}
+	reporter.End(Summary{Results: results, RunFailures: []string{"first", "second"}})
+
+	want := "PASS sub:testOne\nSKIP sub:testTwo\n" +
+		"<run>\n    first\n    second\n" +
+		"1 passing, 0 failing, 0 errored, 1 skipped\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("plain reporter output:\ngot:  %q\nwant: %q", got, want)
+	}
+}

--- a/cli/internal/testerina/runner.go
+++ b/cli/internal/testerina/runner.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testerina
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/ballerina-nutcracker/ballerina/platform/pal"
+	"github.com/ballerina-nutcracker/ballerina/runtime"
+	"github.com/ballerina-nutcracker/ballerina/semtypes"
+	"github.com/ballerina-nutcracker/ballerina/values"
+)
+
+// Outcome is the verdict of a single test.
+type Outcome uint8
+
+const (
+	Passed Outcome = iota
+	Failed
+	Errored
+	Skipped
+)
+
+// Result is the outcome of one scheduled test.
+type Result struct {
+	Step     Step
+	Outcome  Outcome
+	Messages []string
+	Stdout   []byte
+	Duration time.Duration
+}
+
+// Summary is the outcome of a whole run.
+type Summary struct {
+	Results []Result
+	// RunFailures are Fail hook calls made outside any test, e.g. from `main`,
+	// a `$start` hook, or a strand that outlived the test that started it.
+	RunFailures []string
+}
+
+func (s Summary) Failed() bool {
+	if len(s.RunFailures) > 0 {
+		return true
+	}
+	for _, result := range s.Results {
+		if result.Outcome == Failed || result.Outcome == Errored {
+			return true
+		}
+	}
+	return false
+}
+
+// Runner executes a Schedule against a live runtime. It owns the PAL overrides
+// the tests need: per-test stdout capture, the shutdown signal channel, and the
+// Testing.Fail hook.
+type Runner struct {
+	platform pal.Platform
+	// signals is the channel the runtime reads. Only forwardSignals sends on
+	// it and closes it, so Shutdown asks for a signal through requests rather
+	// than writing to it directly.
+	signals  chan pal.Signal
+	requests chan pal.Signal
+	stopOnce sync.Once
+	stop     chan struct{}
+	rt       *runtime.Runtime
+
+	// mu guards the state below, which is touched from arbitrary strands:
+	// workers, $start hooks and service resource goroutines all reach fail and
+	// the stdout hook concurrently with the runner goroutine.
+	mu          sync.Mutex
+	current     *Step
+	stdout      bytes.Buffer
+	failures    []string
+	runFailures []string
+}
+
+// NewRunner builds the runner and its platform overrides. It must be called
+// before runtime.NewRuntime, which copies pal.Platform by value. tyEnv is the
+// environment the caller hands to runtime.NewRuntime; the runner takes it so
+// callers construct both from one place, but only the runtime consults it.
+func NewRunner(platform pal.Platform, osSignals <-chan pal.Signal, _ semtypes.Env) *Runner {
+	r := &Runner{
+		platform: platform,
+		signals:  make(chan pal.Signal, 1),
+		requests: make(chan pal.Signal, 1),
+		stop:     make(chan struct{}),
+	}
+	baseStdout := platform.IO.Stdout
+	r.platform.IO.Stdout = r.writeStdout(baseStdout)
+	r.platform.Signals = pal.SignalSource{Signals: r.signals}
+	r.platform.Testing = pal.Testing{Fail: r.fail}
+	go r.forwardSignals(osSignals)
+	return r
+}
+
+// Platform returns the platform the runtime must be created with.
+func (r *Runner) Platform() pal.Platform {
+	return r.platform
+}
+
+// Start records the runtime the schedule runs against; call it after Init and
+// Listen have completed.
+func (r *Runner) Start(rt *runtime.Runtime) {
+	r.rt = rt
+}
+
+func (r *Runner) writeStdout(base func([]byte) (int, error)) func([]byte) (int, error) {
+	return func(p []byte) (int, error) {
+		r.mu.Lock()
+		if r.current != nil {
+			defer r.mu.Unlock()
+			return r.stdout.Write(p)
+		}
+		r.mu.Unlock()
+		return base(p)
+	}
+}
+
+// forwardSignals relays OS signals and Shutdown's own stop request into the
+// channel the runtime reads. It is the sole sender and closer of that channel;
+// the runtime requires the sender to close it once the exit code is out.
+func (r *Runner) forwardSignals(osSignals <-chan pal.Signal) {
+	defer close(r.signals)
+	for {
+		var signal pal.Signal
+		select {
+		case <-r.stop:
+			return
+		case signal = <-r.requests:
+		case received, ok := <-osSignals:
+			if !ok {
+				// A nil channel blocks forever, so the closed source drops out
+				// of the select instead of spinning it.
+				osSignals = nil
+				continue
+			}
+			signal = received
+		}
+		select {
+		case r.signals <- signal:
+		case <-r.stop:
+			return
+		}
+	}
+}
+
+// fail records a failure against the running test, or against the run itself
+// when no test is running.
+func (r *Runner) fail(message string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.current == nil {
+		r.runFailures = append(r.runFailures, message)
+		return
+	}
+	r.failures = append(r.failures, message)
+}
+
+// Run executes every step sequentially and returns the run summary.
+func (r *Runner) Run(schedule Schedule, reporter Reporter) Summary {
+	reporter.Begin(len(schedule.Steps))
+	summary := Summary{}
+	for _, step := range schedule.Steps {
+		result := r.runStep(step)
+		summary.Results = append(summary.Results, result)
+		reporter.Report(result)
+	}
+	summary.RunFailures = r.RunFailures()
+	return summary
+}
+
+// RunFailures returns the failures reported outside any test so far. Callers
+// re-read it after Shutdown, which is when lifecycle handlers get to run.
+func (r *Runner) RunFailures() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string{}, r.runFailures...)
+}
+
+func (r *Runner) runStep(step Step) Result {
+	if !step.Test.Enabled {
+		return Result{Step: step, Outcome: Skipped}
+	}
+	r.beginStep(step)
+	start := time.Now()
+	messages, errored := r.runStepBody(step)
+	duration := time.Since(start)
+	failures, stdout := r.endStep()
+
+	result := Result{Step: step, Stdout: stdout, Duration: duration}
+	result.Messages = append(append([]string{}, failures...), newMessages(failures, messages)...)
+	switch {
+	case len(failures) > 0:
+		result.Outcome = Failed
+	case errored:
+		result.Outcome = Errored
+	default:
+		result.Outcome = Passed
+	}
+	return result
+}
+
+// runStepBody runs before, the test body and after. A failing before skips both
+// the body and after; a failing after errors the step even if the body passed.
+func (r *Runner) runStepBody(step Step) (messages []string, errored bool) {
+	if !step.Test.Before.IsZero() {
+		if message, failed := r.invoke(step.Test.Before); failed {
+			return []string{message}, true
+		}
+	}
+	if message, failed := r.invoke(bodyRef(step)); failed {
+		messages, errored = append(messages, message), true
+	}
+	if !step.Test.After.IsZero() {
+		if message, failed := r.invoke(step.Test.After); failed {
+			messages, errored = append(messages, message), true
+		}
+	}
+	return messages, errored
+}
+
+// newMessages drops panic and error messages the Fail hook already recorded.
+// assertFail always produces both: it calls the hook and then panics with the
+// same message.
+func newMessages(failures, messages []string) []string {
+	var result []string
+	for _, message := range messages {
+		if !slices.Contains(failures, message) {
+			result = append(result, message)
+		}
+	}
+	return result
+}
+
+func bodyRef(step Step) FunctionRef {
+	return FunctionRef{Org: step.Module.Org, Module: step.Module.Module, Name: step.Test.Name}
+}
+
+func (r *Runner) beginStep(step Step) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current := step
+	r.current = &current
+	r.stdout.Reset()
+	r.failures = nil
+}
+
+func (r *Runner) endStep() (failures []string, stdout []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.current = nil
+	failures, r.failures = r.failures, nil
+	stdout = append([]byte{}, r.stdout.Bytes()...)
+	r.stdout.Reset()
+	return failures, stdout
+}
+
+// invoke calls one Ballerina function, reporting a panic, a returned error
+// value or a Go-level error as a failure message.
+func (r *Runner) invoke(ref FunctionRef) (message string, failed bool) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			message, failed = panicMessage(recovered), true
+		}
+	}()
+	fn, ok := runtime.LookupFunction(r.rt, ref.Org, ref.Module, ref.Name)
+	if !ok {
+		return fmt.Sprintf("function %s/%s:%s not found", ref.Org, ref.Module, ref.Name), true
+	}
+	result, err := runtime.InvokeFunction(r.rt, fn, nil)
+	if err != nil {
+		return err.Error(), true
+	}
+	if returned, ok := result.(*values.Error); ok && returned != nil {
+		return returned.Message, true
+	}
+	return "", false
+}
+
+func panicMessage(recovered any) string {
+	if err, ok := recovered.(*values.Error); ok && err != nil {
+		return err.Message
+	}
+	return fmt.Sprint(recovered)
+}
+
+// Shutdown stops the runtime and the signal forwarder. When no listeners
+// existed, Listen already drove the runtime to Stopped and the exit-status
+// channel holds its code; signalling again would be an illegal transition.
+func (r *Runner) Shutdown(rt *runtime.Runtime) {
+	select {
+	case <-rt.ExitStatus:
+	default:
+		select {
+		case r.requests <- pal.GracefulStop:
+		default:
+		}
+		<-rt.ExitStatus
+	}
+	r.stopOnce.Do(func() { close(r.stop) })
+}

--- a/cli/internal/testerina/schedule.go
+++ b/cli/internal/testerina/schedule.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testerina
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Step is one test to execute, together with the module that declares it.
+type Step struct {
+	Module ModuleKey
+	Test   TestFunction
+}
+
+// Label is the `module:name` form used by --list and the reporters.
+func (s Step) Label() string {
+	return s.Module.displayName() + ":" + s.Test.Name
+}
+
+// Schedule is the flattened, filtered execution order.
+type Schedule struct {
+	Steps []Step
+}
+
+// Filter holds the parsed `--tests` entries. An empty Filter matches every test.
+type Filter []string
+
+// ParseFilter parses a comma-separated `--tests` value. Each entry is either
+// `namePattern` or `modulePattern:namePattern`, where `*` matches any run of
+// characters.
+func ParseFilter(spec string) (Filter, error) {
+	if strings.TrimSpace(spec) == "" {
+		return nil, nil
+	}
+	entries := strings.Split(spec, ",")
+	filter := make(Filter, 0, len(entries))
+	for _, entry := range entries {
+		trimmed := strings.TrimSpace(entry)
+		if trimmed == "" {
+			return nil, fmt.Errorf("invalid --tests value %q: empty entry", spec)
+		}
+		// A qualified entry must be exactly modulePattern:namePattern. Without
+		// this, "app:", ":testOne" and "app:testOne:extra" parse into patterns
+		// that can never match, so the command would succeed having silently
+		// run no tests.
+		if modulePattern, namePattern, qualified := strings.Cut(trimmed, ":"); qualified {
+			switch {
+			case modulePattern == "":
+				return nil, fmt.Errorf(
+					"invalid --tests entry %q: module pattern is empty, want modulePattern:namePattern", trimmed)
+			case namePattern == "":
+				return nil, fmt.Errorf(
+					"invalid --tests entry %q: test name pattern is empty, want modulePattern:namePattern", trimmed)
+			case strings.Contains(namePattern, ":"):
+				return nil, fmt.Errorf(
+					"invalid --tests entry %q: want at most one \":\", as modulePattern:namePattern", trimmed)
+			}
+		}
+		filter = append(filter, trimmed)
+	}
+	return filter, nil
+}
+
+// Matches reports whether the named test in module is selected.
+func (f Filter) Matches(module ModuleKey, name string) bool {
+	if len(f) == 0 {
+		return true
+	}
+	for _, entry := range f {
+		modulePattern, namePattern, qualified := strings.Cut(entry, ":")
+		if !qualified {
+			if matchesPattern(entry, name) {
+				return true
+			}
+			continue
+		}
+		if matchesPattern(modulePattern, module.displayName()) && matchesPattern(namePattern, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesPattern matches value against a pattern whose only metacharacter is
+// `*`, standing for any run of characters.
+func matchesPattern(pattern, value string) bool {
+	segments := strings.Split(pattern, "*")
+	if len(segments) == 1 {
+		return pattern == value
+	}
+	if !strings.HasPrefix(value, segments[0]) {
+		return false
+	}
+	value = value[len(segments[0]):]
+	last := segments[len(segments)-1]
+	for _, segment := range segments[1 : len(segments)-1] {
+		index := strings.Index(value, segment)
+		if index < 0 {
+			return false
+		}
+		value = value[index+len(segment):]
+	}
+	return strings.HasSuffix(value, last) && len(value) >= len(last)
+}
+
+// NewSchedule flattens plan into steps, dropping tests the filter rejects.
+// Matching but disabled tests stay in the schedule and are reported skipped.
+func NewSchedule(plan TestPlan, filter Filter) Schedule {
+	var schedule Schedule
+	for _, module := range plan.Modules {
+		for _, test := range module.Tests {
+			if !filter.Matches(module.Key, test.Name) {
+				continue
+			}
+			schedule.Steps = append(schedule.Steps, Step{Module: module.Key, Test: test})
+		}
+	}
+	return schedule
+}

--- a/cli/internal/testerina/schedule_test.go
+++ b/cli/internal/testerina/schedule_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testerina
+
+import "testing"
+
+func TestParseFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    Filter
+		wantErr bool
+	}{
+		{name: "empty matches all", spec: "", want: nil},
+		{name: "blank matches all", spec: "   ", want: nil},
+		{name: "entries are trimmed", spec: " a , b:c ", want: Filter{"a", "b:c"}},
+		{name: "empty entry rejected", spec: "a,,b", wantErr: true},
+		{name: "trailing comma rejected", spec: "a,", wantErr: true},
+		{name: "empty name pattern rejected", spec: "app:", wantErr: true},
+		{name: "empty module pattern rejected", spec: ":testOne", wantErr: true},
+		{name: "extra colon rejected", spec: "app:testOne:extra", wantErr: true},
+		{name: "malformed entry rejects whole spec", spec: "good,app:", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseFilter(tt.spec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseFilter(%q) = %v, want an error", tt.spec, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseFilter(%q) failed: %v", tt.spec, err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseFilter(%q) = %v, want %v", tt.spec, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("ParseFilter(%q) = %v, want %v", tt.spec, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterMatches(t *testing.T) {
+	defaultModule := ModuleKey{Org: "acme", Module: "app"}
+	subModule := ModuleKey{Org: "acme", Module: "app.sub"}
+
+	tests := []struct {
+		name   string
+		spec   string
+		module ModuleKey
+		test   string
+		want   bool
+	}{
+		{name: "empty filter matches", spec: "", module: defaultModule, test: "testOne", want: true},
+		{name: "bare name matches any module", spec: "testOne", module: subModule, test: "testOne", want: true},
+		{name: "bare name rejects others", spec: "testOne", module: defaultModule, test: "testTwo", want: false},
+		{name: "trailing wildcard", spec: "test*", module: defaultModule, test: "testOne", want: true},
+		{name: "leading wildcard", spec: "*One", module: defaultModule, test: "testOne", want: true},
+		{name: "interior wildcard", spec: "test*One", module: defaultModule, test: "testTheOne", want: true},
+		{name: "interior wildcard rejects", spec: "test*One", module: defaultModule, test: "testTwo", want: false},
+		{name: "bare star matches", spec: "*", module: subModule, test: "anything", want: true},
+		{name: "star colon star matches", spec: "*:*", module: subModule, test: "anything", want: true},
+		{name: "module qualified on default module", spec: "app:testOne", module: defaultModule, test: "testOne", want: true},
+		{name: "submodule uses bare name", spec: "sub:testOne", module: subModule, test: "testOne", want: true},
+		{name: "submodule not matched by package name", spec: "app:testOne", module: subModule, test: "testOne", want: false},
+		{name: "module wildcard", spec: "s*b:test*", module: subModule, test: "testOne", want: true},
+		{name: "any entry may match", spec: "nope,testOne", module: defaultModule, test: "testOne", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := ParseFilter(tt.spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := filter.Matches(tt.module, tt.test); got != tt.want {
+				t.Fatalf("Matches(%v, %q) with %q = %v, want %v", tt.module, tt.test, tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewScheduleKeepsDisabledMatchesAndDropsRest(t *testing.T) {
+	plan := TestPlan{Modules: []ModuleTests{
+		{Key: ModuleKey{Org: "acme", Module: "app"}, Tests: []TestFunction{
+			{Name: "testOne", Enabled: true},
+			{Name: "testTwo", Enabled: false},
+		}},
+		{Key: ModuleKey{Org: "acme", Module: "app.sub"}, Tests: []TestFunction{
+			{Name: "testThree", Enabled: true},
+		}},
+	}}
+
+	filter, err := ParseFilter("test*o,sub:*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schedule := NewSchedule(plan, filter)
+	if len(schedule.Steps) != 2 {
+		t.Fatalf("steps = %#v, want testTwo and testThree", schedule.Steps)
+	}
+	if schedule.Steps[0].Test.Name != "testTwo" || schedule.Steps[0].Test.Enabled {
+		t.Fatalf("first step = %#v, want the disabled testTwo", schedule.Steps[0])
+	}
+	if schedule.Steps[1].Test.Name != "testThree" {
+		t.Fatalf("second step = %#v, want testThree", schedule.Steps[1])
+	}
+}

--- a/compilerplugin/compilerplugin.go
+++ b/compilerplugin/compilerplugin.go
@@ -43,3 +43,17 @@ type CompilerPlugin struct {
 	After              Stage
 	PackageTransformer PackageTransformer
 }
+
+// Provider identifies the package whose exported symbol space a plugin receives
+// and whose import activates it.
+type Provider struct {
+	Org     string
+	Package string
+}
+
+// InjectedPlugin is a compiler plugin supplied by the host for one compilation
+// rather than declared by a package manifest.
+type InjectedPlugin struct {
+	Provider Provider
+	Plugin   CompilerPlugin
+}

--- a/corpus/cli/output/help/help.txtar
+++ b/corpus/cli/output/help/help.txtar
@@ -5,10 +5,14 @@ Usage:
   bal [command]
 
 Available Commands:
+  build       Compile the current package into a standalone executable
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
   new         Create a new Ballerina package
+  pack        Create the distribution format (.bala) of the current package
+  push        Push a Ballerina Archive (BALA) of the current package to the local repository
   run         Build and run the current package or a Ballerina source file
+  test        Compile the current package and run its tests
   version     Print the Ballerina version
 
 Flags:

--- a/corpus/cli/output/test/bad-enable.txtar
+++ b/corpus/cli/output/test/bad-enable.txtar
@@ -1,0 +1,11 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: @test:Config 'enable' must be a boolean literal
+  --> main.bal:21:23
+   |
+21 | @test:Config {enable: enabled}
+   |                       ^^^^^^^
+
+ballerina: compilation contains errors
+-- exitcode --
+1

--- a/corpus/cli/output/test/bad-main.txtar
+++ b/corpus/cli/output/test/bad-main.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: @test:Config cannot be applied to 'main'
+  --> main.bal:20:1
+   |
+20 | public function main() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+21 | }
+   | ^
+
+ballerina: compilation contains errors
+-- exitcode --
+1

--- a/corpus/cli/output/test/bad-param.txtar
+++ b/corpus/cli/output/test/bad-param.txtar
@@ -1,0 +1,15 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: @test:Config function 'testWithAParameter' must not have parameters
+  --> main.bal:21:1
+   |
+21 | function testWithAParameter(int value) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+22 |     io:println(value);
+   |     ^^^^^^^^^^^^^^^^^^
+23 | }
+   | ^
+
+ballerina: compilation contains errors
+-- exitcode --
+1

--- a/corpus/cli/output/test/basic.txtar
+++ b/corpus/cli/output/test/basic.txtar
@@ -1,0 +1,8 @@
+-- stdout --
+main ran
+PASS basic:testOne
+PASS basic:testTwo
+2 passing, 0 failing, 0 errored, 0 skipped
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/cross-module-hook.txtar
+++ b/corpus/cli/output/test/cross-module-hook.txtar
@@ -1,0 +1,8 @@
+-- stdout --
+FAIL crossmodule:testUsesAnotherModulesHook
+crossmodule:testUsesAnotherModulesHook
+    util setUp ran
+0 passing, 1 failing, 0 errored, 0 skipped
+-- stderr --
+-- exitcode --
+1

--- a/corpus/cli/output/test/cross-module-private-hook.txtar
+++ b/corpus/cli/output/test/cross-module-private-hook.txtar
@@ -1,0 +1,11 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: Unknown symbol: privateSetUp
+  --> main.bal:20:23
+   |
+20 | @test:Config {before: util:privateSetUp}
+   |                       ^^^^^^^^^^^^^^^^^
+
+ballerina: compilation contains errors
+-- exitcode --
+1

--- a/corpus/cli/output/test/demo-filtered.txtar
+++ b/corpus/cli/output/test/demo-filtered.txtar
@@ -1,0 +1,17 @@
+-- stdout --
+main: starting up
+calc module loaded
+PASS calc:testAdd
+FAIL calc:testFactorial
+ERROR calc:testDivideByZero
+PASS calc:testDivide
+PASS store:testPutAndGet
+calc:testFactorial
+    factorial(4) should be 24 but was 8
+    factorial(4) = 8
+calc:testDivideByZero
+    divide by zero
+3 passing, 1 failing, 1 errored, 0 skipped
+-- stderr --
+-- exitcode --
+1

--- a/corpus/cli/output/test/demo-list.txtar
+++ b/corpus/cli/output/test/demo-list.txtar
@@ -1,0 +1,15 @@
+-- stdout --
+calc:testAdd
+calc:testFactorial
+calc:testDivideByZero
+calc:testDivide
+store:testPutAndGet
+store:testGetOutOfRange
+store:testSizeExpectations
+store:testNotReadyYet (disabled)
+demo:testCalcAndStoreTogether
+demo:testWithABrokenSetUp
+demo:testMissingConfiguration
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/demo.txtar
+++ b/corpus/cli/output/test/demo.txtar
@@ -1,0 +1,33 @@
+-- stdout --
+main: starting up
+calc module loaded
+PASS calc:testAdd
+FAIL calc:testFactorial
+ERROR calc:testDivideByZero
+PASS calc:testDivide
+PASS store:testPutAndGet
+ERROR store:testGetOutOfRange
+FAIL store:testSizeExpectations
+SKIP store:testNotReadyYet
+PASS demo:testCalcAndStoreTogether
+FAIL demo:testWithABrokenSetUp
+ERROR demo:testMissingConfiguration
+calc:testFactorial
+    factorial(4) should be 24 but was 8
+    factorial(4) = 8
+calc:testDivideByZero
+    divide by zero
+store:testGetOutOfRange
+    invalid array index: 9999
+store:testSizeExpectations
+    size should start at 0
+    size should never shrink
+    both assertions trapped: true
+demo:testWithABrokenSetUp
+    set up could not prepare the fixture
+demo:testMissingConfiguration
+    bad type cast
+4 passing, 3 failing, 3 errored, 1 skipped
+-- stderr --
+-- exitcode --
+1

--- a/corpus/cli/output/test/filter-by-module-and-name.txtar
+++ b/corpus/cli/output/test/filter-by-module-and-name.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+PASS sub:testSubOne
+1 passing, 0 failing, 0 errored, 0 skipped
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/filter-by-name.txtar
+++ b/corpus/cli/output/test/filter-by-name.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+PASS filters:testDefaultOne
+1 passing, 0 failing, 0 errored, 0 skipped
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/filter-by-wildcard.txtar
+++ b/corpus/cli/output/test/filter-by-wildcard.txtar
@@ -1,0 +1,8 @@
+-- stdout --
+PASS filters:testDefaultOne
+PASS filters:testDefaultTwo
+SKIP filters:testDefaultDisabled
+2 passing, 0 failing, 0 errored, 1 skipped
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/filter-matches-disabled.txtar
+++ b/corpus/cli/output/test/filter-matches-disabled.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+SKIP filters:testDefaultDisabled
+0 passing, 0 failing, 0 errored, 1 skipped
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/hooks.txtar
+++ b/corpus/cli/output/test/hooks.txtar
@@ -1,0 +1,19 @@
+-- stdout --
+FAIL hooks:testWithHooks
+ERROR hooks:testBeforePanics
+FAIL hooks:testAfterRunsAfterAPassingBody
+ERROR hooks:testAfterPanics
+hooks:testWithHooks
+    body failed so the captured hook output is shown
+    setUp ran
+    tearDown ran
+hooks:testBeforePanics
+    hook exploded
+hooks:testAfterRunsAfterAPassingBody
+    after ran
+hooks:testAfterPanics
+    hook exploded
+0 passing, 2 failing, 2 errored, 0 skipped
+-- stderr --
+-- exitcode --
+1

--- a/corpus/cli/output/test/list.txtar
+++ b/corpus/cli/output/test/list.txtar
@@ -1,0 +1,8 @@
+-- stdout --
+sub:testSubOne
+filters:testDefaultOne
+filters:testDefaultTwo
+filters:testDefaultDisabled (disabled)
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/listener.txtar
+++ b/corpus/cli/output/test/listener.txtar
@@ -1,0 +1,16 @@
+-- stdout --
+PASS listenertest:testCallsTheService
+FAIL listenertest:testResourceAssertFail
+FAIL listenertest:testStrandAssertFail
+listenertest:testResourceAssertFail
+    failed inside a resource
+listenertest:testStrandAssertFail
+    failed inside a strand
+    true
+<run>
+    failure during graceful stop
+1 passing, 2 failing, 0 errored, 0 skipped
+-- stderr --
+error [ballerina/http]: panic while handling GET /svc/boom: failed inside a resource
+-- exitcode --
+1

--- a/corpus/cli/output/test/lock.txtar
+++ b/corpus/cli/output/test/lock.txtar
@@ -1,0 +1,9 @@
+-- stdout --
+ERROR locktest:testPanicsInsideLock
+PASS locktest:testEntersTheSameLock
+locktest:testPanicsInsideLock
+    invalid array index: 1
+1 passing, 0 failing, 1 errored, 0 skipped
+-- stderr --
+-- exitcode --
+1

--- a/corpus/cli/output/test/main-fail.txtar
+++ b/corpus/cli/output/test/main-fail.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+true
+PASS mainfail:testStillRuns
+<run>
+    first failure from main
+    second failure from main
+1 passing, 0 failing, 0 errored, 0 skipped
+-- stderr --
+-- exitcode --
+1

--- a/corpus/cli/output/test/main-panic.txtar
+++ b/corpus/cli/output/test/main-panic.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+-- stderr --
+error: main exploded
+        at testorg/mainpanic:main(main.bal:20)
+-- exitcode --
+1

--- a/corpus/cli/output/test/multi-module.txtar
+++ b/corpus/cli/output/test/multi-module.txtar
@@ -1,0 +1,9 @@
+-- stdout --
+PASS sub:testSubOne
+PASS filters:testDefaultOne
+PASS filters:testDefaultTwo
+SKIP filters:testDefaultDisabled
+3 passing, 0 failing, 0 errored, 1 skipped
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/no-test-import.txtar
+++ b/corpus/cli/output/test/no-test-import.txtar
@@ -1,0 +1,6 @@
+-- stdout --
+no tests here
+0 passing, 0 failing, 0 errored, 0 skipped
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/output/test/outcomes.txtar
+++ b/corpus/cli/output/test/outcomes.txtar
@@ -1,0 +1,22 @@
+-- stdout --
+FAIL outcomes:testAssertFail
+FAIL outcomes:testTrappedAssertFail
+ERROR outcomes:testPanics
+ERROR outcomes:testReturnsError
+SKIP outcomes:testDisabled
+SKIP outcomes:testDisabledByAConstant
+outcomes:testAssertFail
+    boom
+    printed before failing
+outcomes:testTrappedAssertFail
+    first failure
+    second failure
+    true
+outcomes:testPanics
+    x
+outcomes:testReturnsError
+    returned error
+0 passing, 2 failing, 2 errored, 2 skipped
+-- stderr --
+-- exitcode --
+1

--- a/corpus/cli/output/test/run-does-not-invoke-tests.txtar
+++ b/corpus/cli/output/test/run-does-not-invoke-tests.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+main ran
+-- stderr --
+-- exitcode --
+0

--- a/corpus/cli/testdata/test/bad-enable/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/bad-enable/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "badenable"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/bad-enable/project/main.bal
+++ b/corpus/cli/testdata/test/bad-enable/project/main.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+boolean enabled = false;
+
+@test:Config {enable: enabled}
+function testNonLiteralEnable() {
+}

--- a/corpus/cli/testdata/test/bad-main/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/bad-main/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "badmain"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/bad-main/project/main.bal
+++ b/corpus/cli/testdata/test/bad-main/project/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config {}
+public function main() {
+}

--- a/corpus/cli/testdata/test/bad-param/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/bad-param/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "badparam"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/bad-param/project/main.bal
+++ b/corpus/cli/testdata/test/bad-param/project/main.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+@test:Config {}
+function testWithAParameter(int value) {
+    io:println(value);
+}

--- a/corpus/cli/testdata/test/basic/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/basic/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "basic"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/basic/project/main.bal
+++ b/corpus/cli/testdata/test/basic/project/main.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+public function main() {
+    io:println("main ran");
+}
+
+@test:Config {}
+function testOne() {
+    io:println("stdout of a passing test is swallowed");
+}
+
+@test:Config {}
+function testTwo() {
+}

--- a/corpus/cli/testdata/test/cross-module-private/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/cross-module-private/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "crossmoduleprivate"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/cross-module-private/project/main.bal
+++ b/corpus/cli/testdata/test/cross-module-private/project/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/crossmoduleprivate.util;
+import ballerina/test;
+
+@test:Config {before: util:privateSetUp}
+function testUsesANonPublicHook() {
+}

--- a/corpus/cli/testdata/test/cross-module-private/project/modules/util/util.bal
+++ b/corpus/cli/testdata/test/cross-module-private/project/modules/util/util.bal
@@ -1,0 +1,18 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function privateSetUp() {
+}

--- a/corpus/cli/testdata/test/cross-module/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/cross-module/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "crossmodule"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/cross-module/project/main.bal
+++ b/corpus/cli/testdata/test/cross-module/project/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/crossmodule.util;
+import ballerina/test;
+
+@test:Config {before: util:publicSetUp}
+function testUsesAnotherModulesHook() {
+}

--- a/corpus/cli/testdata/test/cross-module/project/modules/util/util.bal
+++ b/corpus/cli/testdata/test/cross-module/project/modules/util/util.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+// The hook fails so that its execution is observable: a passing test's captured
+// output is never printed, so a hook that only prints proves nothing.
+public function publicSetUp() {
+    test:assertFail("util setUp ran");
+}

--- a/corpus/cli/testdata/test/demo/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/demo/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "demo"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/demo/project/main.bal
+++ b/corpus/cli/testdata/test/demo/project/main.bal
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/demo.calc;
+import testorg/demo.store;
+import ballerina/io;
+import ballerina/test;
+
+public function main() {
+    io:println("main: starting up");
+    calc:describe();
+}
+
+// Uses both modules together.
+@test:Config {}
+function testCalcAndStoreTogether() {
+    int index = store:put(calc:add(20, 22));
+    if store:get(index) != 42 {
+        test:assertFail("expected 42 through calc and store");
+    }
+}
+
+// The before hook fails its own assertion, so the body never runs.
+@test:Config {before: brokenSetUp}
+function testWithABrokenSetUp() {
+    io:println("this body should not run");
+}
+
+// Panics on a nil unwrap in ordinary code: ERROR.
+@test:Config {}
+function testMissingConfiguration() {
+    string? name = lookupName("nobody");
+    string _ = <string>name;
+}
+
+function brokenSetUp() {
+    test:assertFail("set up could not prepare the fixture");
+}
+
+function lookupName(string key) returns string? {
+    if key == "admin" {
+        return "Administrator";
+    }
+    return ();
+}

--- a/corpus/cli/testdata/test/demo/project/modules/calc/calc.bal
+++ b/corpus/cli/testdata/test/demo/project/modules/calc/calc.bal
@@ -1,0 +1,39 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+// add returns the sum of a and b.
+public function add(int a, int b) returns int {
+    return a + b;
+}
+
+// divide panics on a zero divisor, the way ordinary Ballerina code does.
+public function divide(int a, int b) returns int {
+    return a / b;
+}
+
+// factorial is deliberately wrong for n > 2 so a test can catch it.
+public function factorial(int n) returns int {
+    if n <= 1 {
+        return 1;
+    }
+    return n * 2;
+}
+
+public function describe() {
+    io:println("calc module loaded");
+}

--- a/corpus/cli/testdata/test/demo/project/modules/calc/tests.bal
+++ b/corpus/cli/testdata/test/demo/project/modules/calc/tests.bal
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+@test:Config {}
+function testAdd() {
+    int sum = add(2, 3);
+    io:println("add(2, 3) = ", sum);
+    if sum != 5 {
+        test:assertFail("add(2, 3) should be 5");
+    }
+}
+
+// Fails an assertion: factorial(4) is 8, not 24.
+@test:Config {}
+function testFactorial() {
+    int result = factorial(4);
+    io:println("factorial(4) = ", result);
+    if result != 24 {
+        test:assertFail("factorial(4) should be 24 but was " + result.toString());
+    }
+}
+
+// Panics in ordinary code — no assertion involved — so this is reported ERROR.
+@test:Config {}
+function testDivideByZero() {
+    int _ = divide(10, 0);
+}
+
+@test:Config {before: announce}
+function testDivide() {
+    if divide(10, 2) != 5 {
+        test:assertFail("divide(10, 2) should be 5");
+    }
+}
+
+function announce() {
+    io:println("about to divide");
+}

--- a/corpus/cli/testdata/test/demo/project/modules/store/store.bal
+++ b/corpus/cli/testdata/test/demo/project/modules/store/store.bal
@@ -1,0 +1,38 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+isolated int[] entries = [];
+
+// put appends a value and returns its index.
+public isolated function put(int value) returns int {
+    lock {
+        entries.push(value);
+        return entries.length() - 1;
+    }
+}
+
+// get panics when index is out of range.
+public isolated function get(int index) returns int {
+    lock {
+        return entries[index];
+    }
+}
+
+public isolated function size() returns int {
+    lock {
+        return entries.length();
+    }
+}

--- a/corpus/cli/testdata/test/demo/project/modules/store/tests.bal
+++ b/corpus/cli/testdata/test/demo/project/modules/store/tests.bal
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+@test:Config {before: seed, after: report}
+function testPutAndGet() {
+    int index = put(42);
+    if get(index) != 42 {
+        test:assertFail("stored value did not round-trip");
+    }
+}
+
+// Reads past the end of the array, so this panics in ordinary code: ERROR.
+@test:Config {}
+function testGetOutOfRange() {
+    int _ = get(9999);
+}
+
+// Two assertions fail in one test; both messages are reported.
+@test:Config {}
+function testSizeExpectations() {
+    error? first = trap test:assertFail("size should start at 0");
+    error? second = trap test:assertFail("size should never shrink");
+    io:println("both assertions trapped: ", first is error && second is error);
+}
+
+@test:Config {enable: false}
+function testNotReadyYet() {
+    io:println("this never runs");
+}
+
+function seed() {
+    io:println("seeding the store");
+}
+
+function report() {
+    io:println("store size is now ", size());
+}

--- a/corpus/cli/testdata/test/filters/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/filters/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "filters"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/filters/project/main.bal
+++ b/corpus/cli/testdata/test/filters/project/main.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/filters.sub;
+import ballerina/test;
+
+@test:Config {}
+function testDefaultOne() {
+    sub:noop();
+}
+
+@test:Config {}
+function testDefaultTwo() {
+}
+
+@test:Config {enable: false}
+function testDefaultDisabled() {
+}

--- a/corpus/cli/testdata/test/filters/project/modules/sub/sub.bal
+++ b/corpus/cli/testdata/test/filters/project/modules/sub/sub.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+public function noop() {
+}
+
+@test:Config {}
+function testSubOne() {
+}

--- a/corpus/cli/testdata/test/hooks/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/hooks/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "hooks"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/hooks/project/main.bal
+++ b/corpus/cli/testdata/test/hooks/project/main.bal
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+@test:Config {before: setUp, after: tearDown}
+function testWithHooks() {
+    test:assertFail("body failed so the captured hook output is shown");
+}
+
+@test:Config {before: explode}
+function testBeforePanics() {
+    io:println("the body must not run");
+}
+
+// The body passes, so only the failure `after` records proves it ran at all:
+// a passing test's captured output is never printed.
+@test:Config {after: failInAfter}
+function testAfterRunsAfterAPassingBody() {
+}
+
+@test:Config {after: explode}
+function testAfterPanics() {
+}
+
+function setUp() {
+    io:println("setUp ran");
+}
+
+function tearDown() {
+    io:println("tearDown ran");
+}
+
+function failInAfter() {
+    test:assertFail("after ran");
+}
+
+function explode() {
+    panic error("hook exploded");
+}

--- a/corpus/cli/testdata/test/listener/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/listener/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "listenertest"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/listener/project/main.bal
+++ b/corpus/cli/testdata/test/listener/project/main.bal
@@ -1,0 +1,74 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/io;
+import ballerina/lang.runtime;
+import ballerina/test;
+
+service /svc on new http:Listener(19240) {
+    resource function get greeting() returns http:Response {
+        http:Response resp = new;
+        resp.setTextPayload("Hello, World!");
+        return resp;
+    }
+
+    resource function get boom() returns http:Response {
+        test:assertFail("failed inside a resource");
+    }
+}
+
+// Graceful-stop handlers only run during shutdown, after the last test has been
+// reported, so this pins that a failure raised there still reaches the summary
+// and the exit code.
+public function main() {
+    runtime:onGracefulStop(onStop);
+}
+
+function onStop() returns error? {
+    error? trapped = trap test:assertFail("failure during graceful stop");
+    if trapped is error {
+        return;
+    }
+    return;
+}
+
+@test:Config {}
+function testCallsTheService() returns error? {
+    http:Client c = check new http:Client("http://localhost:19240", {});
+    http:Response r = check c->get("/svc/greeting");
+    if r.statusCode != 200 {
+        test:assertFail("unexpected status");
+    }
+    io:println(check r.getTextPayload());
+}
+
+@test:Config {}
+function testResourceAssertFail() returns error? {
+    http:Client c = check new http:Client("http://localhost:19240", {});
+    http:Response _ = check c->get("/svc/boom");
+}
+
+@test:Config {}
+function testStrandAssertFail() {
+    future<()> f = start failInStrand();
+    error? outcome = trap wait f;
+    io:println(outcome is error);
+}
+
+function failInStrand() {
+    test:assertFail("failed inside a strand");
+}

--- a/corpus/cli/testdata/test/lock/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/lock/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "locktest"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/lock/project/main.bal
+++ b/corpus/cli/testdata/test/lock/project/main.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+isolated int counter = 0;
+
+@test:Config {}
+function testPanicsInsideLock() {
+    int[] empty = [];
+    lock {
+        counter += empty[1];
+    }
+}
+
+@test:Config {}
+function testEntersTheSameLock() {
+    lock {
+        counter += 1;
+        io:println(counter);
+    }
+}

--- a/corpus/cli/testdata/test/main-fail/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/main-fail/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "mainfail"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/main-fail/project/main.bal
+++ b/corpus/cli/testdata/test/main-fail/project/main.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+public function main() {
+    error? first = trap test:assertFail("first failure from main");
+    error? second = trap test:assertFail("second failure from main");
+    io:println(first is error && second is error);
+}
+
+@test:Config {}
+function testStillRuns() {
+}

--- a/corpus/cli/testdata/test/main-panic/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/main-panic/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "mainpanic"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/main-panic/project/main.bal
+++ b/corpus/cli/testdata/test/main-panic/project/main.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+public function main() {
+    panic error("main exploded");
+}
+
+@test:Config {}
+function testNeverRuns() {
+}

--- a/corpus/cli/testdata/test/no-test-import/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/no-test-import/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "notestimport"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/no-test-import/project/main.bal
+++ b/corpus/cli/testdata/test/no-test-import/project/main.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+public function main() {
+    io:println("no tests here");
+}

--- a/corpus/cli/testdata/test/outcomes/project/Ballerina.toml
+++ b/corpus/cli/testdata/test/outcomes/project/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "testorg"
+name = "outcomes"
+version = "0.1.0"

--- a/corpus/cli/testdata/test/outcomes/project/main.bal
+++ b/corpus/cli/testdata/test/outcomes/project/main.bal
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+@test:Config {}
+function testAssertFail() {
+    io:println("printed before failing");
+    test:assertFail("boom");
+}
+
+@test:Config {}
+function testTrappedAssertFail() {
+    error? first = trap test:assertFail("first failure");
+    error? second = trap test:assertFail("second failure");
+    io:println(first is error && second is error);
+}
+
+@test:Config {}
+function testPanics() {
+    panic error("x");
+}
+
+@test:Config {}
+function testReturnsError() returns error? {
+    return error("returned error");
+}
+
+@test:Config {enable: false}
+function testDisabled() {
+    io:println("a disabled test never runs");
+}
+
+const boolean ENABLED = false;
+
+// A fully constant attachment carries no literal `enable` expression, so the
+// evaluated annotation value is what decides here.
+@test:Config {enable: ENABLED}
+function testDisabledByAConstant() {
+}

--- a/corpus/cli_integration_test.go
+++ b/corpus/cli_integration_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/ballerina-nutcracker/ballerina/projects"
 	"github.com/ballerina-nutcracker/ballerina/test_util"
+	"golang.org/x/tools/txtar"
 )
 
 const (
@@ -4017,4 +4018,132 @@ func runBalRunCorpusCase(t *testing.T, balBin, repoRoot, coverDir, outputsRoot, 
 			)
 		}
 	})
+}
+
+// assertBalCommandMatchesTxtarExact compares stdout, stderr and the exit code
+// against the txtar fixture verbatim. `bal test`'s assertions are mostly
+// negative — a filtered-out test must be absent, a passing test's io:println
+// must not be printed, a panicking `before` must leave the body unrun — and the
+// substring matching the other helpers use cannot express any of those.
+func assertBalCommandMatchesTxtarExact(
+	t *testing.T, balBin, repoRoot, coverDir string, extraEnv, args []string, txtarPath string,
+) {
+	t.Helper()
+	if runtime.GOOS == "js" || runtime.GOARCH == "wasm" {
+		t.Skip("skipping CLI integration test on WASM (js/wasm)")
+	}
+
+	stdout, stderr, exitCode := runCLICommandWithEnv(t, balBin, repoRoot, coverDir, extraEnv, args...)
+	stdout = normalizePaths(test_util.NormalizeNewlines(stdout), repoRoot)
+	stderr = normalizePaths(test_util.NormalizeNewlines(stderr), repoRoot)
+
+	if *update {
+		test_util.UpdateTxtarArchiveIfNeeded(t, txtarPath, []txtar.File{
+			{Name: "stdout", Data: []byte(stdout)},
+			{Name: "stderr", Data: []byte(stderr)},
+			{Name: "exitcode", Data: []byte(strconv.Itoa(exitCode) + "\n")},
+		})
+		return
+	}
+
+	expectedStdout, expectedStderr, expectedExitCode, err := test_util.LoadTxtarStdoutStderrExitcode(txtarPath)
+	if err != nil {
+		t.Fatalf("failed to parse txtar file %s: %v", txtarPath, err)
+	}
+	if stdout != expectedStdout {
+		t.Fatalf("unexpected stdout for command %q with expected file %s\n%s",
+			strings.Join(args, " "), txtarPath, test_util.FormatExpectedGot(expectedStdout, stdout))
+	}
+	if stderr != expectedStderr {
+		t.Fatalf("unexpected stderr for command %q with expected file %s\n%s",
+			strings.Join(args, " "), txtarPath, test_util.FormatExpectedGot(expectedStderr, stderr))
+	}
+	if strconv.Itoa(exitCode) != expectedExitCode {
+		t.Fatalf("unexpected exit code for command %q with expected file %s\n%s",
+			strings.Join(args, " "), txtarPath,
+			test_util.FormatExpectedGot(expectedExitCode, strconv.Itoa(exitCode)))
+	}
+}
+
+// TestBalTestScenarios drives `bal test` over the fixtures in
+// corpus/cli/testdata/test, asserting stdout (the non-TTY plain reporter),
+// stderr and the exit code exactly.
+func TestBalTestScenarios(t *testing.T) {
+	if runtime.GOOS == "js" || runtime.GOARCH == "wasm" {
+		t.Skip("skipping CLI integration test on WASM (js/wasm)")
+	}
+	balBin, repoRoot, coverDir := integrationTestBalCLI(t, false)
+	testdataRoot := filepath.Join("corpus", "cli", "testdata", "test")
+	outputsRoot := filepath.Join(repoRoot, "corpus", "cli", "output", "test")
+
+	project := func(name string) string { return filepath.Join(testdataRoot, name, "project") }
+
+	tests := []struct {
+		name string
+		args []string
+		// serial marks scenarios that bind a real port, so they must not run
+		// alongside the rest of the table.
+		serial bool
+	}{
+		{name: "basic", args: []string{"test", project("basic")}},
+		{name: "outcomes", args: []string{"test", project("outcomes")}},
+		{name: "hooks", args: []string{"test", project("hooks")}},
+		{name: "multi-module", args: []string{"test", project("filters")}},
+		// A realistic package: three modules, tests calling across them over
+		// shared module state, and every outcome kind in one run.
+		{name: "demo", args: []string{"test", project("demo")}},
+		{name: "demo-filtered", args: []string{"test", project("demo"), "--tests", "calc:test*,store:testPut*"}},
+		{name: "demo-list", args: []string{"test", project("demo"), "--list"}},
+		{name: "filter-by-name", args: []string{"test", project("filters"), "--tests", "testDefaultOne"}},
+		{name: "filter-by-module-and-name", args: []string{"test", project("filters"), "--tests", "sub:testSubOne"}},
+		{name: "filter-by-wildcard", args: []string{"test", project("filters"), "--tests", "testDefault*"}},
+		{name: "filter-matches-disabled", args: []string{"test", project("filters"), "--tests", "*Disabled"}},
+		{name: "list", args: []string{"test", project("filters"), "--list"}},
+		{name: "cross-module-hook", args: []string{"test", project("cross-module")}},
+		{name: "cross-module-private-hook", args: []string{"test", project("cross-module-private")}},
+		{name: "bad-enable", args: []string{"test", project("bad-enable")}},
+		{name: "bad-param", args: []string{"test", project("bad-param")}},
+		{name: "bad-main", args: []string{"test", project("bad-main")}},
+		{name: "main-fail", args: []string{"test", project("main-fail")}},
+		{name: "main-panic", args: []string{"test", project("main-panic")}},
+		{name: "lock", args: []string{"test", project("lock")}},
+		{name: "no-test-import", args: []string{"test", project("no-test-import")}},
+		{name: "run-does-not-invoke-tests", args: []string{"run", project("basic")}},
+		{name: "listener", args: []string{"test", project("listener")}, serial: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.serial {
+				t.Parallel()
+			}
+			assertBalCommandMatchesTxtarExact(t, balBin, repoRoot, coverDir,
+				[]string{"BAL_ENV=" + cliIntegrationBalEnv}, tt.args,
+				filepath.Join(outputsRoot, tt.name+".txtar"))
+		})
+	}
+}
+
+// TestBalTestBuiltBinaryDoesNotRunTests builds the basic fixture and runs the
+// produced executable: `@test:Config` must be a no-op there, exactly as under
+// `bal run`.
+func TestBalTestBuiltBinaryDoesNotRunTests(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "js" || runtime.GOARCH == "wasm" {
+		t.Skip("skipping CLI integration test on WASM (js/wasm)")
+	}
+	balBin, repoRoot, coverDir := integrationTestBalCLI(t, false)
+	projectDir := filepath.Join("corpus", "cli", "testdata", "test", "basic", "project")
+	targetDir := filepath.Join(repoRoot, projectDir, "target")
+	t.Cleanup(func() { _ = os.RemoveAll(targetDir) })
+
+	outBin := filepath.Join(t.TempDir(), hostExeSuffix("basic"))
+	_, buildErr, buildExit := runCLICommandWithEnv(t, balBin, repoRoot, coverDir,
+		[]string{"BAL_ENV=" + cliIntegrationBalEnv}, "build", projectDir, "-o", outBin)
+	if buildExit != 0 {
+		t.Fatalf("bal build failed: exit=%d\nstderr:\n%s", buildExit, buildErr)
+	}
+
+	assertBalCommandMatchesTxtarExact(t, outBin, repoRoot, coverDir, nil, nil,
+		filepath.Join(repoRoot, "corpus", "cli", "output", "test", "run-does-not-invoke-tests.txtar"))
 }

--- a/corpus/integration/lib/subset3/test-assert-fail-p.txtar
+++ b/corpus/integration/lib/subset3/test-assert-fail-p.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+-- stderr --
+error: uncaught failure
+        at ballerina/test:assertFail(0.0.1::test.bal:40)
+           main(test-assert-fail-p.bal:20)

--- a/corpus/integration/lib/subset3/test-assert-fail-v.txtar
+++ b/corpus/integration/lib/subset3/test-assert-fail-v.txtar
@@ -1,0 +1,5 @@
+-- stdout --
+true
+boom
+Test Failed!
+-- stderr --

--- a/corpus/lib/subset3/test-assert-fail-p.bal
+++ b/corpus/lib/subset3/test-assert-fail-p.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+public function main() {
+    test:assertFail("uncaught failure"); // @panic uncaught failure
+}

--- a/corpus/lib/subset3/test-assert-fail-v.bal
+++ b/corpus/lib/subset3/test-assert-fail-v.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+
+// Under `bal run` no host installs pal.Testing.Fail, so assertFail degrades to
+// a plain panic carrying the message.
+public function main() {
+    error? trapped = trap test:assertFail("boom");
+    io:println(trapped is error); // @output true
+    if trapped is error {
+        io:println(trapped.message()); // @output boom
+    }
+
+    error? defaulted = trap test:assertFail();
+    if defaulted is error {
+        io:println(defaulted.message()); // @output Test Failed!
+    }
+}

--- a/lib/rt/libs.go
+++ b/lib/rt/libs.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/os/0.0.1/go1.27/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/protobuf/0.0.1/go1.27/modules/types.any/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/random/0.0.1/go1.27/native"
+	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/test/0.0.1/go1.27/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/time/0.0.1/go1.27/native"
 	_ "github.com/ballerina-nutcracker/ballerina/lib/stdlibs/ballerina/url/0.0.1/go1.27/native"
 )

--- a/lib/stdlibs/ballerina/test/0.0.1/go1.27/Bala.toml
+++ b/lib/stdlibs/ballerina/test/0.0.1/go1.27/Bala.toml
@@ -1,0 +1,8 @@
+[bala]
+schema_version = "4"
+
+[build]
+ballerina_version      = ""
+implementation_vendor  = "WSO2"
+language_spec_version  = "2024R1"
+platform               = "go1.27"

--- a/lib/stdlibs/ballerina/test/0.0.1/go1.27/Ballerina.toml
+++ b/lib/stdlibs/ballerina/test/0.0.1/go1.27/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org     = "ballerina"
+name    = "test"
+version = "0.0.1"

--- a/lib/stdlibs/ballerina/test/0.0.1/go1.27/Dependencies.toml
+++ b/lib/stdlibs/ballerina/test/0.0.1/go1.27/Dependencies.toml
@@ -1,0 +1,7 @@
+[ballerina]
+dependencies-toml-version = "2"
+
+[[package]]
+org     = "ballerina"
+name    = "test"
+version = "0.0.1"

--- a/lib/stdlibs/ballerina/test/0.0.1/go1.27/README.md
+++ b/lib/stdlibs/ballerina/test/0.0.1/go1.27/README.md
@@ -1,0 +1,45 @@
+# Ballerina Test Library
+
+## Overview
+
+The `ballerina/test` library provides the annotation and assertions used by
+`bal test`. A function annotated with `@test:Config` is discovered by the CLI
+and executed against a live runtime.
+
+## Key Functionalities
+
+- Declare a test function with `@test:Config`, optionally disabling it (`enable`)
+  or attaching `before`/`after` hooks.
+- Fail the running test with `test:assertFail`.
+
+## Examples
+
+```ballerina
+import ballerina/test;
+
+@test:Config {}
+function testSomething() {
+    if 1 + 1 != 2 {
+        test:assertFail("arithmetic is broken");
+    }
+}
+```
+
+## Go Native Interpreter Support Status
+
+This library is currently being migrated to Go to support the Ballerina Native Interpreter. The table below outlines the current support level for various features of this library in the Go implementation.
+
+Support Levels:
+
+- **Supported**: Fully implemented and tested in the Go version.
+- **Partially Supported**: Implemented but lacking some edge cases, options, or sub-features. (See comments).
+- **Not Yet Supported**: Planned for migration, but not yet implemented.
+- **Cannot Support**: Cannot be implemented in the Go version due to technical limitations or architectural differences. (See comments).
+
+| Feature/API | Support Status | Comments / Limitations |
+|---|---|---|
+| `@test:Config` with `enable`, `before`, `after` | Supported | `enable` must be a boolean literal. |
+| `test:assertFail` | Supported | Marks the running test failed; under `bal run` it is a plain panic. |
+| Other assertions (`assertEquals`, `assertTrue`, ...) | Not Yet Supported | |
+| `groups`, `dependsOn`, data providers, mocking | Not Yet Supported | |
+| Test reports and code coverage | Not Yet Supported | |

--- a/lib/stdlibs/ballerina/test/0.0.1/go1.27/native/test.go
+++ b/lib/stdlibs/ballerina/test/0.0.1/go1.27/native/test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package native
+
+import (
+	"github.com/ballerina-nutcracker/ballerina/runtime"
+	"github.com/ballerina-nutcracker/ballerina/runtime/extern"
+	"github.com/ballerina-nutcracker/ballerina/values"
+)
+
+const (
+	orgName    = "ballerina"
+	moduleName = "test"
+)
+
+// externFail reports the failure to the host through PAL when a host installed
+// a hook, and always yields the error value assertFail panics.
+func externFail(ctx *extern.Context, args []values.BalValue) (values.BalValue, error) {
+	msg, _ := args[0].(string)
+	if fail := ctx.Env.Platform.Testing.Fail; fail != nil {
+		fail(msg)
+	}
+	return values.NewErrorWithMessage(msg), nil
+}
+
+func initTestModule(rt *runtime.Runtime) {
+	runtime.RegisterExternFunction(rt, orgName, moduleName, "externFail", externFail)
+}
+
+func init() {
+	runtime.RegisterModuleInitializer(initTestModule)
+}

--- a/lib/stdlibs/ballerina/test/0.0.1/go1.27/test.bal
+++ b/lib/stdlibs/ballerina/test/0.0.1/go1.27/test.bal
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Configuration of a test function.
+#
+# + enable - Whether the test is executed
+# + before - Function executed before the test body
+# + after - Function executed after the test body
+public type TestConfig record {|
+    boolean enable = true;
+    (function () returns (any|error)) before?;
+    (function () returns (any|error)) after?;
+|};
+
+# Marks a function as a test.
+#
+# `TestConfig` is a valid annotation type even though it is `on function` (and
+# therefore runtime-visible): a `function` value is inherently immutable, hence
+# `Cloneable`, so this closed record is a subtype of `map<Cloneable>`.
+public annotation TestConfig Config on function;
+
+# Marks the currently running test as failed and aborts it.
+#
+# + msg - The failure message
+# + return - Never returns; always panics
+public function assertFail(string msg = "Test Failed!") returns never {
+    panic externFail(msg);
+}
+
+function externFail(string msg) returns error = external;

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,227 @@
+# `bal test` (POC) — implementation plan
+
+## Context
+
+`spec.md` (authoritative, do not redesign) specifies a `bal test` command for the Go Ballerina
+implementation. Today there is no way to run test functions: `bal run` and `bal build` are the only
+execution paths, the only compiler plugins are those declared by a package manifest and statically
+linked through the generated `compilerpluginregistry`, and there is no `ballerina/test` stdlib.
+
+The feature needs four things that do not exist yet:
+
+1. A **host-injected compiler plugin** — the CLI must supply a plugin for one compilation, activated
+   by a module importing `ballerina/test`, so it can see `*ast.BLangPackage` and discover
+   `@test:Config` functions. `*ast.BLangPackage` is reachable only from a `PackageTransformer`
+   (`moduleContext.bLangPkg` is private and not exposed on `projects.Package`).
+2. A minimal **`ballerina/test` stdlib** (`TestConfig`, `Config`, `assertFail`).
+3. A **PAL `Testing.Fail` hook** so `assertFail` can signal failure to the CLI, which owns the PAL.
+4. A **test runner** in the CLI that drives `runtime.LookupFunction`/`InvokeFunction` directly,
+   after `Init` and `Listen`, with per-test stdout capture and outcome reporting.
+
+Outcome: `bal test` runs every enabled, matching `@test:Config` function and reports pass/fail/error/skip;
+`bal run` and `bal build` on the same package behave exactly as before (the annotation type-checks and is
+a no-op).
+
+## Decisions filling gaps the spec leaves open
+
+- **`--tests` / `--list` module form: bare submodule name.** `ModuleKey{Org, Module}` keeps the full
+  dotted runtime identity (`foo.sub`), which is what `runtime.LookupFunction` needs. The *display and
+  filter* name is the text after the first `.`, or the whole string when there is none — so package
+  `foo`'s default module shows as `foo` and its submodule `sub` as `sub`. Add
+  `func (k ModuleKey) displayName() string` and use it in both `Filter.Matches` and the reporters.
+  Root-package module names are always `<pkgName>` or `<pkgName>.<rest>`, so this needs no package name.
+- **`Result.Duration` is not printed.** The spec's Reporter section fully specifies both output
+  formats and neither includes a duration; printing one would make every txtar golden flaky. Keep the
+  field (the spec declares it), leave it out of the output.
+- **Unit tests live beside the code, not in the corpus.** Three scenarios the corpus cannot reach get
+  ordinary Go unit tests. The spec's `bal test` fixtures still go through
+  `corpus/cli_integration_test.go`, which drives the real `bal` binary with arbitrary args (it already
+  covers `bal build` and `bal pack`) — that is not the `corpus/bal` per-stage corpus.
+
+## Verified facts the implementation depends on
+
+- `att.Symbol()` **is** populated after semantics: `semantics/internal/symbols/symbol_resolver.go:1460`
+  calls `target.SetSymbol(symRef)`. `GetAnnotationAttachments()` returns the slice header
+  (`ast/ast.go:935`), so the type resolver's in-place mutations are visible to the plugin. Match
+  `Config` via `compilerCtx.SymbolPackage(att.Symbol())` (`{Organization:"ballerina", Package:"test"}`,
+  ignore `Version`) plus `SymbolName(att.Symbol()) == "Config"`. Guard with `ast.SymbolIsSet`.
+- `AnnotationValue` is populated **only when the whole attachment is constant**
+  (`semantics/internal/types/type_resolver.go:1475-1490`) — a `before`/`after` function reference makes
+  it nil. This is why the spec needs both the AST path and the `*values.Map` path.
+- `att.Expr` is **not** desugared before `AfterSemantics` (plugins are phase 3, desugar is phase 4,
+  `projects/package_compilation.go:154-167`) and the runtime-value rewrite never fires for function
+  annotations (sink is nil, `type_resolver.go:1273`). So
+  `att.Expr.(*ast.BLangMappingConstructorExpr)` → `*ast.BLangMappingKeyValueField` is safe.
+- `Config`'s record type **passes** the annotation-type check: a `function` value is inherently
+  immutable (`btFunction < btFuture`, `semtypes/basic_type_code.go:92`), hence `Cloneable`, hence the
+  closed record is a subtype of `map<Cloneable>`. Worth a comment in `test.bal` — it is non-obvious.
+- `ballerina/test` **will** be in `resolver.providers` and in `Environment.publicSymbols`:
+  `newCompilerPluginResolver` is fed `topologicallySortedModuleList`, which includes dependency
+  modules, and phase 1 publishes symbols for every source-loaded module
+  (`projects/module_context.go:299`). So the hard `InternalError` at `package_compilation.go:226` is
+  unreachable.
+- `runtime.LookupFunction` keys on `org + "/" + module + ":" + name`
+  (`runtime/internal/exec/dispatch.go:48`) where `module` is `PackageID.PkgName` = the full dotted
+  module name (`projects/module_context.go:516`), with no visibility check and no dead-code
+  elimination. So `ModuleKey` from `pkg.PackageID` matches exactly, and non-`public` test functions
+  are reachable.
+- `import ballerina/test;` used only in `@test:Config` does **not** trigger "unused import prefix"
+  (`symbol_resolver.go:309-314` marks the prefix used on the annotation path).
+- A Ballerina `panic` leaves `InvokeFunction` as a **Go panic**; the Go `error` return is always nil
+  for BIR functions (`runtime/internal/exec/handle.go:44-52`). A test that *returns* an error yields it
+  as the `values.BalValue` result — type-assert to `*values.Error`.
+- `returns never` + `panic <call-expr>` is accepted (`corpus/bal/subset9/09-function/never-3-v.bal`).
+- `isTerminal()` already exists at `cli/cmd/utils.go:72` — reuse it, at command level, not inside the
+  reporter.
+
+## Stages
+
+Each stage builds (`go build ./...` per module; `go.work` already covers every module) and has a test
+that passes at that stage. Stages 3 and 5 are the transient states the spec permits.
+
+### Stage 1 — `feat(pal): add Testing group`
+`platform/pal/platform.go`: add `Testing Testing` to `Platform` and
+`type Testing struct{ Fail func(message string) }` in the same `type (...)` block. `palnative.NewPlatform`
+leaves it zero. Purely additive; proof is compilation of `platform`, `runtime`, `lib`, `cli`.
+
+### Stage 2 — `fix(runtime): release held locks when an invoked function panics`
+`runtime/runtime.go:40-43`: add a deferred `recover` to `InvokeFunction` that calls
+`cx.ReleaseAllHeldLocks()` and re-panics with the same value. `cx` is `*extern.Context`
+(`runtime/internal/exec/exec.go:28`), so `ReleaseAllHeldLocks` (`runtime/extern/extern.go:181`) is in
+scope. Mirrors `exec.RunEntrypoints` (`runtime/internal/exec/interpreter.go:33-38`) and
+`exec.startFuture`. The three existing callers (`corpus/integration_test.go:373`,
+`runtime/lifecycle_test.go:374`, `test_util/testharness/test_harness.go:549`) do not rely on locks
+staying held.
+
+**Test:** `runtime/lifecycle_test.go` — a `lock`-holding function that panics, then a second function
+entering the same `lock`; assert it completes under a `time.After` guard. The file already has
+`newLifecycleTestRuntime` (line 377), `invokeAndRecover` (line 370) and that guard idiom (line 365).
+
+### Stage 3 — `feat(compilerplugin): add injected plugin types`
+`compilerplugin/compilerplugin.go`: add `Provider{Org, Package}` and
+`InjectedPlugin{Provider, Plugin}`. Data only; no consumer yet.
+
+### Stage 4 — `feat(projects): apply host-injected compiler plugins`
+- `projects/env.go` — private `injectedPlugins` field + `injectedCompilerPlugins()` accessor.
+- `projects/project_environment_builder.go` — field + `WithCompilerPlugins`, copied in `Build()`.
+- `projects/project_loader.go` — `CompilerPlugins` on `ProjectLoadConfig`; thread it through
+  `createEnvironmentWithRepositories` and `createWorkspaceEnvironment`. `loadBalaProjectWithEnv`
+  inherits via the shared environment, as the spec states.
+- `projects/compiler_plugin_registry.go` — `rootPackage PackageDescriptor` and
+  `injected []compilerplugin.InjectedPlugin` on the resolver; new `newCompilerPluginResolver`
+  signature; `injected bool` on `resolvedCompilerPlugin` (error messages only); `pluginsFor` appends
+  injected plugins **after** manifest plugins, only when the module's package descriptor equals
+  `rootPackage` and `module.explicitImports` contains the provider. `declaration.function` is
+  `"<injected>"`; `position` is the matching import — `runCompilerPlugins` uses only
+  `resolved.position.position` as a diagnostic location, so no change is needed there.
+- `projects/package_compilation.go:155` — pass `c.rootPackageContext.getDescriptor()` and
+  `...Environment().injectedCompilerPlugins()`.
+
+**Test:** `projects/compiler_plugin_registry_test.go` — three cases (root-package module importing the
+provider → applied; dependency-package module → not applied; injected runs after manifest). The
+existing tests already build `&compilerPluginResolver{...}` and `&moduleContext{...}` literals directly
+(lines 32-120), so these drop into that pattern. Plus `go test ./projects/...` for regressions.
+
+### Stage 5 — `feat(lib): add ballerina/test stdlib`
+New `lib/stdlibs/ballerina/test/0.0.1/go1.27/`: `Ballerina.toml`, `Bala.toml`, `Dependencies.toml`,
+`README.md`, `test.bal`, `native/test.go` — copy the shapes from
+`lib/stdlibs/ballerina/random/0.0.1/go1.27/*` (`Bala.toml` needs `schema_version = "4"`,
+`platform = "go1.27"`). No `CompilerPlugin.toml`, so plugin-gen and the manifest path ignore it.
+`lib/stdlibs/embed.go` needs no change (`//go:embed all:ballerina`). Add the blank import to
+`lib/rt/libs.go` (alphabetically, after `random`).
+
+`native/test.go` follows the `random` template: `init()` → `runtime.RegisterModuleInitializer`,
+`RegisterExternFunction(rt, "ballerina", "test", "externFail", externFail)`; `externFail` calls
+`ctx.Env.Platform.Testing.Fail` when non-nil and returns `values.NewErrorWithMessage(msg), nil`.
+
+**Test:** a corpus lib fixture under `corpus/lib/subset<N>/` (per `AGENTS.md`) — `trap test:assertFail("boom")`
+printing the message, plus a `-p` case for the bare default-arg call. This proves `returns never` +
+`panic externFail(msg)` + the defaultable param compile and run, and that a nil `Testing.Fail`
+degrades to a plain panic, all before any CLI code exists. Golden via `go test ./corpus -update`.
+
+### Stage 6 — `feat(cli): add testerina plan, collector and schedule`
+New `cli/internal/testerina/{plan.go,collector.go,schedule.go}` exactly as specified.
+`collector.collect` must hold `c.mu` — `runCompilerPlugins` runs one goroutine per module
+(`package_compilation.go:156` via `runModulePhase`). Source-order sorting is by
+`(Position.FileIndex(), Position.StartOffset())`; those accessors have pointer receivers
+(`tools/diagnostics/location.go:69-79`), so keep the `slices.SortFunc` comparator over
+`TestFunction` values.
+
+`cli/go.mod`: promote `ast`, `model`, `values` to direct requires and add `compilerplugin`
+(`context` is already direct). `go.work` already has the `replace` directives, so no `go.sum` change.
+
+**Test:** `cli/internal/testerina/schedule_test.go` for `ParseFilter`/`Matches` only — wildcard
+placement (leading, trailing, interior, bare `*`, `*:*`), `module:name` vs bare `name`, empty-entry
+rejection, and the bare-submodule display-name rule. Pure string logic, no compiler dependency.
+
+### Stage 7 — `feat(cli): add bal test command`
+New `cli/internal/testerina/{runner.go,reporter.go}` and `cli/cmd/test.go`. Follow `build.go`'s style
+(`type testOptions struct`, `var testCmd = createTestCmd()`, `cmd.OutOrStdout()`/`cmd.ErrOrStderr()`)
+rather than `run.go`'s package-level var and raw `os.Stdout`. Register in `cli/cmd/bal.go`.
+
+Two constraints that are not optional:
+
+- **PAL install order.** `extern.InitEnv` copies `pal.Platform` **by value**
+  (`runtime/extern/extern.go:55-64`), so every override must be in place before `NewRuntime`:
+  `NewRunner(platform, osSignals, tyEnv)` → `runtime.NewRuntime(runner.Platform(), tyEnv)` →
+  `runner.Start(rt)` → `rt.Init` per package → `rt.Listen()` → `runner.Run(schedule, reporter)` →
+  `runner.Shutdown(rt)`. The signal channel must be non-nil at the first `Init` —
+  `setupSignalListeners` panics on nil (`runtime/lifecycle.go:293`).
+- **`Shutdown` must not signal an already-stopped runtime.** With no listeners, `Listen()` runs
+  `GracefulStopping → Stopped`, and `stoppedAction` writes and **closes** `exitCodeChan`
+  (`runtime/lifecycle.go:272-284`). The signal watcher checks `state == StateStopped` *before* its
+  receive (`lifecycle.go:288-305`), so a later `GracefulStop` send wakes it and it calls
+  `go rt.transition(StateGracefulStopping)` — and `transitionTable[StateStopped][StateGracefulStopping]`
+  is nil, so `transition` **panics on a bare goroutine and kills the process** after the summary.
+  This would hit most fixtures. Guard as the spec's own wording implies ("if no listeners existed the
+  channel already holds `0`"): non-blocking read of `rt.ExitStatus` first and return if it yields;
+  otherwise non-blocking `GracefulStop` send, then `<-rt.ExitStatus`. Then close the runner's signal
+  channel (`lifecycle.go:73` requires the sender to close) and stop the OS-signal forwarder.
+  Running tests after the runtime reaches `Stopped` is fine — `LookupFunction`/`InvokeFunction` consult
+  only the module registry and never check lifecycle state.
+
+Also: `runner.fail`, the `IO.Stdout` closure and `current` are called from arbitrary strands (workers,
+`$start` hooks, HTTP resource goroutines), so all of that state shares one mutex. `invoke` detects
+`Errored` three ways — a recovered panic (`*values.Error` → `.Message`, else `fmt.Sprint(v)`), a
+returned `*values.Error` result, and a non-nil Go `error`.
+
+`corpus/cli/output/help/help.txtar` will change: registering a non-hidden `test` alters `bal --help`
+and breaks `TestBalHelp` (`corpus/cli_integration_test.go:62`). Regenerate deliberately — the golden is
+already stale, so expect the diff to also add `build`, `pack`, `push`.
+
+**Test:** `cli/internal/testerina/reporter_test.go` for `ttyReporter` (feed a fixed `[]Result` to
+`NewTTYReporter(&bytes.Buffer{})` and assert the `\r`-rewritten line) — the corpus harness runs over
+pipes and can never reach it. Plus one smoke corpus fixture and `TestBalHelp`.
+
+### Stage 8 — `test(corpus): bal test scenarios`
+Fixtures under `corpus/cli/testdata/test/<case>/`, goldens under `corpus/cli/output/test/*.txtar`, and a
+table-driven `TestBalTestScenarios` in `corpus/cli_integration_test.go` modelled on
+`TestBalBuildScenarios` (line 567). Cover every scenario in the spec's Tests section.
+
+**This stage needs a new exact-match assertion helper.** All three existing helpers
+(`assertBalCommandMatchesTxtarFragmentsLoose` at line 471, `...WithEnv` at 518,
+`...ForBinary` at 3201) match stdout by **substring**, which cannot express the spec's negative
+assertions: "non-matching tests absent from output", "`io:println` in a passing test is not printed",
+"`before` panic → body not run", "`--list` runs nothing". Factor the exact comparison already written
+inline in `TestBalBuildWorkspace` (lines 740-757: `test_util.LoadTxtarStdoutStderrExitcode` +
+equality + `test_util.FormatExpectedGot`) into a local `assertBalCommandMatchesTxtarExact`.
+
+The `http:Listener` fixture: model it on `corpus/extern/testdata/http-service/http-svc-basic-v.bal:33-40`
+(a service on `new http:Listener(port)` plus a client call), renaming its driver to a `@test:Config`
+function. `ballerina/http` is a bundled stdlib, not a bala with native Go sources, so
+`execWithNativeRunner` finds nothing and does not re-exec. Give it a port not used by
+`corpus/extern/testdata/http-service/*` and keep it out of the parallel table. This is the fixture that
+proves the `Shutdown` path, since `Listen()` genuinely parks in `StateListening`.
+
+## Verification
+
+- `make build && make vet` — every module compiles.
+- `go test ./runtime/... ./projects/... ./cli/...` — the unit gates from stages 2, 4, 6, 7.
+- `go test ./corpus -run 'TestLibIntegration'` — stage 5's stdlib fixture.
+- `go test ./corpus -run 'TestBalTestScenarios|TestBalHelp|TestBalRunCorpus|TestBalBuildScenarios'` —
+  the `bal test` acceptance suite, the regenerated help golden, and proof that `bal run`/`bal build`
+  still behave as before.
+- Manual end-to-end: `go run ./cli/cmd test <fixture>` on the basic fixture (2 passing), the
+  `assertFail` fixture (exit 1, message in summary), `--list`, `--tests`, and the listener fixture
+  (must exit, not hang).
+- `make test` before finishing — the full native suite.

--- a/platform/pal/platform.go
+++ b/platform/pal/platform.go
@@ -55,6 +55,12 @@ type (
 		Time    Time
 		HTTP    HTTP
 		Signals SignalSource
+		Testing Testing
+	}
+	// Testing lets library code signal test outcomes to the host. All fields may
+	// be nil; callers must nil-check before invoking them.
+	Testing struct {
+		Fail func(message string)
 	}
 	IO struct {
 		Stdout func(p []byte) (n int, err error)

--- a/projects/compiler_plugin_registry.go
+++ b/projects/compiler_plugin_registry.go
@@ -100,13 +100,21 @@ type compilerPluginResolver struct {
 	registry     *compilerPluginRegistry
 	moduleOwners map[moduleIdentity]string
 	providers    map[string]compilerPluginProvider
+	rootPackage  PackageDescriptor
+	injected     []compilerplugin.InjectedPlugin
 }
 
-func newCompilerPluginResolver(modules []*moduleContext) *compilerPluginResolver {
+func newCompilerPluginResolver(
+	modules []*moduleContext,
+	rootPackage PackageDescriptor,
+	injected []compilerplugin.InjectedPlugin,
+) *compilerPluginResolver {
 	resolver := &compilerPluginResolver{
 		registry:     getLinkedCompilerPluginRegistry(),
 		moduleOwners: make(map[moduleIdentity]string),
 		providers:    make(map[string]compilerPluginProvider),
+		rootPackage:  rootPackage,
+		injected:     injected,
 	}
 	for _, module := range modules {
 		descriptor := module.getDescriptor()
@@ -176,7 +184,12 @@ type resolvedCompilerPlugin struct {
 	declaration compilerPluginDeclaration
 	plugin      compilerplugin.CompilerPlugin
 	position    moduleImport
+	injected    bool
 }
+
+// injectedPluginFunctionName stands in for the manifest-declared Go function
+// name in diagnostics about host-injected plugins, which have none.
+const injectedPluginFunctionName = "<injected>"
 
 func (r *compilerPluginResolver) pluginsFor(module *moduleContext) ([]resolvedCompilerPlugin, error) {
 	providers := make(map[string]moduleImport)
@@ -219,7 +232,56 @@ func (r *compilerPluginResolver) pluginsFor(module *moduleContext) ([]resolvedCo
 			})
 		}
 	}
-	return result, nil
+	return append(result, r.injectedPluginsFor(module, modulePackage)...), nil
+}
+
+// injectedPluginsFor returns the host-injected plugins that apply to module:
+// those whose provider package is explicitly imported by a root-package module.
+func (r *compilerPluginResolver) injectedPluginsFor(
+	module *moduleContext, modulePackage PackageDescriptor,
+) []resolvedCompilerPlugin {
+	if len(r.injected) == 0 || !modulePackage.Equals(r.rootPackage) {
+		return nil
+	}
+	var result []resolvedCompilerPlugin
+	for _, injected := range r.injected {
+		key := providerKey(injected.Provider.Org, injected.Provider.Package)
+		imported, ok := r.explicitImportOf(module, key)
+		if !ok {
+			continue
+		}
+		provider, ok := r.providers[key]
+		if !ok {
+			continue
+		}
+		result = append(result, resolvedCompilerPlugin{
+			provider: provider,
+			declaration: compilerPluginDeclaration{
+				after: injected.Plugin.After, function: injectedPluginFunctionName,
+			},
+			plugin:   injected.Plugin,
+			position: imported,
+			injected: true,
+		})
+	}
+	return result
+}
+
+// explicitImportOf reports whether module explicitly imports any module owned
+// by the package providerKey identifies. The import is matched through
+// moduleOwners rather than by module name, because compilerplugin.Provider
+// names a package: importing a non-default module such as
+// ballerina/test.helpers still activates the ballerina/test provider.
+func (r *compilerPluginResolver) explicitImportOf(
+	module *moduleContext, providerKey string,
+) (moduleImport, bool) {
+	for _, imported := range module.explicitImports {
+		owner, known := r.moduleOwners[moduleIdentity{org: imported.org, moduleName: imported.moduleName}]
+		if known && owner == providerKey {
+			return imported, true
+		}
+	}
+	return moduleImport{}, false
 }
 
 func parseCompilerPluginManifest(content string) ([]compilerPluginDeclaration, error) {

--- a/projects/compiler_plugin_registry_test.go
+++ b/projects/compiler_plugin_registry_test.go
@@ -254,3 +254,182 @@ func mustParseCompilerPluginManifest(t *testing.T, content string) []compilerPlu
 	}
 	return declarations
 }
+
+func TestInjectedCompilerPluginsApplyOnlyToImportingRootPackageModules(t *testing.T) {
+	version, err := NewPackageVersionFromString("1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootPackage := NewPackageDescriptor(NewPackageOrg("acme"), NewPackageName("app"), version)
+	dependencyPackage := NewPackageDescriptor(NewPackageOrg("acme"), NewPackageName("dep"), version)
+	testProvider := compilerPluginProvider{
+		org: "ballerina", pkg: "test",
+		exported: semantics.PackageIdentifier{OrgName: "ballerina", ModuleName: "test"},
+	}
+	injected := []compilerplugin.InjectedPlugin{{
+		Provider: compilerplugin.Provider{Org: "ballerina", Package: "test"},
+		Plugin: compilerplugin.CompilerPlugin{
+			After: compilerplugin.AfterSemantics,
+			PackageTransformer: func(_ *compilercontext.CompilerContext, _ model.ExportedSymbolSpace, pkg *ast.BLangPackage) (*ast.BLangPackage, error) {
+				return pkg, nil
+			},
+		},
+	}}
+	newResolver := func() *compilerPluginResolver {
+		return &compilerPluginResolver{
+			registry: newCompilerPluginRegistry(),
+			moduleOwners: map[moduleIdentity]string{
+				{org: "ballerina", moduleName: "test"}: "ballerina/test",
+			},
+			providers:   map[string]compilerPluginProvider{"ballerina/test": testProvider},
+			rootPackage: rootPackage,
+			injected:    injected,
+		}
+	}
+	testImport := []moduleImport{{org: "ballerina", moduleName: "test"}}
+
+	rootModule := &moduleContext{
+		moduleDescriptor: NewModuleDescriptorForDefaultModule(rootPackage),
+		explicitImports:  testImport,
+	}
+	plugins, err := newResolver().pluginsFor(rootModule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plugins) != 1 || !plugins[0].injected {
+		t.Fatalf("root-package module plugins = %#v, want one injected plugin", plugins)
+	}
+
+	rootModuleWithoutImport := &moduleContext{
+		moduleDescriptor: NewModuleDescriptorForDefaultModule(rootPackage),
+	}
+	plugins, err = newResolver().pluginsFor(rootModuleWithoutImport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plugins) != 0 {
+		t.Fatalf("module without the provider import activated plugins: %#v", plugins)
+	}
+
+	dependencyModule := &moduleContext{
+		moduleDescriptor: NewModuleDescriptorForDefaultModule(dependencyPackage),
+		explicitImports:  testImport,
+	}
+	plugins, err = newResolver().pluginsFor(dependencyModule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plugins) != 0 {
+		t.Fatalf("dependency-package module activated injected plugins: %#v", plugins)
+	}
+}
+
+func TestInjectedCompilerPluginsActivateOnNonDefaultModuleImport(t *testing.T) {
+	version, err := NewPackageVersionFromString("1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootPackage := NewPackageDescriptor(NewPackageOrg("acme"), NewPackageName("app"), version)
+	testProvider := compilerPluginProvider{
+		org: "ballerina", pkg: "test",
+		exported: semantics.PackageIdentifier{OrgName: "ballerina", ModuleName: "test"},
+	}
+	resolver := &compilerPluginResolver{
+		registry: newCompilerPluginRegistry(),
+		// Both modules belong to the ballerina/test package.
+		moduleOwners: map[moduleIdentity]string{
+			{org: "ballerina", moduleName: "test"}:         "ballerina/test",
+			{org: "ballerina", moduleName: "test.helpers"}: "ballerina/test",
+		},
+		providers:   map[string]compilerPluginProvider{"ballerina/test": testProvider},
+		rootPackage: rootPackage,
+		injected: []compilerplugin.InjectedPlugin{{
+			Provider: compilerplugin.Provider{Org: "ballerina", Package: "test"},
+			Plugin: compilerplugin.CompilerPlugin{
+				After: compilerplugin.AfterSemantics,
+				PackageTransformer: func(_ *compilercontext.CompilerContext, _ model.ExportedSymbolSpace, pkg *ast.BLangPackage) (*ast.BLangPackage, error) {
+					return pkg, nil
+				},
+			},
+		}},
+	}
+
+	// Importing a non-default module of the provider package has to activate
+	// the provider: compilerplugin.Provider identifies a package, not a module.
+	module := &moduleContext{
+		moduleDescriptor: NewModuleDescriptorForDefaultModule(rootPackage),
+		explicitImports:  []moduleImport{{org: "ballerina", moduleName: "test.helpers"}},
+	}
+	plugins, err := resolver.pluginsFor(module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plugins) != 1 || !plugins[0].injected {
+		t.Fatalf("non-default module import plugins = %#v, want one injected plugin", plugins)
+	}
+	if plugins[0].position.moduleName != "test.helpers" {
+		t.Fatalf("injected plugin position = %#v, want the test.helpers import", plugins[0].position)
+	}
+
+	// An unrelated import of the same org must not activate it.
+	unrelated := &moduleContext{
+		moduleDescriptor: NewModuleDescriptorForDefaultModule(rootPackage),
+		explicitImports:  []moduleImport{{org: "ballerina", moduleName: "io"}},
+	}
+	plugins, err = resolver.pluginsFor(unrelated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plugins) != 0 {
+		t.Fatalf("unrelated import activated injected plugins: %#v", plugins)
+	}
+}
+
+func TestInjectedCompilerPluginsRunAfterManifestPlugins(t *testing.T) {
+	version, err := NewPackageVersionFromString("1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootPackage := NewPackageDescriptor(NewPackageOrg("acme"), NewPackageName("app"), version)
+	resolver := &compilerPluginResolver{
+		registry: newCompilerPluginRegistry(),
+		moduleOwners: map[moduleIdentity]string{
+			{org: "ballerina", moduleName: "http"}: "ballerina/http",
+			{org: "ballerina", moduleName: "test"}: "ballerina/test",
+		},
+		providers: map[string]compilerPluginProvider{
+			"ballerina/http": {
+				org: "ballerina", pkg: "http",
+				declarations: []compilerPluginDeclaration{{
+					after: compilerplugin.AfterSemantics, function: "ValidateService",
+				}},
+			},
+			"ballerina/test": {org: "ballerina", pkg: "test"},
+		},
+		rootPackage: rootPackage,
+		injected: []compilerplugin.InjectedPlugin{{
+			Provider: compilerplugin.Provider{Org: "ballerina", Package: "test"},
+		}},
+	}
+	module := &moduleContext{
+		moduleDescriptor: NewModuleDescriptorForDefaultModule(rootPackage),
+		explicitImports: []moduleImport{
+			{org: "ballerina", moduleName: "test"},
+			{org: "ballerina", moduleName: "http"},
+		},
+	}
+
+	plugins, err := resolver.pluginsFor(module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plugins) != 2 {
+		t.Fatalf("plugins = %#v, want a manifest plugin followed by an injected one", plugins)
+	}
+	if plugins[0].injected || plugins[0].declaration.function != "ValidateService" {
+		t.Fatalf("first plugin = %#v, want the manifest-declared plugin", plugins[0])
+	}
+	if !plugins[1].injected || plugins[1].declaration.function != injectedPluginFunctionName {
+		t.Fatalf("second plugin = %#v, want the injected plugin", plugins[1])
+	}
+}

--- a/projects/env.go
+++ b/projects/env.go
@@ -19,6 +19,7 @@ package projects
 import (
 	"io/fs"
 
+	"github.com/ballerina-nutcracker/ballerina/compilerplugin"
 	"github.com/ballerina-nutcracker/ballerina/context"
 	"github.com/ballerina-nutcracker/ballerina/model"
 	"github.com/ballerina-nutcracker/ballerina/semantics"
@@ -35,6 +36,14 @@ type Environment struct {
 	resolutionOptions ResolutionOptions
 	// TODO: find better place to put this
 	publicSymbols map[semantics.PackageIdentifier]model.ExportedSymbolSpace
+	// injectedPlugins are compiler plugins supplied by the host for this
+	// compilation rather than declared by a package manifest.
+	injectedPlugins []compilerplugin.InjectedPlugin
+}
+
+// injectedCompilerPlugins returns the host-supplied compiler plugins.
+func (e *Environment) injectedCompilerPlugins() []compilerplugin.InjectedPlugin {
+	return e.injectedPlugins
 }
 
 // NewEnvironment creates a new Environment.

--- a/projects/package_compilation.go
+++ b/projects/package_compilation.go
@@ -152,7 +152,11 @@ func (c *PackageCompilation) compileModulesInternal() {
 		}
 
 		// Phase 3: compiler plugins. This is a package-wide barrier before desugaring.
-		c.compilerPluginManager = newCompilerPluginResolver(modules)
+		c.compilerPluginManager = newCompilerPluginResolver(
+			modules,
+			c.rootPackageContext.getDescriptor(),
+			c.rootPackageContext.project.Environment().injectedCompilerPlugins(),
+		)
 		runModulePhase(modules, func(module *moduleContext) {
 			c.runCompilerPlugins(module)
 		})

--- a/projects/project_environment_builder.go
+++ b/projects/project_environment_builder.go
@@ -19,15 +19,17 @@ package projects
 import (
 	"io/fs"
 
+	"github.com/ballerina-nutcracker/ballerina/compilerplugin"
 	"github.com/ballerina-nutcracker/ballerina/context"
 	"github.com/ballerina-nutcracker/ballerina/lib/langlibs"
 	"github.com/ballerina-nutcracker/ballerina/semtypes"
 )
 
 type ProjectEnvironmentBuilder struct {
-	fsys         fs.FS
-	repositories []Repository
-	buildOptions BuildOptions
+	fsys            fs.FS
+	repositories    []Repository
+	buildOptions    BuildOptions
+	compilerPlugins []compilerplugin.InjectedPlugin
 }
 
 func NewProjectEnvironmentBuilder(fsys fs.FS) *ProjectEnvironmentBuilder {
@@ -47,9 +49,17 @@ func (b *ProjectEnvironmentBuilder) WithBuildOptions(options BuildOptions) *Proj
 	return b
 }
 
+// WithCompilerPlugins sets the host-injected compiler plugins applied to the
+// root package during compilation.
+func (b *ProjectEnvironmentBuilder) WithCompilerPlugins(plugins []compilerplugin.InjectedPlugin) *ProjectEnvironmentBuilder {
+	b.compilerPlugins = plugins
+	return b
+}
+
 func (b *ProjectEnvironmentBuilder) Build() *Environment {
 	env := context.NewCompilerEnvironment(semtypes.CreateTypeEnv(), b.buildOptions.Stats())
 	projEnv := NewEnvironment(b.fsys, env)
+	projEnv.injectedPlugins = b.compilerPlugins
 
 	// ResolutionOptions are a runtime-facing subset of BuildOptions; derive
 	// them so callers configure a single source of truth (BuildOptions) and

--- a/projects/project_loader.go
+++ b/projects/project_loader.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/ballerina-nutcracker/ballerina/common/tomlparser"
+	"github.com/ballerina-nutcracker/ballerina/compilerplugin"
 	"github.com/ballerina-nutcracker/ballerina/tools/diagnostics"
 )
 
@@ -39,6 +40,9 @@ type ProjectLoadConfig struct {
 	// <project-path>/.ballerina for build projects and <file-path-parent>/.ballerina
 	// for single-file projects.
 	BallerinaEnvFs fs.FS
+	// CompilerPlugins are host-injected compiler plugins applied to root-package
+	// modules that explicitly import the plugin's provider package.
+	CompilerPlugins []compilerplugin.InjectedPlugin
 }
 
 // ProjectLoader loads Ballerina projects from the filesystem.
@@ -146,6 +150,7 @@ func (l *ProjectLoader) createWorkspaceEnvironment(cfg ProjectLoadConfig, worksp
 	env := NewProjectEnvironmentBuilder(l.projectFs).
 		WithRepositories(repos).
 		WithBuildOptions(buildOpts).
+		WithCompilerPlugins(cfg.CompilerPlugins).
 		Build()
 	env.setCustomRepos(customRepos)
 	return env
@@ -200,6 +205,7 @@ func (l *ProjectLoader) createEnvironmentWithRepositories(cfg ProjectLoadConfig,
 	env := NewProjectEnvironmentBuilder(l.projectFs).
 		WithRepositories(repos).
 		WithBuildOptions(buildOpts).
+		WithCompilerPlugins(cfg.CompilerPlugins).
 		Build()
 	env.setCustomRepos(customRepos)
 	return env

--- a/runtime/lifecycle_test.go
+++ b/runtime/lifecycle_test.go
@@ -523,3 +523,56 @@ func (p *lifecycleTestPal) Stdout() string {
 func (p *lifecycleTestPal) String() string {
 	return fmt.Sprintf("stdout=%q stderr=%q", p.stdout.String(), p.stderr.String())
 }
+
+// InvokeFunction must not leak locks held by a panicking callee; otherwise the
+// next invocation entering the same lock deadlocks.
+func TestInvokeFunctionReleasesHeldLocksOnPanic(t *testing.T) {
+	platform := newLifecycleTestPal(t)
+	rt := newLifecycleTestRuntime(t, `
+isolated int counter = 0;
+
+public function panicInLock() {
+    int[] empty = [];
+    lock {
+        counter += empty[1];
+    }
+}
+
+public function enterLock() returns int {
+    lock {
+        counter += 1;
+        return counter;
+    }
+}
+`, platform)
+
+	panicking, ok := runtime.LookupFunction(rt, "testorg", "lifecycletest", "panicInLock")
+	if !ok {
+		t.Fatal("panicInLock not found")
+	}
+	if recovered := invokeAndRecover(rt, panicking); recovered == nil {
+		t.Fatal("expected panicInLock to panic")
+	}
+
+	entering, ok := runtime.LookupFunction(rt, "testorg", "lifecycletest", "enterLock")
+	if !ok {
+		t.Fatal("enterLock not found")
+	}
+	done := make(chan values.BalValue, 1)
+	go func() {
+		result, err := runtime.InvokeFunction(rt, entering, nil)
+		if err != nil {
+			t.Errorf("enterLock returned an error: %v", err)
+		}
+		done <- result
+	}()
+
+	select {
+	case result := <-done:
+		if got, want := result, values.BalValue(int64(1)); got != want {
+			t.Fatalf("enterLock returned %v, want %v", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("enterLock deadlocked on a lock held by the panicking invocation")
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -39,6 +39,14 @@ func LookupFunction(rt *Runtime, org, module, name string) (any, bool) {
 
 func InvokeFunction(rt *Runtime, fn any, args []values.BalValue) (values.BalValue, error) {
 	cx := exec.CreateContext(rt.env)
+	// A panic escaping the invoked function would otherwise leave every lock it
+	// entered held forever, deadlocking later invocations on the same lock.
+	defer func() {
+		if r := recover(); r != nil {
+			cx.ReleaseAllHeldLocks()
+			panic(r)
+		}
+	}()
 	return exec.Invoke(cx, fn, args)
 }
 

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,477 @@
+# `bal test` command (POC)
+
+Specify:
+
+- Goals
+  - Add a `bal test` command that compiles the current package with an additional, CLI-injected compiler
+    plugin, discovers functions annotated with `@test:Config`, and executes them against a live runtime.
+  - Provide a minimal `ballerina/test` standard library: `TestConfig`, the `Config` annotation, and
+    `assertFail`.
+  - `assertFail` signals failure to the host through PAL; the CLI installs the callback.
+  - Support `enable`, `before`, `after`; filtering with `--tests`; progress output; failures-only summary;
+    exit code 1 if any test fails or errors.
+  - Keep test data (`TestPlan`), execution order (`Schedule`), and execution (`Runner`) as separate pieces.
+- Non-goals
+  - `tests/` directory support, a separate test module, or any visibility changes. Tests live in ordinary
+    source files and follow existing visibility rules.
+  - Mocking, `groups`, `dependsOn`, data providers, any assert other than `assertFail`, test reports, code
+    coverage, running tests of dependency packages.
+  - Skipping `main` in `bal test`. `main` runs exactly as in `bal run`.
+  - Stack traces for test failures. Output is the panic message only.
+  - A bubbletea TUI. The progress line is plain terminal output.
+- Success criteria
+  - `bal test` on a package with `@test:Config` functions runs every enabled, matching test and prints a
+    progress line (TTY) or one line per test (non-TTY), then a summary that lists only failed/errored tests.
+  - `assertFail` marks the running test failed, whether called directly, under `trap`, in a worker, or in a
+    resource invoked by the test.
+  - `bal run` and `bal build` on the same package behave as before: the annotation type-checks and is
+    otherwise a no-op, `main` runs, test functions are never invoked.
+  - A test that panics inside a `lock` block does not deadlock later tests.
+  - All scenarios in the Tests section pass as corpus tests.
+
+# Design
+
+## Components
+
+- `ballerina/test` stdlib (`lib/stdlibs/ballerina/test/0.0.1/go1.27/`): Ballerina sources plus one native
+  function. No `CompilerPlugin.toml`, so plugin-gen and the manifest-driven plugin path ignore it.
+- `pal.Testing`: new PAL group with a `Fail(message string)` function field. `palnative` leaves it nil.
+- `cli/internal/testerina`: the CLI-owned pieces.
+  - `Collector`: owns the injected compiler plugin and accumulates per-module discoveries.
+  - `TestPlan` / `Schedule`: data and ordering.
+  - `Runner`: executes a `Schedule` on a `*runtime.Runtime`, owns the PAL hook and per-test stdout capture.
+  - `Reporter`: progress and summary output.
+- `cli/cmd/test.go`: the cobra command.
+- Project API: an injection point for compiler plugins supplied by the host, threaded from
+  `ProjectLoadConfig` to the plugin resolver.
+- Runtime: `InvokeFunction` releases held locks when the invoked function panics.
+
+## Compilation flow
+
+1. `bal test [path]` loads the project exactly like `bal run` (`runBallerina` steps up to
+   `pkg.Compilation()`), except that `ProjectLoadConfig.CompilerPlugins` contains `collector.Plugin()`.
+2. The project environment stores the injected plugins. During `PackageCompilation` phase 3 the plugin
+   resolver merges them with manifest-declared plugins. An injected plugin is applied to a module iff:
+   - the module belongs to the root package (not to a dependency), and
+   - the module explicitly imports the plugin's provider package (`ballerina/test`).
+   It receives the provider's exported symbol space exactly like a manifest plugin.
+3. The plugin (`Collector.collect`) runs at `AfterSemantics`, on each qualifying module concurrently:
+   - For each `fn` in `pkg.Functions`, for each attachment in `fn.GetAnnotationAttachments()` whose symbol
+     package is `ballerina/test` and whose name is `Config`:
+     - `enable`: `true` unless the attachment expression contains an `enable` key whose value expression is a
+       `*ast.BLangLiteral` with a bool `Value`. If the whole attachment is constant, `ann.AnnotationValue`
+       (a `*values.Map`) is used instead. A non-literal `enable` is a semantic error.
+     - `before` / `after`: absent, or a `*ast.BLangVarRef` whose symbol kind is `model.SymbolKindFunction`.
+       Recorded as `FunctionRef{Org, Module, Name}` from `compilerCtx.SymbolPackage(ref)` and
+       `compilerCtx.SymbolName(ref)`. Visibility is already enforced by the type checker; the plugin adds
+       nothing. Any other expression shape is a semantic error.
+     - The annotated function must have no required, defaultable or rest parameters and must not be named
+       `main` or `init`; otherwise a semantic error is reported at the function position.
+   - Stores `ModuleTests` for the module under the collector's mutex, keyed by `ModuleKey{Org, Module}`.
+   - Returns the package unchanged.
+4. Diagnostics are printed as in `run`; any error aborts. BIR is generated with `NewBallerinaBackend`.
+5. `collector.Plan(order)` produces the `TestPlan` with modules in the root package's topological module
+   order (taken from `compilation.Resolution().ModuleDependencyGraph()` restricted to root-package modules)
+   and tests in source order (position order within the module).
+
+## Execution flow
+
+1. `NewSchedule(plan, filter)` flattens the plan into steps and applies `--tests`. Filter syntax is
+   jBallerina's: comma-separated entries, each `name` or `module:name`, `*` matches any run of characters.
+   A bare `name` matches that function in any module. Tests that do not match are dropped from the schedule
+   and never reported. Matching disabled tests stay in the schedule and are reported `Skipped`.
+2. `--list` prints the schedule (`module:name` per line, disabled tests suffixed `(disabled)`) and exits 0.
+3. The runner builds the PAL:
+   - Starts from `palnative.NewPlatform()`.
+   - Replaces `IO.Stdout` with a function that writes to the current test's buffer when a test is running,
+     else to `os.Stdout`.
+   - Replaces `Signals.Signals` with a channel the runner owns; a goroutine forwards OS signals from the
+     palnative channel into it. The runtime reads this channel once at init and panics if it is nil, so it is
+     always set.
+   - Sets `Testing.Fail` to `runner.fail`.
+4. `rt := runtime.NewRuntime(pal, tyEnv)`; `rt.Init(pkg)` for every BIR package in order. `Init` runs
+   `$init` and `main` as in `bal run`; an `Init` error is printed and the command exits 1 without running
+   tests. `rt.Listen()` runs all `$start` hooks and returns.
+5. For each step, on the runner goroutine, sequentially:
+   1. Set `current = step`, clear its buffer and failure list.
+   2. `before` (if any): `invoke`. Panic or non-nil error return → outcome `Errored`, body and `after`
+      skipped.
+   3. body: `invoke`.
+   4. `after` (if any): `invoke`. Panic or error return → `Errored` even when the body passed.
+   5. Outcome: `Failed` if `runner.fail` was called at least once during the step (regardless of how any
+      invoke ended); else `Errored` if any invoke panicked or returned an `error` value; else `Passed`.
+      Disabled tests are `Skipped` without invoking anything.
+   6. `reporter.Report(result)`; `current = nil`.
+   `invoke` = `runtime.LookupFunction` + `runtime.InvokeFunction` wrapped in `recover`. A recovered
+   `*values.Error` contributes its `Message`; any other recovered value contributes `fmt.Sprint(v)`.
+6. `runner.fail(msg)` appends `msg` to `current`'s failure list. When `current` is nil (called from `init`,
+   `main`, a `$start` hook, or a strand outliving its test) it is appended to the run-level failure list; a
+   non-empty run-level list makes the run fail.
+7. Shutdown: send `pal.GracefulStop` on the runner's signal channel without blocking, then read
+   `<-rt.ExitStatus`. The runtime's exit code is ignored; if no listeners existed the channel already holds
+   `0`.
+8. `reporter.End(summary)` prints failed and errored tests with their messages and captured stdout, then
+   totals. The command returns a non-nil error (exit 1) if any test is `Failed` or `Errored`, or the run-level
+   failure list is non-empty.
+
+## Reporter
+
+- `plainReporter` (non-TTY): one line per result: `PASS|FAIL|ERROR|SKIP <module>:<name>`.
+- `ttyReporter` (`isTerminal()`): a single line rewritten with `\r`:
+  `Running <done>/<total>  passed <p>  failed <f>  errored <e>  skipped <s>`. Final newline before the
+  summary.
+- Both print the same summary: for each `Failed`/`Errored` result, `module:name`, each message, and captured
+  stdout indented; then `N passing, N failing, N errored, N skipped`.
+
+## `assertFail` path
+
+`assertFail` is Ballerina; it calls the native `externFail`, which invokes `Testing.Fail` when set and
+returns an `error` value, which `assertFail` panics. Under `bal run` the hook is nil, so `assertFail` is a
+plain panic with the message. `returns never` is implemented in Ballerina (validated: a never-returning
+Ballerina function under `trap` compiles and runs), so no `never`-returning extern is needed.
+
+# API changes
+
+## lib/stdlibs/ballerina/test/0.0.1/go1.27/test.bal (new)
+
+```ballerina
+public type TestConfig record {|
+    boolean enable = true;
+    (function () returns (any|error)) before?;
+    (function () returns (any|error)) after?;
+|};
+
+public annotation TestConfig Config on function;
+
+public function assertFail(string msg = "Test Failed!") returns never {
+    panic externFail(msg);
+}
+
+function externFail(string msg) returns error = external;
+```
+
+Behavior: `Config` is runtime-visible (`on function`, not `source function`); nothing reads the value at
+runtime today. `externFail` calls the PAL hook and returns `error(msg)`.
+
+## lib/stdlibs/ballerina/test/0.0.1/go1.27/{Ballerina.toml, Bala.toml, Dependencies.toml, README.md} (new)
+
+Same shape as `ballerina/io` with `name = "test"`, `platform = "go1.27"`.
+
+## lib/stdlibs/ballerina/test/0.0.1/go1.27/native/test.go (new)
+
+```go
+func init() // runtime.RegisterModuleInitializer(initTestModule)
+func initTestModule(rt *runtime.Runtime) // RegisterExternFunction(rt, "ballerina", "test", "externFail", externFail)
+func externFail(ctx *extern.Context, args []values.BalValue) (values.BalValue, error)
+```
+
+Behavior: reads `args[0]` as `values.BalValue` string; if `ctx.Env.Platform.Testing.Fail != nil` calls it
+with the message; returns `values.NewErrorWithMessage(msg), nil`.
+
+## lib/rt/libs.go
+
+- Current: blank imports of every stdlib `native` package.
+- Proposed: add `_ ".../lib/stdlibs/ballerina/test/0.0.1/go1.27/native"`.
+
+## platform/pal/platform.go
+
+- Current:
+  ```go
+  type Platform struct { IO IO; FS FS; OS OS; Time Time; HTTP HTTP; Signals SignalSource }
+  ```
+- Proposed:
+  ```go
+  type Platform struct { IO IO; FS FS; OS OS; Time Time; HTTP HTTP; Signals SignalSource; Testing Testing }
+
+  // Testing lets library code signal test outcomes to the host. All fields may be nil.
+  type Testing struct {
+      Fail func(message string)
+  }
+  ```
+- Behavior: purely additive. `palnative.NewPlatform` leaves `Testing` zero-valued. Callers must nil-check.
+
+## compilerplugin/compilerplugin.go
+
+- Current: `Stage`, `AfterSemantics`, `PackageTransformer`, `CompilerPlugin{After, PackageTransformer}`.
+- Proposed additions:
+  ```go
+  // Provider identifies the package whose exported symbol space a plugin receives and whose import
+  // activates it.
+  type Provider struct {
+      Org     string
+      Package string
+  }
+
+  // InjectedPlugin is a compiler plugin supplied by the host for one compilation rather than declared by a
+  // package manifest.
+  type InjectedPlugin struct {
+      Provider Provider
+      Plugin   CompilerPlugin
+  }
+  ```
+- Behavior: data only.
+
+## projects/project_loader.go
+
+- Current:
+  ```go
+  type ProjectLoadConfig struct { BuildOptions *BuildOptions; Repositories []Repository; BallerinaEnvFs fs.FS }
+  ```
+- Proposed: add `CompilerPlugins []compilerplugin.InjectedPlugin`.
+- Behavior: `createEnvironmentWithRepositories` and `createWorkspaceEnvironment` pass
+  `cfg.CompilerPlugins` to the environment builder via `WithCompilerPlugins`. Both build-project and
+  workspace-member environments carry the plugins. Bala projects loaded with a shared environment inherit it.
+
+## projects/project_environment_builder.go
+
+- Current: `ProjectEnvironmentBuilder{fsys, repositories, buildOptions}` with `WithRepositories`,
+  `WithBuildOptions`, `Build`.
+- Proposed:
+  ```go
+  func (b *ProjectEnvironmentBuilder) WithCompilerPlugins(plugins []compilerplugin.InjectedPlugin) *ProjectEnvironmentBuilder
+  ```
+  plus a private `compilerPlugins []compilerplugin.InjectedPlugin` field; `Build` copies it onto the
+  `Environment`.
+
+## projects/env.go
+
+- Current: `Environment{fsys, compilerEnv, packageCache, packageResolver, resolutionOptions, publicSymbols}`.
+- Proposed: add private field `injectedCompilerPlugins []compilerplugin.InjectedPlugin` and accessor
+  ```go
+  func (e *Environment) injectedCompilerPlugins() []compilerplugin.InjectedPlugin
+  ```
+
+## projects/compiler_plugin_registry.go
+
+- Current:
+  ```go
+  func newCompilerPluginResolver(modules []*moduleContext) *compilerPluginResolver
+  func (r *compilerPluginResolver) pluginsFor(module *moduleContext) ([]resolvedCompilerPlugin, error)
+  ```
+- Proposed:
+  ```go
+  func newCompilerPluginResolver(
+      modules []*moduleContext,
+      rootPackage *PackageDescriptor,
+      injected []compilerplugin.InjectedPlugin,
+  ) *compilerPluginResolver
+  ```
+  `compilerPluginResolver` gains `rootPackage *PackageDescriptor` and `injected []compilerplugin.InjectedPlugin`.
+  `resolvedCompilerPlugin` gains `injected bool` (for error messages only).
+- Behavior of `pluginsFor`: unchanged for manifest plugins. Afterwards, for each injected plugin in order:
+  skip unless the module's package descriptor equals `rootPackage` and `module.explicitImports` contains an
+  import whose `org`/`moduleName` equals the provider. Look up the provider in `r.providers` (it exists iff
+  the provider package is part of the compilation; if absent, skip). Append a `resolvedCompilerPlugin` whose
+  `provider` is that entry, `declaration.function` is `"<injected>"`, `position` is the matching import.
+  Injected plugins run after manifest plugins for the same module.
+
+## projects/package_compilation.go
+
+- Current: `c.compilerPluginManager = newCompilerPluginResolver(modules)`.
+- Proposed: pass `c.rootPackageContext.getDescriptor()` and
+  `c.rootPackageContext.project.Environment().injectedCompilerPlugins()`.
+- Behavior of `runCompilerPlugins`: unchanged. Error messages for injected plugins use the provider key and
+  the literal function name `<injected>`.
+
+## runtime/runtime.go
+
+- Current:
+  ```go
+  func InvokeFunction(rt *Runtime, fn any, args []values.BalValue) (values.BalValue, error) {
+      cx := exec.CreateContext(rt.env)
+      return exec.Invoke(cx, fn, args)
+  }
+  ```
+- Proposed: same signature. Adds a deferred `recover` that calls `cx.ReleaseAllHeldLocks()` and re-panics
+  with the same value.
+- Behavior: panics still propagate to the caller unchanged; locks acquired by the invoked strand are no
+  longer leaked. Matches what `RunEntrypoints` and `startFuture` already do.
+
+## cli/internal/testerina/plan.go (new)
+
+```go
+type ModuleKey struct{ Org, Module string }
+
+type FunctionRef struct{ Org, Module, Name string } // zero value means none
+func (f FunctionRef) IsZero() bool
+
+type TestFunction struct {
+    Name     string
+    Enabled  bool
+    Before   FunctionRef
+    After    FunctionRef
+    Position diagnostics.Location
+}
+
+type ModuleTests struct {
+    Key   ModuleKey
+    Tests []TestFunction // source order
+}
+
+type TestPlan struct {
+    Modules []ModuleTests // root package topological module order
+}
+```
+
+## cli/internal/testerina/collector.go (new)
+
+```go
+type Collector struct {
+    mu      sync.Mutex
+    modules map[ModuleKey]ModuleTests
+}
+
+func NewCollector() *Collector
+func (c *Collector) Plugin() compilerplugin.InjectedPlugin
+func (c *Collector) Plan(order []ModuleKey) TestPlan
+func (c *Collector) collect(*context.CompilerContext, model.ExportedSymbolSpace, *ast.BLangPackage) (*ast.BLangPackage, error)
+```
+
+Behavior: `Plugin()` returns provider `{"ballerina", "test"}`, stage `AfterSemantics`, transformer
+`c.collect`. `collect` is safe for concurrent calls. `Plan` emits modules in `order`, skipping keys with no
+tests, and sorts each module's tests by `Position`.
+
+## cli/internal/testerina/schedule.go (new)
+
+```go
+type Step struct {
+    Module ModuleKey
+    Test   TestFunction
+}
+
+type Schedule struct{ Steps []Step }
+
+type Filter []string // parsed --tests entries
+
+func ParseFilter(spec string) (Filter, error)      // "" means match all
+func (f Filter) Matches(module ModuleKey, name string) bool
+func NewSchedule(plan TestPlan, filter Filter) Schedule
+```
+
+Behavior: `ParseFilter` splits on `,`, trims, rejects empty entries. An entry with `:` is
+`modulePattern:namePattern`; without, `namePattern` against any module. `*` is the only metacharacter.
+
+## cli/internal/testerina/runner.go (new)
+
+```go
+type Outcome uint8
+const (
+    Passed Outcome = iota
+    Failed
+    Errored
+    Skipped
+)
+
+type Result struct {
+    Step     Step
+    Outcome  Outcome
+    Messages []string // Fail hook messages, panic/error messages
+    Stdout   []byte
+    Duration time.Duration
+}
+
+type Summary struct {
+    Results     []Result
+    RunFailures []string // Fail hook calls outside any test
+}
+func (s Summary) Failed() bool
+
+type Runner struct { /* rt, pal channel, current step state under mutex */ }
+
+func NewRunner(platform pal.Platform, osSignals <-chan pal.Signal, tyEnv semtypes.Env) *Runner
+func (r *Runner) Platform() pal.Platform            // platform with Stdout, Signals, Testing overridden
+func (r *Runner) Start(rt *runtime.Runtime)         // records rt after Init/Listen
+func (r *Runner) Run(schedule Schedule, reporter Reporter) Summary
+func (r *Runner) Shutdown(rt *runtime.Runtime)      // non-blocking GracefulStop send, then <-rt.ExitStatus
+```
+
+Behavior as described in Execution flow steps 5 to 7. The runner must be constructed before
+`runtime.NewRuntime` because the runtime copies `pal.Platform` by value.
+
+## cli/internal/testerina/reporter.go (new)
+
+```go
+type Reporter interface {
+    Begin(total int)
+    Report(Result)
+    End(Summary)
+}
+
+func NewPlainReporter(w io.Writer) Reporter
+func NewTTYReporter(w io.Writer) Reporter
+```
+
+## cli/cmd/test.go (new)
+
+```go
+var testOpts struct {
+    tests string // --tests
+    list  bool   // --list
+    // dump/stats/log-file flags identical to run
+}
+var testCmd = &cobra.Command{Use: "test [<package-dir> | .]", RunE: runTests}
+func runTests(cmd *cobra.Command, args []string) error
+```
+
+Behavior: single `.bal` files are rejected (same rule as `run`, since `Load` on a file yields a single-file
+project; tests require a package). Workspace handling copies `run`. Native re-exec via
+`execWithNativeRunner` is applied exactly as `run` does, so packages with native Go dependencies work.
+Returns `fmt.Errorf("tests failed")` (exit 1) when `Summary.Failed()`; compilation errors and `Init`
+failures return errors as `run` does.
+
+## cli/cmd/bal.go
+
+- Current: registers `new, run, pack, build, push, version`.
+- Proposed: add `rootCmd.AddCommand(testCmd)`.
+
+## cli/go.mod
+
+- Proposed: add direct requires for `ast`, `context`, `model`, `compilerplugin`, `values` (currently indirect
+  or absent) since `cli/internal/testerina` imports them.
+
+## Unchanged
+
+`bir`, `birgen`, `desugar`, `semantics`, `runtime/internal/*`, `palnative`, `compilerpluginregistry`,
+`compiler-tools/plugin-gen`.
+
+# Tests
+
+All as corpus fixtures under `corpus/cli/testdata/test/<case>/` driven by a new `bal test` section in
+`corpus/cli_integration_test.go`, asserting stdout (non-TTY reporter), stderr, and exit code. Each fixture is
+a build project importing `ballerina/test`.
+
+- Basic pass: two enabled tests, no before/after → both `PASS`, summary `2 passing`, exit 0.
+- `assertFail` direct: one test calls `test:assertFail("boom")` → `FAIL`, summary shows `boom`, exit 1.
+- `assertFail` under `trap`: test traps two `assertFail` calls and returns normally → `FAIL` with both
+  messages.
+- Panic in body (non-assert): `panic error("x")` → `ERROR` with message `x`, exit 1.
+- Error return: test `returns error?` and returns an error → `ERROR`.
+- `before` runs and its stdout is captured; `before` panic → `ERROR`, body not run (assert via io:println
+  absence).
+- `after` runs after a passing body; `after` panic → `ERROR`.
+- `before`/`after` referencing a public function in another module of the same package → runs.
+- `before` referencing a non-public function in another module → compile error from the type checker, exit 1.
+- `enable: false` → `SKIP`, not counted as failure, exit 0.
+- `enable` given a non-literal expression → semantic error from the plugin.
+- Test function with a parameter → semantic error from the plugin.
+- `@test:Config` on `main` → semantic error.
+- `--tests` filtering: `name`, `module:name`, `*` patterns; non-matching tests absent from output; matching
+  disabled test reported `SKIP`.
+- `--list` prints `module:name` per line with `(disabled)` suffix and runs nothing, exit 0.
+- Multi-module package: tests in default module and a submodule run in topological order, output grouped
+  accordingly.
+- Listener present: a module `http:Listener` with a service; a test issues a request via `http:Client` and
+  asserts on the response; run completes and process exits (graceful stop delivered).
+- `assertFail` inside a resource invoked by a test → the invoking test is `FAIL`.
+- `assertFail` inside a worker started by a test and awaited → `FAIL`.
+- `assertFail` called from `main` → run-level failure, exit 1, tests still run.
+- `main` panics → `Init` error printed, no tests run, exit 1.
+- Panic inside a `lock` block in one test, next test enters the same `lock` → second test runs (no deadlock).
+- Stdout capture: `io:println` inside a passing test is not printed; inside a failing test it appears in the
+  summary.
+- Same package under `bal run`: `main` runs, test functions are not invoked, `assertFail` never called, exit 0.
+- Same package under `bal build` then executing the binary: as `bal run`.
+- Package that does not import `ballerina/test` under `bal test`: `0 passing`, exit 0, plugin not applied.
+- Unit tests in `projects/compiler_plugin_registry_test.go`: injected plugin applied only to root-package
+  modules that import the provider; not applied to dependency modules; runs after manifest plugins.
+- Unit test in `runtime/lifecycle_test.go`: `InvokeFunction` releases a held lock when the callee panics.

--- a/spec.md
+++ b/spec.md
@@ -66,7 +66,9 @@ Specify:
        `compilerCtx.SymbolName(ref)`. Visibility is already enforced by the type checker; the plugin adds
        nothing. Any other expression shape is a semantic error.
      - The annotated function must have no required, defaultable or rest parameters and must not be named
-       `main` or `init`; otherwise a semantic error is reported at the function position.
+       `main` or `init`; otherwise a semantic error is reported at the function position. Defaultable
+       parameters live inside `RequiredParams` (flagged by `IsDefaultableParam()`), so the check is
+       `len(fn.RequiredParams) == 0 && fn.RestParam == nil`.
    - Stores `ModuleTests` for the module under the collector's mutex, keyed by `ModuleKey{Org, Module}`.
    - Returns the package unchanged.
 4. Diagnostics are printed as in `run`; any error aborts. BIR is generated with `NewBallerinaBackend`.
@@ -236,10 +238,11 @@ with the message; returns `values.NewErrorWithMessage(msg), nil`.
 ## projects/env.go
 
 - Current: `Environment{fsys, compilerEnv, packageCache, packageResolver, resolutionOptions, publicSymbols}`.
-- Proposed: add private field `injectedCompilerPlugins []compilerplugin.InjectedPlugin` and accessor
+- Proposed: add private field `injectedPlugins []compilerplugin.InjectedPlugin` and accessor
   ```go
   func (e *Environment) injectedCompilerPlugins() []compilerplugin.InjectedPlugin
   ```
+  The field cannot share the accessor's name.
 
 ## projects/compiler_plugin_registry.go
 
@@ -252,11 +255,13 @@ with the message; returns `values.NewErrorWithMessage(msg), nil`.
   ```go
   func newCompilerPluginResolver(
       modules []*moduleContext,
-      rootPackage *PackageDescriptor,
+      rootPackage PackageDescriptor,
       injected []compilerplugin.InjectedPlugin,
   ) *compilerPluginResolver
   ```
-  `compilerPluginResolver` gains `rootPackage *PackageDescriptor` and `injected []compilerplugin.InjectedPlugin`.
+  `compilerPluginResolver` gains `rootPackage PackageDescriptor` and `injected []compilerplugin.InjectedPlugin`.
+  `PackageDescriptor` is passed by value: `packageContext.getDescriptor()` returns a value and
+  `PackageDescriptor.Equals` takes one.
   `resolvedCompilerPlugin` gains `injected bool` (for error messages only).
 - Behavior of `pluginsFor`: unchanged for manifest plugins. Afterwards, for each injected plugin in order:
   skip unless the module's package descriptor equals `rootPackage` and `module.explicitImports` contains an


### PR DESCRIPTION
## Purpose

Proof of concept for a Ballerina test framework (testerina): a `bal test` command that discovers, schedules, runs, and reports on test functions declared with `@test:Config`. This validates the design end to end on a deliberately small subset of `ballerina/test` before committing to the full surface.

Scope of the subset (see `INTENT.md`):
- only the `enable`, `before`, and `after` configurations
- test filtering via `--tests` with `module:fn` and `*` wildcard support
- only `assertFail` from `ballerina/test`
- no mocking, no special test packages or visibility rules

## Approach

- **`ballerina/test` stdlib package** — declares `TestConfig`/`Config` annotation and `assertFail`, with the native Go side under `lib/stdlibs/ballerina/test/`.
- **Compiler plugin** — an additional plugin, active only when a module imports `ballerina/test`, reads the `Config` annotations and builds a `TestPlan`. For `bal run`/`bal build` the annotation stays a no-op. Builds on the compiler-plugin infrastructure in the PR below.
- **`cli/internal/testerina`** — collector (annotation → plan), schedule (test plus its before/after hooks, ordered deterministically), runner, and reporter.
- **`bal test` command** (`cli/cmd/test.go`) — compiles the project with the plugin enabled, applies `--tests` filters, runs the schedule, and reports pass/fail/error/skip counts. `--list` prints the schedule without running it.

## Checklist
- [x] Read the [Contributing Guide](CONTRIBUTING.md)
- [x] Added or updated [corpus tests](AGENTS.md#corpus-tests)

## Validation

- `make test` (full suite) — passing
- `make lint` — clean
- Corpus CLI output tests under `corpus/cli/output/test/` cover filtering, hooks, cross-module hooks, disabled tests, multi-module projects, outcome reporting, and the failure modes (bad `enable`, bad `main`, bad params, panics, missing `ballerina/test` import).

## Remarks

- Stacked on #921 (compiler plugins); review that one first — this PR's diff is only the testerina layer.
- The design docs (`INTENT.md`, `spec.md`, `plan.md`) are committed here for review context.
- Proof of concept, not the final framework: no mocking, no data providers, no groups, no test-scoped visibility rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `bal test` command for discovering and running annotated tests.
  * Supports filtering, listing, lifecycle hooks, disabled tests, captured output, progress reporting, and pass/fail/error/skip summaries.
  * Added the `ballerina/test` library with test configuration and `assertFail`.
  * Supports testing across multiple modules and service-based scenarios.

* **Bug Fixes**
  * Prevented locks from remaining held when a runtime invocation panics.

* **Documentation**
  * Added documentation and specifications for the testing workflow and supported APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->