### PR TITLE
test: cover trap on remote and resource actions

### DIFF
--- a/corpus/ast/subset9/09-object/trap-action1-v.txt
+++ b/corpus/ast/subset9/09-object/trap-action1-v.txt
@@ -1,0 +1,155 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (class-definition Client
+    (function $remote$broken () (
+      (value-type int))
+      (block-function-body
+        (panic
+          (error-constructor-expr (
+            (literal remote panic))))))
+    (function $remote$returnError (
+      (variable failure (type
+        (error-type)))) (
+      (union-type
+        (value-type int)
+        (error-type)))
+      (block-function-body
+        (return
+          (simple-var-ref failure))))
+    (function $remote$value () (
+      (value-type int))
+      (block-function-body
+        (return
+          (literal 1))))
+    (resource-function get name:albums
+      (value-type int)
+      (block-function-body
+        (return
+          (literal 1))))
+    (resource-function get name:broken
+      (value-type int)
+      (block-function-body
+        (panic
+          (error-constructor-expr (
+            (literal resource panic))))))
+    (resource-function get name:failure
+      (variable failure (type
+        (error-type)))
+      (union-type
+        (value-type int)
+        (error-type))
+      (block-function-body
+        (return
+          (simple-var-ref failure)))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable c (type
+          (user-defined-type Client)) (expr
+          (new ()))))
+      (var-def
+        (variable remoteValue (type
+          (union-type
+            (value-type int)
+            (error-type))) (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (simple-var-ref c) ())))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref remoteValue))))
+      (var-def
+        (variable resourceValue (type
+          (union-type
+            (value-type int)
+            (error-type))) (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:albums)))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref resourceValue))))
+      (var-def
+        (variable remotePanic (type
+          (union-type
+            (value-type int)
+            (error-type))) (expr
+          (trap-expr
+            (remote-method-call broken expr:
+              (simple-var-ref c) ())))))
+      (if
+        (type-test-expr is
+          (simple-var-ref remotePanic)
+          (error-type))
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (invocation message expr:
+                (simple-var-ref remotePanic) ()))))) ())
+      (block-stmt
+        (var-def
+          (variable resourcePanic (type
+            (union-type
+              (value-type int)
+              (error-type))) (expr
+            (trap-expr
+              (client-resource-access get expr:
+                (simple-var-ref c) name:broken)))))
+        (if
+          (type-test-expr is
+            (simple-var-ref resourcePanic)
+            (error-type))
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (invocation message expr:
+                  (simple-var-ref resourcePanic) ()))))) ())
+        (block-stmt
+          (var-def
+            (variable failure (type
+              (error-type)) (expr
+              (error-constructor-expr (
+                (literal returned error))))))
+          (var-def
+            (variable remoteError (expr
+              (trap-expr
+                (remote-method-call returnError expr:
+                  (simple-var-ref c) (
+                  (simple-var-ref failure)))))))
+          (expression-stmt
+            (invocation io println (
+              (binary-expr ===
+                (simple-var-ref remoteError)
+                (simple-var-ref failure)))))
+          (var-def
+            (variable resourceError (expr
+              (trap-expr
+                (client-resource-access get expr:
+                  (simple-var-ref c) name:failure
+                  (simple-var-ref failure))))))
+          (expression-stmt
+            (invocation io println (
+              (binary-expr ===
+                (simple-var-ref resourceError)
+                (simple-var-ref failure)))))
+          (var-def
+            (variable nested (expr
+              (trap-expr
+                (trap-expr
+                  (remote-method-call broken expr:
+                    (simple-var-ref c) ()))))))
+          (if
+            (type-test-expr is
+              (simple-var-ref nested)
+              (error-type))
+            (block-stmt
+              (expression-stmt
+                (invocation io println (
+                  (invocation message expr:
+                    (simple-var-ref nested) ()))))) ())
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (literal continued))))))))))

--- a/corpus/ast/subset9/09-object/trap-action2-v.txt
+++ b/corpus/ast/subset9/09-object/trap-action2-v.txt
@@ -1,0 +1,238 @@
+(compilation-unit
+(package-id $anon . 0.0.0)
+  (import-package ballerina io (as io))
+  (variable calls (type
+    (value-type int)) (expr
+    (literal 0)))
+  (function failInt (
+    (variable message (type
+      (value-type string)))) (
+    (value-type int))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (simple-var-ref message))))))
+  (function failValues () (
+    (array-type
+      (value-type int) dimensions: 1 ([])))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (literal spread panic))))))
+  (function failClient () (
+    (user-defined-type Client))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (literal receiver panic))))))
+  (class-definition Client
+    (function $remote$value (
+      (variable value (type
+        (value-type int)) (expr
+        (invocation failInt (
+          (literal remote default panic)))))) (
+      (value-type int))
+      (block-function-body
+        (compound-assignment +
+          (simple-var-ref calls)
+          (literal 1))
+        (return
+          (simple-var-ref value))))
+    (function $remote$values (
+      (variable values (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))))) (
+      (value-type int))
+      (block-function-body
+        (compound-assignment +
+          (simple-var-ref calls)
+          (literal 1))
+        (return
+          (invocation length expr:
+            (simple-var-ref values) ()))))
+    (resource-function get name:item
+      (param id
+        (value-type int))
+      (variable value (type
+        (value-type int)) (expr
+        (invocation failInt (
+          (literal resource default panic)))))
+      (value-type int)
+      (block-function-body
+        (compound-assignment +
+          (simple-var-ref calls)
+          (literal 1))
+        (return
+          (binary-expr +
+            (simple-var-ref id)
+            (simple-var-ref value)))))
+    (resource-function get name:values
+      (variable values (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))))
+      (value-type int)
+      (block-function-body
+        (compound-assignment +
+          (simple-var-ref calls)
+          (literal 1))
+        (return
+          (invocation length expr:
+            (simple-var-ref values) ())))))
+  (function message (
+    (variable result (type
+      (union-type
+        (value-type int)
+        (error-type))))) (
+    (value-type string))
+    (block-function-body
+      (return
+        (ternary-expr
+          (type-test-expr is
+            (simple-var-ref result)
+            (error-type))
+          (invocation message expr:
+            (simple-var-ref result) ())
+          (literal not trapped)))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable c (type
+          (user-defined-type Client)) (expr
+          (new ()))))
+      (var-def
+        (variable remoteReceiver (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (group-expr
+                (invocation failClient ())) (
+              (literal 1)))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref remoteReceiver))))))
+      (var-def
+        (variable resourceReceiver (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (group-expr
+                (invocation failClient ())) name:item computed:
+              (literal 1)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref resourceReceiver))))))
+      (var-def
+        (variable path (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:item computed:
+              (invocation failInt (
+                (literal path panic)))
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref path))))))
+      (var-def
+        (variable remoteArgument (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (simple-var-ref c) (
+              (invocation failInt (
+                (literal remote argument panic)))))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref remoteArgument))))))
+      (var-def
+        (variable resourceArgument (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:item computed:
+              (literal 1)
+              (invocation failInt (
+                (literal resource argument panic))))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref resourceArgument))))))
+      (var-def
+        (variable remoteDefault (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (simple-var-ref c) ())))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref remoteDefault))))))
+      (var-def
+        (variable resourceDefault (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:item computed:
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref resourceDefault))))))
+      (var-def
+        (variable useSpread (type
+          (value-type boolean)) (expr
+          (literal true))))
+      (var-def
+        (variable remoteSpread (expr
+          (trap-expr
+            (remote-method-call values expr:
+              (simple-var-ref c) (
+              (ternary-expr
+                (simple-var-ref useSpread)
+                (list-constructor-expr
+                  (literal 0)
+                  (invocation failValues ()))
+                (list-constructor-expr))))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref remoteSpread))))))
+      (var-def
+        (variable resourceSpread (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:values
+              (ternary-expr
+                (simple-var-ref useSpread)
+                (list-constructor-expr
+                  (literal 0)
+                  (invocation failValues ()))
+                (list-constructor-expr)))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref resourceSpread))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref calls))))
+      (var-def
+        (variable remoteValue (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (simple-var-ref c) (
+              (literal 5)))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref remoteValue))))
+      (var-def
+        (variable resourceValue (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:item computed:
+              (literal 2)
+              (literal 3))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref resourceValue))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref calls)))))))

--- a/corpus/bal/subset9/09-object/trap-action1-v.bal
+++ b/corpus/bal/subset9/09-object/trap-action1-v.bal
@@ -1,0 +1,72 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+client class Client {
+    remote function value() returns int {
+        return 1;
+    }
+
+    resource function get albums() returns int {
+        return 1;
+    }
+
+    remote function broken() returns int {
+        panic error("remote panic");
+    }
+
+    resource function get broken() returns int {
+        panic error("resource panic");
+    }
+
+    remote function returnError(error failure) returns int|error {
+        return failure;
+    }
+
+    resource function get failure(error failure) returns int|error {
+        return failure;
+    }
+}
+
+public function main() {
+    Client c = new;
+    int|error remoteValue = trap c->value();
+    io:println(remoteValue); // @output 1
+    int|error resourceValue = trap c->/albums;
+    io:println(resourceValue); // @output 1
+
+    int|error remotePanic = trap c->broken();
+    if remotePanic is error {
+        io:println(remotePanic.message()); // @output remote panic
+    }
+    int|error resourcePanic = trap c->/broken;
+    if resourcePanic is error {
+        io:println(resourcePanic.message()); // @output resource panic
+    }
+
+    error failure = error("returned error");
+    var remoteError = trap c->returnError(failure);
+    io:println(remoteError === failure); // @output true
+    var resourceError = trap c->/failure.get(failure);
+    io:println(resourceError === failure); // @output true
+
+    var nested = trap trap c->broken();
+    if nested is error {
+        io:println(nested.message()); // @output remote panic
+    }
+    io:println("continued"); // @output continued
+}

--- a/corpus/bal/subset9/09-object/trap-action2-v.bal
+++ b/corpus/bal/subset9/09-object/trap-action2-v.bal
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+int calls = 0;
+
+function failInt(string message) returns int {
+    panic error(message);
+}
+
+function failValues() returns int[] {
+    panic error("spread panic");
+}
+
+function failClient() returns Client {
+    panic error("receiver panic");
+}
+
+client class Client {
+    remote function value(int value = failInt("remote default panic")) returns int {
+        calls += 1;
+        return value;
+    }
+
+    resource function get item/[int id](int value = failInt("resource default panic")) returns int {
+        calls += 1;
+        return id + value;
+    }
+
+    remote function values(int[] values) returns int {
+        calls += 1;
+        return values.length();
+    }
+
+    resource function get values(int[] values) returns int {
+        calls += 1;
+        return values.length();
+    }
+}
+
+function message(int|error result) returns string {
+    return result is error ? result.message() : "not trapped";
+}
+
+public function main() {
+    Client c = new;
+    var remoteReceiver = trap (failClient())->value(1);
+    io:println(message(remoteReceiver)); // @output receiver panic
+    var resourceReceiver = trap (failClient())->/item/[1].get(1);
+    io:println(message(resourceReceiver)); // @output receiver panic
+
+    var path = trap c->/item/[failInt("path panic")].get(1);
+    io:println(message(path)); // @output path panic
+    var remoteArgument = trap c->value(failInt("remote argument panic"));
+    io:println(message(remoteArgument)); // @output remote argument panic
+    var resourceArgument = trap c->/item/[1].get(failInt("resource argument panic"));
+    io:println(message(resourceArgument)); // @output resource argument panic
+
+    var remoteDefault = trap c->value();
+    io:println(message(remoteDefault)); // @output remote default panic
+    var resourceDefault = trap c->/item/[1];
+    io:println(message(resourceDefault)); // @output resource default panic
+
+    boolean useSpread = true;
+    var remoteSpread = trap c->values(useSpread ? [0, ...failValues()] : []);
+    io:println(message(remoteSpread)); // @output spread panic
+    var resourceSpread = trap c->/values.get(useSpread ? [0, ...failValues()] : []);
+    io:println(message(resourceSpread)); // @output spread panic
+    io:println(calls); // @output 0
+
+    var remoteValue = trap c->value(5);
+    io:println(remoteValue); // @output 5
+    var resourceValue = trap c->/item/[2].get(3);
+    io:println(resourceValue); // @output 5
+    io:println(calls); // @output 2
+}

--- a/corpus/bal/subset9/09-object/trap-action3-e.bal
+++ b/corpus/bal/subset9/09-object/trap-action3-e.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+
+client class Client {
+    remote function value() returns int {
+        return 1;
+    }
+
+    resource function get albums() returns int {
+        return 1;
+    }
+}
+
+public function main() {
+    Client c = new;
+    int remoteValue = trap c->value(); // @error trap result includes error
+    int resourceValue = trap c->/albums; // @error trap result includes error
+    io:println(remoteValue, resourceValue);
+}

--- a/corpus/bir/subset9/09-object/trap-action1-v.txt
+++ b/corpus/bir/subset9/09-object/trap-action1-v.txt
@@ -1,0 +1,249 @@
+module $anon.. v 0.0.0;
+class Client {
+
+  $remote$broken() -> int{
+    bb0 {
+      %2 = ConstantLoad remote panic
+      %3 = newError error(%2)
+      panic %3;
+    }
+  }
+
+  $remote$returnError(error) -> int|error{
+    bb0 {
+      %0 = failure;
+      return;
+    }
+  }
+
+  $remote$value() -> int{
+    bb0 {
+      %2 = ConstantLoad 1
+      %0 = %2;
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+
+  resource get albums Client.$resource$get$0() -> int{
+    bb0 {
+      %2 = ConstantLoad 1
+      %0 = %2;
+      return;
+    }
+  }
+
+  resource get broken Client.$resource$get$1() -> int{
+    bb0 {
+      %2 = ConstantLoad resource panic
+      %3 = newError error(%2)
+      panic %3;
+    }
+  }
+
+  resource get failure Client.$resource$get$2(error) -> int|error{
+    bb0 {
+      %0 = failure;
+      return;
+    }
+  }
+}
+main() -> nil{
+  bb0 {
+    %1 = newObject $anon/.:Client
+    %2 = %1.init() -> bb1;
+  }
+  bb1 {
+    %4 = %2 is nil
+    %4 ? bb2 : bb3;
+  }
+  bb2 {
+    %3 = %1;
+    GOTO bb4;
+  }
+  bb3 {
+    %3 = %2;
+    GOTO bb4;
+  }
+  bb4 {
+    c = %3;
+    GOTO bb5;
+  }
+  bb5 {
+    %7 = c.$remote$value() -> bb6;
+  }
+  bb6 {
+    %6 = %7;
+    GOTO bb7;
+  }
+  bb7 {
+    remoteValue = %6;
+    %9 = println(remoteValue) -> bb8;
+  }
+  bb8 {
+    GOTO bb9;
+  }
+  bb9 {
+    %11 = ConstantLoad albums
+    %12 = c->[%11].get() -> bb10;
+  }
+  bb10 {
+    %10 = %12;
+    GOTO bb11;
+  }
+  bb11 {
+    resourceValue = %10;
+    %14 = println(resourceValue) -> bb12;
+  }
+  bb12 {
+    GOTO bb13;
+  }
+  bb13 {
+    %16 = c.$remote$broken() -> bb14;
+  }
+  bb14 {
+    %15 = %16;
+    GOTO bb15;
+  }
+  bb15 {
+    remotePanic = %15;
+    %18 = remotePanic is error
+    %18 ? bb16 : bb19;
+  }
+  bb16 {
+    PushScopeFrame 2
+    %0 = message((1, remotePanic)) -> bb17;
+  }
+  bb17 {
+    %1 = println(%0) -> bb18;
+  }
+  bb18 {
+    PopScopeFrame
+    GOTO bb19;
+  }
+  bb19 {
+    PushScopeFrame 5
+    GOTO bb20;
+  }
+  bb20 {
+    %1 = ConstantLoad broken
+    %2 = (1, c)->[%1].get() -> bb21;
+  }
+  bb21 {
+    %0 = %2;
+    GOTO bb22;
+  }
+  bb22 {
+    resourcePanic = %0;
+    %4 = resourcePanic is error
+    %4 ? bb23 : bb26;
+  }
+  bb23 {
+    PushScopeFrame 2
+    %0 = message((1, resourcePanic)) -> bb24;
+  }
+  bb24 {
+    %1 = println(%0) -> bb25;
+  }
+  bb25 {
+    PopScopeFrame
+    GOTO bb26;
+  }
+  bb26 {
+    PushScopeFrame 21
+    %0 = ConstantLoad returned error
+    %1 = newError error(%0)
+    failure = %1;
+    GOTO bb27;
+  }
+  bb27 {
+    %4 = (2, c).$remote$returnError(failure) -> bb28;
+  }
+  bb28 {
+    %3 = %4;
+    GOTO bb29;
+  }
+  bb29 {
+    remoteError = %3;
+    %6 = unknown remoteError failure;
+    %7 = %6;
+    %8 = println(%7) -> bb30;
+  }
+  bb30 {
+    GOTO bb31;
+  }
+  bb31 {
+    %10 = ConstantLoad failure
+    %11 = (2, c)->[%10].get(failure) -> bb32;
+  }
+  bb32 {
+    %9 = %11;
+    GOTO bb33;
+  }
+  bb33 {
+    resourceError = %9;
+    %13 = unknown resourceError failure;
+    %14 = %13;
+    %15 = println(%14) -> bb34;
+  }
+  bb34 {
+    GOTO bb35;
+  }
+  bb35 {
+    GOTO bb36;
+  }
+  bb36 {
+    %18 = (2, c).$remote$broken() -> bb37;
+  }
+  bb37 {
+    %17 = %18;
+    GOTO bb38;
+  }
+  bb38 {
+    %16 = %17;
+    GOTO bb39;
+  }
+  bb39 {
+    nested = %16;
+    %20 = nested is error
+    %20 ? bb40 : bb43;
+  }
+  bb40 {
+    PushScopeFrame 2
+    %0 = message((1, nested)) -> bb41;
+  }
+  bb41 {
+    %1 = println(%0) -> bb42;
+  }
+  bb42 {
+    PopScopeFrame
+    GOTO bb43;
+  }
+  bb43 {
+    PushScopeFrame 2
+    %0 = ConstantLoad continued
+    %1 = println(%0) -> bb44;
+  }
+  bb44 {
+    PopScopeFrame
+    PopScopeFrame
+    PopScopeFrame
+    return;
+  }
+  
+  error-table {
+    [bb5, bb6] -> bb7, %6
+    [bb9, bb10] -> bb11, %10
+    [bb13, bb14] -> bb15, %15
+    [bb20, bb21] -> bb22, %0
+    [bb27, bb28] -> bb29, %3
+    [bb31, bb32] -> bb33, %9
+    [bb36, bb37] -> bb38, %17
+    [bb35, bb38] -> bb39, %16
+  }
+}

--- a/corpus/bir/subset9/09-object/trap-action2-v.txt
+++ b/corpus/bir/subset9/09-object/trap-action2-v.txt
@@ -1,0 +1,515 @@
+module $anon.. v 0.0.0;
+calls  int;
+class Client {
+
+  $remote$value(int) -> int{
+    bb0 {
+      %4 = ConstantLoad 1
+      %5 = %4;
+      %3 = + calls %5;
+      calls = %3;
+      %0 = value;
+      return;
+    }
+  }
+
+  $remote$values([int...]) -> int{
+    bb0 {
+      %4 = ConstantLoad 1
+      %5 = %4;
+      %3 = + calls %5;
+      calls = %3;
+      %6 = length(values) -> bb1;
+    }
+    bb1 {
+      %0 = %6;
+      return;
+    }
+  }
+
+  init() -> nil{
+    bb0 {
+      return;
+    }
+  }
+
+  resource get item/[int] Client.$resource$get$0(int,int) -> int{
+    bb0 {
+      %5 = ConstantLoad 1
+      %6 = %5;
+      %4 = + calls %6;
+      calls = %4;
+      %8 = id;
+      %9 = value;
+      %7 = + %8 %9;
+      %0 = %7;
+      return;
+    }
+  }
+
+  resource get values Client.$resource$get$1([int...]) -> int{
+    bb0 {
+      %4 = ConstantLoad 1
+      %5 = %4;
+      %3 = + calls %5;
+      calls = %3;
+      %6 = length(values) -> bb1;
+    }
+    bb1 {
+      %0 = %6;
+      return;
+    }
+  }
+}
+failInt(string) -> int{
+  bb0 {
+    %2 = newError error(message)
+    panic %2;
+  }
+}
+failValues() -> [int...]{
+  bb0 {
+    %1 = ConstantLoad spread panic
+    %2 = newError error(%1)
+    panic %2;
+  }
+}
+failClient() -> client object { private remote function $remote$value(int) returns int; private remote function $remote$values([int...]) returns int; public function init() returns nil }{
+  bb0 {
+    %1 = ConstantLoad receiver panic
+    %2 = newError error(%1)
+    panic %2;
+  }
+}
+message(int|error) -> string{
+  bb0 {
+    %3 = result is error
+    %3 ? bb1 : bb2;
+  }
+  bb1 {
+    %4 = message(result) -> bb4;
+  }
+  bb2 {
+    %5 = ConstantLoad not trapped
+    %2 = %5;
+    GOTO bb3;
+  }
+  bb3 {
+    %0 = %2;
+    return;
+  }
+  bb4 {
+    %2 = %4;
+    GOTO bb3;
+  }
+}
+main() -> nil{
+  bb0 {
+    %1 = newObject $anon/.:Client
+    %2 = %1.init() -> bb1;
+  }
+  bb1 {
+    %4 = %2 is nil
+    %4 ? bb2 : bb3;
+  }
+  bb2 {
+    %3 = %1;
+    GOTO bb4;
+  }
+  bb3 {
+    %3 = %2;
+    GOTO bb4;
+  }
+  bb4 {
+    c = %3;
+    GOTO bb5;
+  }
+  bb5 {
+    %7 = failClient() -> bb6;
+  }
+  bb6 {
+    %8 = ConstantLoad 1
+    %9 = %8;
+    %10 = %7.$remote$value(%9) -> bb7;
+  }
+  bb7 {
+    %6 = %10;
+    GOTO bb8;
+  }
+  bb8 {
+    remoteReceiver = %6;
+    %12 = message(remoteReceiver) -> bb9;
+  }
+  bb9 {
+    %13 = println(%12) -> bb10;
+  }
+  bb10 {
+    GOTO bb11;
+  }
+  bb11 {
+    %15 = failClient() -> bb12;
+  }
+  bb12 {
+    %16 = ConstantLoad item
+    %17 = ConstantLoad 1
+    %18 = %17;
+    %19 = ConstantLoad 1
+    %20 = %19;
+    %21 = %15->[%16,%18].get(%20) -> bb13;
+  }
+  bb13 {
+    %14 = %21;
+    GOTO bb14;
+  }
+  bb14 {
+    resourceReceiver = %14;
+    %23 = message(resourceReceiver) -> bb15;
+  }
+  bb15 {
+    %24 = println(%23) -> bb16;
+  }
+  bb16 {
+    GOTO bb17;
+  }
+  bb17 {
+    %26 = ConstantLoad item
+    %27 = ConstantLoad path panic
+    %28 = failInt(%27) -> bb18;
+  }
+  bb18 {
+    %29 = %28;
+    %30 = ConstantLoad 1
+    %31 = %30;
+    %32 = c->[%26,%29].get(%31) -> bb19;
+  }
+  bb19 {
+    %25 = %32;
+    GOTO bb20;
+  }
+  bb20 {
+    path = %25;
+    %34 = message(path) -> bb21;
+  }
+  bb21 {
+    %35 = println(%34) -> bb22;
+  }
+  bb22 {
+    GOTO bb23;
+  }
+  bb23 {
+    %37 = ConstantLoad remote argument panic
+    %38 = failInt(%37) -> bb24;
+  }
+  bb24 {
+    %39 = %38;
+    %40 = c.$remote$value(%39) -> bb25;
+  }
+  bb25 {
+    %36 = %40;
+    GOTO bb26;
+  }
+  bb26 {
+    remoteArgument = %36;
+    %42 = message(remoteArgument) -> bb27;
+  }
+  bb27 {
+    %43 = println(%42) -> bb28;
+  }
+  bb28 {
+    GOTO bb29;
+  }
+  bb29 {
+    %45 = ConstantLoad item
+    %46 = ConstantLoad 1
+    %47 = %46;
+    %48 = ConstantLoad resource argument panic
+    %49 = failInt(%48) -> bb30;
+  }
+  bb30 {
+    %50 = %49;
+    %51 = c->[%45,%47].get(%50) -> bb31;
+  }
+  bb31 {
+    %44 = %51;
+    GOTO bb32;
+  }
+  bb32 {
+    resourceArgument = %44;
+    %53 = message(resourceArgument) -> bb33;
+  }
+  bb33 {
+    %54 = println(%53) -> bb34;
+  }
+  bb34 {
+    GOTO bb35;
+  }
+  bb35 {
+    %56 = $default$0() -> bb36;
+  }
+  bb36 {
+    $desugar$0 = %56;
+    %58 = $desugar$0;
+    %59 = c.$remote$value(%58) -> bb37;
+  }
+  bb37 {
+    %55 = %59;
+    GOTO bb38;
+  }
+  bb38 {
+    remoteDefault = %55;
+    %61 = message(remoteDefault) -> bb39;
+  }
+  bb39 {
+    %62 = println(%61) -> bb40;
+  }
+  bb40 {
+    GOTO bb41;
+  }
+  bb41 {
+    %64 = $default$1() -> bb42;
+  }
+  bb42 {
+    $desugar$1 = %64;
+    %66 = ConstantLoad item
+    %67 = ConstantLoad 1
+    %68 = %67;
+    %69 = $desugar$1;
+    %70 = c->[%66,%68].get(%69) -> bb43;
+  }
+  bb43 {
+    %63 = %70;
+    GOTO bb44;
+  }
+  bb44 {
+    resourceDefault = %63;
+    %72 = message(resourceDefault) -> bb45;
+  }
+  bb45 {
+    %73 = println(%72) -> bb46;
+  }
+  bb46 {
+    %74 = ConstantLoad true
+    useSpread = %74;
+    GOTO bb47;
+  }
+  bb47 {
+    useSpread ? bb48 : bb49;
+  }
+  bb48 {
+    %78 = ConstantLoad 0
+    %79 = newArray [int...][%78]{}
+    $desugar$2 = %79;
+    %81 = ConstantLoad 0
+    %82 = %81;
+    %83 = push($desugar$2,%82) -> bb51;
+  }
+  bb49 {
+    %93 = ConstantLoad 0
+    %94 = newArray [int...][%93]{}
+    %77 = %94;
+    GOTO bb50;
+  }
+  bb50 {
+    %95 = c.$remote$values(%77) -> bb58;
+  }
+  bb51 {
+    %84 = failValues() -> bb52;
+  }
+  bb52 {
+    $desugar$3 = %84;
+    %86 = length($desugar$3) -> bb53;
+  }
+  bb53 {
+    $desugar$4 = %86;
+    %88 = ConstantLoad 0
+    $desugar$5 = %88;
+    GOTO bb54;
+  }
+  bb54 {
+    %91 = $desugar$5;
+    %92 = $desugar$4;
+    %90 = < %91 %92;
+    %90 ? bb55 : bb56;
+  }
+  bb55 {
+    PushScopeFrame 7
+    %0 = (1, $desugar$3)[(1, $desugar$5)];
+    %1 = %0;
+    %2 = push((1, $desugar$2),%1) -> bb57;
+  }
+  bb56 {
+    %77 = $desugar$2;
+    GOTO bb50;
+  }
+  bb57 {
+    %4 = (1, $desugar$5);
+    %5 = ConstantLoad 1
+    %6 = %5;
+    %3 = + %4 %6;
+    (1, $desugar$5) = %3;
+    PopScopeFrame
+    GOTO bb54;
+  }
+  bb58 {
+    %76 = %95;
+    GOTO bb59;
+  }
+  bb59 {
+    remoteSpread = %76;
+    %97 = message(remoteSpread) -> bb60;
+  }
+  bb60 {
+    %98 = println(%97) -> bb61;
+  }
+  bb61 {
+    GOTO bb62;
+  }
+  bb62 {
+    %100 = ConstantLoad values
+    useSpread ? bb63 : bb64;
+  }
+  bb63 {
+    %102 = ConstantLoad 0
+    %103 = newArray [int...][%102]{}
+    $desugar$6 = %103;
+    %105 = ConstantLoad 0
+    %106 = %105;
+    %107 = push($desugar$6,%106) -> bb66;
+  }
+  bb64 {
+    %117 = ConstantLoad 0
+    %118 = newArray [int...][%117]{}
+    %101 = %118;
+    GOTO bb65;
+  }
+  bb65 {
+    %119 = c->[%100].get(%101) -> bb73;
+  }
+  bb66 {
+    %108 = failValues() -> bb67;
+  }
+  bb67 {
+    $desugar$7 = %108;
+    %110 = length($desugar$7) -> bb68;
+  }
+  bb68 {
+    $desugar$8 = %110;
+    %112 = ConstantLoad 0
+    $desugar$9 = %112;
+    GOTO bb69;
+  }
+  bb69 {
+    %115 = $desugar$9;
+    %116 = $desugar$8;
+    %114 = < %115 %116;
+    %114 ? bb70 : bb71;
+  }
+  bb70 {
+    PushScopeFrame 7
+    %0 = (1, $desugar$7)[(1, $desugar$9)];
+    %1 = %0;
+    %2 = push((1, $desugar$6),%1) -> bb72;
+  }
+  bb71 {
+    %101 = $desugar$6;
+    GOTO bb65;
+  }
+  bb72 {
+    %4 = (1, $desugar$9);
+    %5 = ConstantLoad 1
+    %6 = %5;
+    %3 = + %4 %6;
+    (1, $desugar$9) = %3;
+    PopScopeFrame
+    GOTO bb69;
+  }
+  bb73 {
+    %99 = %119;
+    GOTO bb74;
+  }
+  bb74 {
+    resourceSpread = %99;
+    %121 = message(resourceSpread) -> bb75;
+  }
+  bb75 {
+    %122 = println(%121) -> bb76;
+  }
+  bb76 {
+    %123 = println(calls) -> bb77;
+  }
+  bb77 {
+    GOTO bb78;
+  }
+  bb78 {
+    %125 = ConstantLoad 5
+    %126 = %125;
+    %127 = c.$remote$value(%126) -> bb79;
+  }
+  bb79 {
+    %124 = %127;
+    GOTO bb80;
+  }
+  bb80 {
+    remoteValue = %124;
+    %129 = println(remoteValue) -> bb81;
+  }
+  bb81 {
+    GOTO bb82;
+  }
+  bb82 {
+    %131 = ConstantLoad item
+    %132 = ConstantLoad 2
+    %133 = %132;
+    %134 = ConstantLoad 3
+    %135 = %134;
+    %136 = c->[%131,%133].get(%135) -> bb83;
+  }
+  bb83 {
+    %130 = %136;
+    GOTO bb84;
+  }
+  bb84 {
+    resourceValue = %130;
+    %138 = println(resourceValue) -> bb85;
+  }
+  bb85 {
+    %139 = println(calls) -> bb86;
+  }
+  bb86 {
+    return;
+  }
+  
+  error-table {
+    [bb5, bb7] -> bb8, %6
+    [bb11, bb13] -> bb14, %14
+    [bb17, bb19] -> bb20, %25
+    [bb23, bb25] -> bb26, %36
+    [bb29, bb31] -> bb32, %44
+    [bb35, bb37] -> bb38, %55
+    [bb41, bb43] -> bb44, %63
+    [bb47, bb58] -> bb59, %76
+    [bb62, bb73] -> bb74, %99
+    [bb78, bb79] -> bb80, %124
+    [bb82, bb83] -> bb84, %130
+  }
+}
+$default$0() -> int{
+  bb0 {
+    %1 = ConstantLoad remote default panic
+    %2 = failInt(%1) -> bb1;
+  }
+  bb1 {
+    %0 = %2;
+    return;
+  }
+}
+$default$1() -> int{
+  bb0 {
+    %1 = ConstantLoad resource default panic
+    %2 = failInt(%1) -> bb1;
+  }
+  bb1 {
+    %0 = %2;
+    return;
+  }
+}

--- a/corpus/cfg/subset9/09-object/trap-action1-v.txt
+++ b/corpus/cfg/subset9/09-object/trap-action1-v.txt
@@ -1,0 +1,155 @@
+(Client
+  ($remote$broken
+    (bb0 () ()
+      (panic
+        (error-constructor-expr (
+          (literal remote panic))))
+    )
+  )
+  ($remote$returnError
+    (bb0 () ()
+      (return
+        (simple-var-ref failure))
+    )
+  )
+  ($remote$value
+    (bb0 () ()
+      (return
+        (literal 1))
+    )
+  )
+  (Client.$resource$get$0
+    (bb0 () ()
+      (return
+        (literal 1))
+    )
+  )
+  (Client.$resource$get$1
+    (bb0 () ()
+      (panic
+        (error-constructor-expr (
+          (literal resource panic))))
+    )
+  )
+  (Client.$resource$get$2
+    (bb0 () ()
+      (return
+        (simple-var-ref failure))
+    )
+  )
+)
+(main
+  (bb0 () (bb1 bb2)
+    (var-def
+      (variable c (type
+        (user-defined-type Client)) (expr
+        (new ()))))
+    (var-def
+      (variable remoteValue (type
+        (union-type
+          (value-type int)
+          (error-type))) (expr
+        (trap-expr
+          (remote-method-call value expr:
+            (simple-var-ref c) ())))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref remoteValue))))
+    (var-def
+      (variable resourceValue (type
+        (union-type
+          (value-type int)
+          (error-type))) (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (simple-var-ref c) name:albums)))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref resourceValue))))
+    (var-def
+      (variable remotePanic (type
+        (union-type
+          (value-type int)
+          (error-type))) (expr
+        (trap-expr
+          (remote-method-call broken expr:
+            (simple-var-ref c) ())))))
+    (type-test-expr is
+      (simple-var-ref remotePanic)
+      (error-type))
+  )
+  (bb1 (bb0) (bb2)
+    (expression-stmt
+      (invocation io println (
+        (invocation lang.error message (
+          (simple-var-ref remotePanic))))))
+  )
+  (bb2 (bb1 bb0) (bb3 bb4)
+    (var-def
+      (variable resourcePanic (type
+        (union-type
+          (value-type int)
+          (error-type))) (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (simple-var-ref c) name:broken)))))
+    (type-test-expr is
+      (simple-var-ref resourcePanic)
+      (error-type))
+  )
+  (bb3 (bb2) (bb4)
+    (expression-stmt
+      (invocation io println (
+        (invocation lang.error message (
+          (simple-var-ref resourcePanic))))))
+  )
+  (bb4 (bb3 bb2) (bb5 bb6)
+    (var-def
+      (variable failure (type
+        (error-type)) (expr
+        (error-constructor-expr (
+          (literal returned error))))))
+    (var-def
+      (variable remoteError (expr
+        (trap-expr
+          (remote-method-call returnError expr:
+            (simple-var-ref c) (
+            (simple-var-ref failure)))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr ===
+          (simple-var-ref remoteError)
+          (simple-var-ref failure)))))
+    (var-def
+      (variable resourceError (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (simple-var-ref c) name:failure
+            (simple-var-ref failure))))))
+    (expression-stmt
+      (invocation io println (
+        (binary-expr ===
+          (simple-var-ref resourceError)
+          (simple-var-ref failure)))))
+    (var-def
+      (variable nested (expr
+        (trap-expr
+          (trap-expr
+            (remote-method-call broken expr:
+              (simple-var-ref c) ()))))))
+    (type-test-expr is
+      (simple-var-ref nested)
+      (error-type))
+  )
+  (bb5 (bb4) (bb6)
+    (expression-stmt
+      (invocation io println (
+        (invocation lang.error message (
+          (simple-var-ref nested))))))
+  )
+  (bb6 (bb5 bb4) ()
+    (expression-stmt
+      (invocation io println (
+        (literal continued))))
+  )
+)

--- a/corpus/cfg/subset9/09-object/trap-action2-v.txt
+++ b/corpus/cfg/subset9/09-object/trap-action2-v.txt
@@ -1,0 +1,219 @@
+(Client
+  ($remote$value
+    (bb0 () ()
+      (compound-assignment +
+        (simple-var-ref calls)
+        (literal 1))
+      (return
+        (simple-var-ref value))
+    )
+  )
+  ($remote$values
+    (bb0 () ()
+      (compound-assignment +
+        (simple-var-ref calls)
+        (literal 1))
+      (return
+        (invocation lang.array length (
+          (simple-var-ref values))))
+    )
+  )
+  (Client.$resource$get$0
+    (bb0 () ()
+      (compound-assignment +
+        (simple-var-ref calls)
+        (literal 1))
+      (return
+        (binary-expr +
+          (simple-var-ref id)
+          (simple-var-ref value)))
+    )
+  )
+  (Client.$resource$get$1
+    (bb0 () ()
+      (compound-assignment +
+        (simple-var-ref calls)
+        (literal 1))
+      (return
+        (invocation lang.array length (
+          (simple-var-ref values))))
+    )
+  )
+)
+(failClient
+  (bb0 () ()
+    (panic
+      (error-constructor-expr (
+        (literal receiver panic))))
+  )
+)
+(failInt
+  (bb0 () ()
+    (panic
+      (error-constructor-expr (
+        (simple-var-ref message))))
+  )
+)
+(failValues
+  (bb0 () ()
+    (panic
+      (error-constructor-expr (
+        (literal spread panic))))
+  )
+)
+(main
+  (bb0 () ()
+    (var-def
+      (variable c (type
+        (user-defined-type Client)) (expr
+        (new ()))))
+    (var-def
+      (variable remoteReceiver (expr
+        (trap-expr
+          (remote-method-call value expr:
+            (group-expr
+              (invocation failClient ())) (
+            (literal 1)))))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref remoteReceiver))))))
+    (var-def
+      (variable resourceReceiver (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (group-expr
+              (invocation failClient ())) name:item computed:
+            (literal 1)
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref resourceReceiver))))))
+    (var-def
+      (variable path (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (simple-var-ref c) name:item computed:
+            (invocation failInt (
+              (literal path panic)))
+            (literal 1))))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref path))))))
+    (var-def
+      (variable remoteArgument (expr
+        (trap-expr
+          (remote-method-call value expr:
+            (simple-var-ref c) (
+            (invocation failInt (
+              (literal remote argument panic)))))))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref remoteArgument))))))
+    (var-def
+      (variable resourceArgument (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (simple-var-ref c) name:item computed:
+            (literal 1)
+            (invocation failInt (
+              (literal resource argument panic))))))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref resourceArgument))))))
+    (var-def
+      (variable remoteDefault (expr
+        (trap-expr
+          (remote-method-call value expr:
+            (simple-var-ref c) ( <default>))))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref remoteDefault))))))
+    (var-def
+      (variable resourceDefault (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (simple-var-ref c) name:item computed:
+            (literal 1) <default>)))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref resourceDefault))))))
+    (var-def
+      (variable useSpread (type
+        (value-type boolean)) (expr
+        (literal true))))
+    (var-def
+      (variable remoteSpread (expr
+        (trap-expr
+          (remote-method-call values expr:
+            (simple-var-ref c) (
+            (ternary-expr
+              (simple-var-ref useSpread)
+              (list-constructor-expr
+                (literal 0)
+                (invocation failValues ()))
+              (list-constructor-expr))))))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref remoteSpread))))))
+    (var-def
+      (variable resourceSpread (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (simple-var-ref c) name:values
+            (ternary-expr
+              (simple-var-ref useSpread)
+              (list-constructor-expr
+                (literal 0)
+                (invocation failValues ()))
+              (list-constructor-expr)))))))
+    (expression-stmt
+      (invocation io println (
+        (invocation message (
+          (simple-var-ref resourceSpread))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref calls))))
+    (var-def
+      (variable remoteValue (expr
+        (trap-expr
+          (remote-method-call value expr:
+            (simple-var-ref c) (
+            (literal 5)))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref remoteValue))))
+    (var-def
+      (variable resourceValue (expr
+        (trap-expr
+          (client-resource-access get expr:
+            (simple-var-ref c) name:item computed:
+            (literal 2)
+            (literal 3))))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref resourceValue))))
+    (expression-stmt
+      (invocation io println (
+        (simple-var-ref calls))))
+  )
+)
+(message
+  (bb0 () ()
+    (return
+      (ternary-expr
+        (type-test-expr is
+          (simple-var-ref result)
+          (error-type))
+        (invocation lang.error message (
+          (simple-var-ref result)))
+        (literal not trapped)))
+  )
+)

--- a/corpus/desugared/subset9/09-object/trap-action1-v.txt
+++ b/corpus/desugared/subset9/09-object/trap-action1-v.txt
@@ -1,0 +1,157 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang error (as lang.error))
+  (class-definition Client
+    (function init () ()
+      (block-function-body))
+    (function $remote$broken () (
+      (value-type int))
+      (block-function-body
+        (panic
+          (error-constructor-expr (
+            (literal remote panic))))))
+    (function $remote$returnError (
+      (variable failure (type
+        (error-type)))) (
+      (union-type
+        (value-type int)
+        (error-type)))
+      (block-function-body
+        (return
+          (simple-var-ref failure))))
+    (function $remote$value () (
+      (value-type int))
+      (block-function-body
+        (return
+          (literal 1))))
+    (resource-function get name:albums
+      (value-type int)
+      (block-function-body
+        (return
+          (literal 1))))
+    (resource-function get name:broken
+      (value-type int)
+      (block-function-body
+        (panic
+          (error-constructor-expr (
+            (literal resource panic))))))
+    (resource-function get name:failure
+      (variable failure (type
+        (error-type)))
+      (union-type
+        (value-type int)
+        (error-type))
+      (block-function-body
+        (return
+          (simple-var-ref failure)))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable c (type
+          (user-defined-type Client)) (expr
+          (new ()))))
+      (var-def
+        (variable remoteValue (type
+          (union-type
+            (value-type int)
+            (error-type))) (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (simple-var-ref c) ())))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref remoteValue))))
+      (var-def
+        (variable resourceValue (type
+          (union-type
+            (value-type int)
+            (error-type))) (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:albums)))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref resourceValue))))
+      (var-def
+        (variable remotePanic (type
+          (union-type
+            (value-type int)
+            (error-type))) (expr
+          (trap-expr
+            (remote-method-call broken expr:
+              (simple-var-ref c) ())))))
+      (if
+        (type-test-expr is
+          (simple-var-ref remotePanic)
+          (error-type))
+        (block-stmt
+          (expression-stmt
+            (invocation io println (
+              (invocation lang.error message (
+                (simple-var-ref remotePanic))))))) ())
+      (block-stmt
+        (var-def
+          (variable resourcePanic (type
+            (union-type
+              (value-type int)
+              (error-type))) (expr
+            (trap-expr
+              (client-resource-access get expr:
+                (simple-var-ref c) name:broken)))))
+        (if
+          (type-test-expr is
+            (simple-var-ref resourcePanic)
+            (error-type))
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (invocation lang.error message (
+                  (simple-var-ref resourcePanic))))))) ())
+        (block-stmt
+          (var-def
+            (variable failure (type
+              (error-type)) (expr
+              (error-constructor-expr (
+                (literal returned error))))))
+          (var-def
+            (variable remoteError (expr
+              (trap-expr
+                (remote-method-call returnError expr:
+                  (simple-var-ref c) (
+                  (simple-var-ref failure)))))))
+          (expression-stmt
+            (invocation io println (
+              (binary-expr ===
+                (simple-var-ref remoteError)
+                (simple-var-ref failure)))))
+          (var-def
+            (variable resourceError (expr
+              (trap-expr
+                (client-resource-access get expr:
+                  (simple-var-ref c) name:failure
+                  (simple-var-ref failure))))))
+          (expression-stmt
+            (invocation io println (
+              (binary-expr ===
+                (simple-var-ref resourceError)
+                (simple-var-ref failure)))))
+          (var-def
+            (variable nested (expr
+              (trap-expr
+                (trap-expr
+                  (remote-method-call broken expr:
+                    (simple-var-ref c) ()))))))
+          (if
+            (type-test-expr is
+              (simple-var-ref nested)
+              (error-type))
+            (block-stmt
+              (expression-stmt
+                (invocation io println (
+                  (invocation lang.error message (
+                    (simple-var-ref nested))))))) ())
+          (block-stmt
+            (expression-stmt
+              (invocation io println (
+                (literal continued))))))))))

--- a/corpus/desugared/subset9/09-object/trap-action2-v.txt
+++ b/corpus/desugared/subset9/09-object/trap-action2-v.txt
@@ -1,0 +1,330 @@
+(package
+  (import-package ballerina io (as io))
+  (import-package ballerina lang array (as lang.array))
+  (import-package ballerina lang array (as lang.array))
+  (import-package ballerina lang error (as lang.error))
+  (variable calls (type
+    (value-type int)))
+  (class-definition Client
+    (function init () ()
+      (block-function-body))
+    (function $remote$value (
+      (variable value (type
+        (value-type int)) (expr
+        (invocation failInt (
+          (literal remote default panic)))))) (
+      (value-type int))
+      (block-function-body
+        (compound-assignment +
+          (simple-var-ref calls)
+          (literal 1))
+        (return
+          (simple-var-ref value))))
+    (function $remote$values (
+      (variable values (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))))) (
+      (value-type int))
+      (block-function-body
+        (compound-assignment +
+          (simple-var-ref calls)
+          (literal 1))
+        (return
+          (invocation lang.array length (
+            (simple-var-ref values))))))
+    (resource-function get name:item
+      (param id
+        (value-type int))
+      (variable value (type
+        (value-type int)) (expr
+        (invocation failInt (
+          (literal resource default panic)))))
+      (value-type int)
+      (block-function-body
+        (compound-assignment +
+          (simple-var-ref calls)
+          (literal 1))
+        (return
+          (binary-expr +
+            (simple-var-ref id)
+            (simple-var-ref value)))))
+    (resource-function get name:values
+      (variable values (type
+        (array-type
+          (value-type int) dimensions: 1 ([]))))
+      (value-type int)
+      (block-function-body
+        (compound-assignment +
+          (simple-var-ref calls)
+          (literal 1))
+        (return
+          (invocation lang.array length (
+            (simple-var-ref values)))))))
+  (function init () ()
+    (block-function-body
+      (assignment
+        (simple-var-ref calls)
+        (literal 0))))
+  (function failInt (
+    (variable message (type
+      (value-type string)))) (
+    (value-type int))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (simple-var-ref message))))))
+  (function failValues () (
+    (array-type
+      (value-type int) dimensions: 1 ([])))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (literal spread panic))))))
+  (function failClient () (
+    (user-defined-type Client))
+    (block-function-body
+      (panic
+        (error-constructor-expr (
+          (literal receiver panic))))))
+  (function message (
+    (variable result (type
+      (union-type
+        (value-type int)
+        (error-type))))) (
+    (value-type string))
+    (block-function-body
+      (return
+        (ternary-expr
+          (type-test-expr is
+            (simple-var-ref result)
+            (error-type))
+          (invocation lang.error message (
+            (simple-var-ref result)))
+          (literal not trapped)))))
+  (function main () (
+    (value-type null))
+    (block-function-body
+      (var-def
+        (variable c (type
+          (user-defined-type Client)) (expr
+          (new ()))))
+      (var-def
+        (variable remoteReceiver (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (group-expr
+                (invocation failClient ())) (
+              (literal 1)))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref remoteReceiver))))))
+      (var-def
+        (variable resourceReceiver (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (group-expr
+                (invocation failClient ())) name:item computed:
+              (literal 1)
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref resourceReceiver))))))
+      (var-def
+        (variable path (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:item computed:
+              (invocation failInt (
+                (literal path panic)))
+              (literal 1))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref path))))))
+      (var-def
+        (variable remoteArgument (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (simple-var-ref c) (
+              (invocation failInt (
+                (literal remote argument panic)))))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref remoteArgument))))))
+      (var-def
+        (variable resourceArgument (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:item computed:
+              (literal 1)
+              (invocation failInt (
+                (literal resource argument panic))))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref resourceArgument))))))
+      (var-def
+        (variable remoteDefault (expr
+          (trap-expr
+            (expression-thunk
+            (var-def
+              (variable $desugar$0 (expr
+                (invocation $default$0 ()))))
+            (remote-method-call value expr:
+              (simple-var-ref c) (
+              (simple-var-ref $desugar$0))))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref remoteDefault))))))
+      (var-def
+        (variable resourceDefault (expr
+          (trap-expr
+            (expression-thunk
+            (var-def
+              (variable $desugar$1 (expr
+                (invocation $default$1 ()))))
+            (client-resource-access get expr:
+              (simple-var-ref c) name:item computed:
+              (literal 1)
+              (simple-var-ref $desugar$1)))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref resourceDefault))))))
+      (var-def
+        (variable useSpread (type
+          (value-type boolean)) (expr
+          (literal true))))
+      (var-def
+        (variable remoteSpread (expr
+          (trap-expr
+            (remote-method-call values expr:
+              (simple-var-ref c) (
+              (ternary-expr
+                (simple-var-ref useSpread)
+                (expression-thunk
+                (var-def
+                  (variable $desugar$2 (expr
+                    (list-constructor-expr))))
+                (expression-stmt
+                  (invocation lang.array push (
+                    (simple-var-ref $desugar$2)
+                    (literal 0))))
+                (var-def
+                  (variable $desugar$3 (expr
+                    (invocation failValues ()))))
+                (var-def
+                  (variable $desugar$4 (expr
+                    (invocation lang.array length (
+                      (simple-var-ref $desugar$3))))))
+                (var-def
+                  (variable $desugar$5 (expr
+                    (numeric-literal 0))))
+                (while
+                  (binary-expr <
+                    (simple-var-ref $desugar$5)
+                    (simple-var-ref $desugar$4))
+                  (block-stmt
+                    (expression-stmt
+                      (invocation lang.array push (
+                        (simple-var-ref $desugar$2)
+                        (index-based-access
+                          (simple-var-ref $desugar$3)
+                          (simple-var-ref $desugar$5)))))
+                    (assignment
+                      (simple-var-ref $desugar$5)
+                      (binary-expr +
+                        (simple-var-ref $desugar$5)
+                        (numeric-literal 1)))))
+                (simple-var-ref $desugar$2))
+                (list-constructor-expr))))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref remoteSpread))))))
+      (var-def
+        (variable resourceSpread (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:values
+              (ternary-expr
+                (simple-var-ref useSpread)
+                (expression-thunk
+                (var-def
+                  (variable $desugar$6 (expr
+                    (list-constructor-expr))))
+                (expression-stmt
+                  (invocation lang.array push (
+                    (simple-var-ref $desugar$6)
+                    (literal 0))))
+                (var-def
+                  (variable $desugar$7 (expr
+                    (invocation failValues ()))))
+                (var-def
+                  (variable $desugar$8 (expr
+                    (invocation lang.array length (
+                      (simple-var-ref $desugar$7))))))
+                (var-def
+                  (variable $desugar$9 (expr
+                    (numeric-literal 0))))
+                (while
+                  (binary-expr <
+                    (simple-var-ref $desugar$9)
+                    (simple-var-ref $desugar$8))
+                  (block-stmt
+                    (expression-stmt
+                      (invocation lang.array push (
+                        (simple-var-ref $desugar$6)
+                        (index-based-access
+                          (simple-var-ref $desugar$7)
+                          (simple-var-ref $desugar$9)))))
+                    (assignment
+                      (simple-var-ref $desugar$9)
+                      (binary-expr +
+                        (simple-var-ref $desugar$9)
+                        (numeric-literal 1)))))
+                (simple-var-ref $desugar$6))
+                (list-constructor-expr)))))))
+      (expression-stmt
+        (invocation io println (
+          (invocation message (
+            (simple-var-ref resourceSpread))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref calls))))
+      (var-def
+        (variable remoteValue (expr
+          (trap-expr
+            (remote-method-call value expr:
+              (simple-var-ref c) (
+              (literal 5)))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref remoteValue))))
+      (var-def
+        (variable resourceValue (expr
+          (trap-expr
+            (client-resource-access get expr:
+              (simple-var-ref c) name:item computed:
+              (literal 2)
+              (literal 3))))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref resourceValue))))
+      (expression-stmt
+        (invocation io println (
+          (simple-var-ref calls))))))
+  (function $default$0 () ()
+    (block-function-body
+      (return
+        (invocation failInt (
+          (literal remote default panic))))))
+  (function $default$1 () ()
+    (block-function-body
+      (return
+        (invocation failInt (
+          (literal resource default panic)))))))

--- a/corpus/integration/subset9/09-object/trap-action1-v.txtar
+++ b/corpus/integration/subset9/09-object/trap-action1-v.txtar
@@ -1,0 +1,10 @@
+-- stdout --
+1
+1
+remote panic
+resource panic
+true
+true
+remote panic
+continued
+-- stderr --

--- a/corpus/integration/subset9/09-object/trap-action2-v.txtar
+++ b/corpus/integration/subset9/09-object/trap-action2-v.txtar
@@ -1,0 +1,15 @@
+-- stdout --
+receiver panic
+receiver panic
+path panic
+remote argument panic
+resource argument panic
+remote default panic
+resource default panic
+spread panic
+spread panic
+0
+5
+5
+2
+-- stderr --

--- a/corpus/integration/subset9/09-object/trap-action3-e.txtar
+++ b/corpus/integration/subset9/09-object/trap-action3-e.txtar
@@ -1,0 +1,13 @@
+-- stdout --
+-- stderr --
+error[SEMANTIC_ERROR]: incompatible type: expected int, got int|error
+  --> trap-action3-e.bal:31:23
+   |
+31 |     int remoteValue = trap c->value(); // @error trap result includes error
+   |                       ^^^^^^^^^^^^^^^
+
+error[SEMANTIC_ERROR]: incompatible type: expected int, got int|error
+  --> trap-action3-e.bal:32:25
+   |
+32 |     int resourceValue = trap c->/albums; // @error trap result includes error
+   |                         ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Purpose
Closes #829.

`trap` already accepts action operands following the start/wait work (`31d61107b`). The current AST, desugar expression thunks, and BIR trap regions handle remote and client resource calls without further production changes. Add dedicated regression coverage for the original report and operand-evaluation boundaries.

## Approach
Add three corpus cases and their AST, CFG, desugared, BIR, and integration goldens where applicable:
- `trap-action1-v.bal`: remote/resource success, method panics, returned-error identity, nested traps, and continued execution.
- `trap-action2-v.bal`: panics in receivers, computed resource paths, explicit/default arguments, and branching spread expressions requiring lowering setup. Call counters verify failed operand evaluation does not invoke the method and subsequent calls still execute.
- `trap-action3-e.bal`: assigning either trapped action to `int` rejects the `int|error` result with ordinary diagnostics.

## Automation tests
Passed:
```sh
go test ./nodebuilder ./semantics/... ./desugar ./birgen ./corpus \
  -run 'Test[^/]+/subset9/09-object/trap-action' -count=1
```
Both valid cases produce matching output under jBallerina (`bal run`); the error case reports incompatible types on the same two lines. Commit-hook builds and lint checks passed.

## Documentation
N/A — regression tests for existing behavior; no production API changes.

## Release note
Add regression coverage for trapping remote method and client resource access actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for trapping client remote and resource method calls.
  - Verified handling of successful results, panics, returned errors, nested traps, argument evaluation failures, and continued execution.
  - Added expected runtime output and semantic error validations for trapped calls assigned to incompatible types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->